### PR TITLE
DLR grammar: colour a hand type whatever case its prefix is written in

### DIFF
--- a/vs-code/syntaxes/dlr.tmLanguage.json
+++ b/vs-code/syntaxes/dlr.tmLanguage.json
@@ -204,11 +204,11 @@
       "patterns": [
         {
           "name": "support.type.leveling.share.dlr",
-          "match": "\\b(?:HandType|LevelType)[A-Za-z0-9_]*(?i:_Share)\\b"
+          "match": "\\b(?i:HandType|LevelType)[A-Za-z0-9_]*(?i:_Share)\\b"
         },
         {
           "name": "support.type.leveling.dlr",
-          "match": "\\b(?:HandType|LevelType)[A-Za-z0-9_]*\\b"
+          "match": "\\b(?i:HandType|LevelType)[A-Za-z0-9_]*\\b"
         },
         {
           "name": "support.type.leveling.dlr",


### PR DESCRIPTION
Regenerated from dealer3, where the prefix stopped being case-sensitive (bridge-craftwork/Dealer3#31).

`HandType_` is a magic word, and a name differing only in case is not a name anybody meant to be different. `handtype_south_15` used to declare no hand type at all — no levelling, no PBN tags, no rounds — and the grammar agreed with the engine by colouring it as an ordinary variable. Both read it as the type it is now.

```
\b(?i:HandType|LevelType)[A-Za-z0-9_]*(?i:_Share)\b
\b(?i:HandType|LevelType)[A-Za-z0-9_]*\b
```

Checked under real vscode-textmate: `handtype_x`, `HANDTYPE_x`, `HandType_x`, `leveltype_x` and `handtype_x_SHARE` all take the levelling scopes.

The variable itself is still case-sensitive to *refer* to, as it is in dealer.exe. That is a fact about the name rather than about the convention, and nothing a highlighter could show.

Reload VS Code fully (Cmd+Q, not Reload Window) to pick it up — the extension is a symlink and a reload does not re-scan it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)