### PR TITLE
Fix table creation for BBO's Phoenix UI

### DIFF
--- a/-PBS.txt
+++ b/-PBS.txt
@@ -130,6 +130,34 @@ Script
 //Script,setBiddingTable
 var delayValue = 500;
 var t0 = Date.now();
+// BBO's create-table UI ("Phoenix") replaced the old start-table-screen. The
+// Start button now lives in bbo-sticky-bottom-create, which is a SIBLING of
+// bbo-create-table-modal, not a descendant - do not scope this under the modal.
+// This matches exactly one element and needs no translation table, unlike the
+// positional .eq(2) it replaces.
+var START_TABLE_BUTTON = "bbo-sticky-bottom-create button.primary";
+
+// The table options PBS wants, recovered from the pre-Phoenix comments in this
+// file's history (commit 2f76b1a1, 2024-03-09): a private, invisible table that
+// nobody can join or kibitz uninvited. Keyed by BBO's stable input ids, which
+// are both language-independent and order-independent - the old positional
+// .eq(0..4) silently set the wrong options once BBO inserted "Video chat" at
+// index 0. "video-chat" is deliberately absent here: it postdates PBS's
+// original intent, so we leave BBO's own default alone.
+//
+// Observed on a live table (2026-09-09): BBO does not persist
+// permission-required-to-kibitz when allow-kibitzers is false - reopening Table
+// options on the created table reads it back as false. It looks to be normalised
+// away as moot, since disallowing kibitzers already prevents kibitzing. The net
+// effect still matches the intent above, so we keep setting it for explicitness;
+// do not be surprised when it reads back false.
+var TABLE_OPTIONS = {
+    "allow-kibitzers": false,
+    "allow-kibitzers-chat": false,
+    "permission-required-to-kibitz": true,
+    "permission-required-to-play": true,
+    "invisible-table": true
+};
 console.log("[PBS] setBiddingTable START");
 Promise.resolve()
     .then(() => {
@@ -148,17 +176,11 @@ Promise.resolve()
     .then(() => delay(delayValue))
     .then(() => $("button.bbo-phx-navigation:contains('Start a bidding table')", BBOcontext()).first().click())
     .then(() => delay(delayValue))
-    .then(() => $("table-options-panel .toggleDivClass ion-toggle", BBOcontext()).eq(0).click())
-    .then(() => delay(delayValue))
-    .then(() => $("table-options-panel .toggleDivClass ion-toggle", BBOcontext()).eq(1).click())
-    .then(() => delay(delayValue))
-    .then(() => $("table-options-panel .toggleDivClass ion-toggle", BBOcontext()).eq(2).click())
-    .then(() => delay(delayValue))
-    .then(() => $("table-options-panel .toggleDivClass ion-toggle", BBOcontext()).eq(3).click())
-    .then(() => delay(delayValue))
-    .then(() => $("table-options-panel .toggleDivClass ion-toggle", BBOcontext()).eq(4).click())
-    .then(() => delay(delayValue))
-    .then(() => $("start-table-screen .buttonRowClass button", BBOcontext()).eq(2).click())
+    // Wait for BBO's create-table modal, set the options, then press Start Table.
+    .then(() => waitFor(() => $("bbo-create-table-modal", BBOcontext()).length > 0))
+    .then(() => setTableOptions())
+    .then(() => waitFor(() => $(START_TABLE_BUTTON, BBOcontext()).length > 0))
+    .then(() => clickNative(START_TABLE_BUTTON))
     .then(() => waitFor(() => $("bridge-screen .nameDisplayClass", BBOcontext()).length > 0))
     .then(() => delay(3000))
     .then(() => $("bridge-screen .nameDisplayClass", BBOcontext()).eq(0).click())
@@ -177,6 +199,28 @@ Promise.resolve()
     .then(() => delay(delayValue))
     .then(() => $("bridge-screen menu-item", BBOcontext()).eq(0).children().click())
     .then(() => console.log("[PBS] setBiddingTable DONE in " + (Date.now() - t0) + "ms"))
+    .catch((e) => console.error("[PBS] setBiddingTable FAILED after " + (Date.now() - t0) + "ms: " + ((e && e.message) || e)))
+// Set each toggle TO a state rather than blind-toggling it, so re-running is
+// idempotent and a changed BBO default cannot invert our intent. Clicking the
+// real <input> is what propagates into Angular's reactive form.
+function setTableOptions() {
+    var missing = [];
+    Object.keys(TABLE_OPTIONS).forEach(function (id) {
+        var el = BBOcontext().getElementById(id);
+        if (!el) { missing.push(id); return; }
+        if (el.checked !== TABLE_OPTIONS[id]) el.click();
+    });
+    if (missing.length) {
+        console.warn("[PBS] table option toggles not found (BBO UI change?): " + missing.join(", "));
+    }
+}
+
+function clickNative(selector) {
+    var el = $(selector, BBOcontext())[0];
+    if (!el) throw new Error("clickNative: no element for " + selector);
+    el.click();
+}
+
 function delay(duration) {
     return new Promise((resolve) => {
         setTimeout(resolve, duration);
@@ -198,6 +242,34 @@ function waitFor(test, interval, timeout) {
 //Script,setTeachingTable
 var delayValue = 500;
 var t0 = Date.now();
+// BBO's create-table UI ("Phoenix") replaced the old start-table-screen. The
+// Start button now lives in bbo-sticky-bottom-create, which is a SIBLING of
+// bbo-create-table-modal, not a descendant - do not scope this under the modal.
+// This matches exactly one element and needs no translation table, unlike the
+// positional .eq(2) it replaces.
+var START_TABLE_BUTTON = "bbo-sticky-bottom-create button.primary";
+
+// The table options PBS wants, recovered from the pre-Phoenix comments in this
+// file's history (commit 2f76b1a1, 2024-03-09): a private, invisible table that
+// nobody can join or kibitz uninvited. Keyed by BBO's stable input ids, which
+// are both language-independent and order-independent - the old positional
+// .eq(0..4) silently set the wrong options once BBO inserted "Video chat" at
+// index 0. "video-chat" is deliberately absent here: it postdates PBS's
+// original intent, so we leave BBO's own default alone.
+//
+// Observed on a live table (2026-09-09): BBO does not persist
+// permission-required-to-kibitz when allow-kibitzers is false - reopening Table
+// options on the created table reads it back as false. It looks to be normalised
+// away as moot, since disallowing kibitzers already prevents kibitzing. The net
+// effect still matches the intent above, so we keep setting it for explicitness;
+// do not be surprised when it reads back false.
+var TABLE_OPTIONS = {
+    "allow-kibitzers": false,
+    "allow-kibitzers-chat": false,
+    "permission-required-to-kibitz": true,
+    "permission-required-to-play": true,
+    "invisible-table": true
+};
 console.log("[PBS] setTeachingTable START");
 Promise.resolve()
     .then(() => {
@@ -216,17 +288,11 @@ Promise.resolve()
     .then(() => delay(delayValue))
     .then(() => $("button.bbo-phx-navigation:contains('Start a teaching table')", BBOcontext()).first().click())
     .then(() => delay(delayValue))
-    .then(() => $("table-options-panel .toggleDivClass ion-toggle", BBOcontext()).eq(0).click())
-    .then(() => delay(delayValue))
-    .then(() => $("table-options-panel .toggleDivClass ion-toggle", BBOcontext()).eq(1).click())
-    .then(() => delay(delayValue))
-    .then(() => $("table-options-panel .toggleDivClass ion-toggle", BBOcontext()).eq(2).click())
-    .then(() => delay(delayValue))
-    .then(() => $("table-options-panel .toggleDivClass ion-toggle", BBOcontext()).eq(3).click())
-    .then(() => delay(delayValue))
-    .then(() => $("table-options-panel .toggleDivClass ion-toggle", BBOcontext()).eq(4).click())
-    .then(() => delay(delayValue))
-    .then(() => $("start-table-screen .buttonRowClass button", BBOcontext()).eq(2).click())
+    // Wait for BBO's create-table modal, set the options, then press Start Table.
+    .then(() => waitFor(() => $("bbo-create-table-modal", BBOcontext()).length > 0))
+    .then(() => setTableOptions())
+    .then(() => waitFor(() => $(START_TABLE_BUTTON, BBOcontext()).length > 0))
+    .then(() => clickNative(START_TABLE_BUTTON))
     .then(() => waitFor(() => $("bridge-screen .nameDisplayClass", BBOcontext()).length > 0))
     .then(() => delay(3000))
     .then(() => $("bridge-screen .nameDisplayClass", BBOcontext()).eq(0).click())
@@ -245,6 +311,28 @@ Promise.resolve()
     .then(() => delay(delayValue))
     .then(() => $("bridge-screen menu-item", BBOcontext()).eq(0).children().click())
     .then(() => console.log("[PBS] setTeachingTable DONE in " + (Date.now() - t0) + "ms"))
+    .catch((e) => console.error("[PBS] setTeachingTable FAILED after " + (Date.now() - t0) + "ms: " + ((e && e.message) || e)))
+// Set each toggle TO a state rather than blind-toggling it, so re-running is
+// idempotent and a changed BBO default cannot invert our intent. Clicking the
+// real <input> is what propagates into Angular's reactive form.
+function setTableOptions() {
+    var missing = [];
+    Object.keys(TABLE_OPTIONS).forEach(function (id) {
+        var el = BBOcontext().getElementById(id);
+        if (!el) { missing.push(id); return; }
+        if (el.checked !== TABLE_OPTIONS[id]) el.click();
+    });
+    if (missing.length) {
+        console.warn("[PBS] table option toggles not found (BBO UI change?): " + missing.join(", "));
+    }
+}
+
+function clickNative(selector) {
+    var el = $(selector, BBOcontext())[0];
+    if (!el) throw new Error("clickNative: no element for " + selector);
+    el.click();
+}
+
 function delay(duration) {
     return new Promise((resolve) => {
         setTimeout(resolve, duration);


### PR DESCRIPTION
`setBiddingTable` and `setTeachingTable` stopped starting tables. They navigated to the practice screen, opened the create-table dialog, then silently did nothing — leaving the user to click **Start Table** by hand.

## Cause

BBO replaced the table-creation UI ("Phoenix"). `start-table-screen` and `table-options-panel` no longer exist; creation is now `bbo-create-table-modal`, with Start in `bbo-sticky-bottom-create`. Measured live:

| selector | matches |
|---|---|
| `start-table-screen .buttonRowClass button` | **0** |
| `table-options-panel .toggleDivClass ion-toggle` | **0** |
| `button.bbo-phx-navigation:contains('Practice')` | 1 ✅ |

jQuery `.click()` on an empty set throws nothing, so both failures were invisible. The only symptom was a bare `waitFor timeout` from the *next* step, because neither chain had a `.catch()`.

Worth noting: the selectors that still worked were already `bbo-phx-*`. **This was a half-finished migration**, not a fresh break.

## Changes

**Start button** → `bbo-sticky-bottom-create button.primary`. Matches exactly one element and needs no translation table, unlike the positional `.eq(2)` it replaces. It's a *sibling* of the modal, not a descendant — don't scope it under the modal. (Bare `button.bbo-phx-button.primary` would be wrong: 3 matches.)

**Table options** → keyed by BBO's stable input ids (`allow-kibitzers`, `invisible-table`, …), which are language- *and* order-independent. This matters: the old code blind-toggled positions 0–4, and BBO has since inserted **"Video chat" at index 0**, so even a working selector would have set the wrong options. Now **set-to-state** instead of toggled, so re-running is idempotent and a changed BBO default can't invert the intent.

The intended states were recovered from the comments in 2f76b1a1 (2024-03-09), which a later refactor stripped:

| id | want | why |
|---|---|---|
| `allow-kibitzers` | off | "Disallow kibitzers" |
| `allow-kibitzers-chat` | off | "Disallow kibitzers to chat with players" |
| `permission-required-to-kibitz` | on | "Set Permission required to kibitz" |
| `permission-required-to-play` | on | "Set Permission required to play" |
| `invisible-table` | on | "Make the table Invisible" |

`video-chat` is deliberately left alone — it postdates PBS's intent, so BBO's default stands.

**`.catch()` on both chains**, so the next BBO UI change names the failing step instead of failing silently.

## Verification (live BBO session)

Tested two ways. First the logic in isolation, then **the real thing**: pushed this branch, pointed a live extension's `PBSCache` at this file, and clicked `Strt Bid Tbl`.

```
[PBS] setBiddingTable DONE in 9019ms
```

No `FAILED`, no `waitFor timeout`. Table came up unattended with `kemistry` + 3 `Adv GIBBO 2/1` robots seated. Isolated run of the same chain reached a live table in ~2.3s. Confirmed a programmatic click on the real `<input>` propagates into Angular's reactive form (the five touched toggles go `ng-dirty`; untouched `video-chat` stays `ng-pristine`). Post-start robot seating works unchanged. Both script blocks pass `node --check`.

## One documented quirk

BBO **does not persist `permission-required-to-kibitz` when `allow-kibitzers` is false** — reopening Table options on the created table reads it back `false`. It appears normalised away as moot, since disallowing kibitzers already prevents kibitzing. Net effect still matches intent, so we keep setting it for explicitness; there's a comment in the file so the next person isn't puzzled.

## Not addressed

`setBiddingTable` still uses blind `delay(500)` steps between the surviving actions, and the seat/menu clicks are still positional (`menu-item .eq(0)` = "Sit"). Both work today and are the same fragility class that caused this bug — but changing them isn't needed to fix it, so I left them. `setDealerCode-polling.js` is the model if you want that cleanup later.

Refs bridge-craftwork/pbs-bbo-extension#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
