### PR TITLE
Handle late-arriving BBO tabs (release)

### DIFF
--- a/-PBS-beta.txt
+++ b/-PBS-beta.txt
@@ -6,6 +6,50 @@ Javascript,https://github.com/stanmaz/BBOalert/blob/master/Plugins/PBNcapture.js
 Javascript,https://github.com/Rick-Wilson/bbo-pbs/blob/master/Plugins/BBAcompare.js
 Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 
+// --- Late-arriving BBO tabs -------------------------------------------------
+// The host extension binds an onmousedown handler to each tab present when
+// setTabEvents() runs; that handler is what calls setOptionsOff() to hide the
+// extension's panel so BBO's own panel can show. BBO adds tabs at runtime - a
+// "Tables" tab appears once a table is created - and such a tab gets no handler,
+// so clicking it never hides the panel. The panel stays on top of BBO's, the tab
+// highlights but shows nothing, and the right-hand side looks frozen while CPU
+// sits at 0%. It self-heals confusingly: clicking the PBS tab re-runs
+// setTabEvents() and finally binds the new tab, so it comes and goes with click
+// order.
+//
+// Fixed here rather than in the extension so it ships by pushing this file, with
+// no store release - and because BBOalert loads this same file, one fix repairs
+// both extensions in their own iframes.
+//
+// addEventListener, not onmousedown: both extensions bind the same element, and
+// assigning would clobber whichever bound first. document.title tells us which
+// host we are in, so each instance leaves its own tab alone.
+Script,onDataLoad
+(function () {
+    if (window.__pbsTabDelegationInstalled) return;
+    var doc, vt;
+    try {
+        doc = parent.document;
+        vt = doc.querySelector('#rightDiv .verticalTabBarClass');
+    } catch (e) {
+        return;
+    }
+    if (!vt) return;
+
+    var myTab = (document.title || '').indexOf('PBS') !== -1 ? 'PBS' : 'BBOalert';
+
+    vt.addEventListener('mousedown', function (ev) {
+        var btn = (ev && ev.target && ev.target.closest) ? ev.target.closest('tab-bar-button') : null;
+        if (btn == null) return;
+        if (btn.textContent.indexOf(myTab) !== -1) return;
+        if (typeof setOptionsOff === 'function') setOptionsOff();
+    }, true);
+
+    window.__pbsTabDelegationInstalled = true;
+    console.log('[PBS] tab delegation installed for ' + myTab);
+})();
+Script
+
 // Display HCP for visible hands
 Script,onDataLoad
 displayHCP = function () {

--- a/-PBS-beta.txt
+++ b/-PBS-beta.txt
@@ -6,50 +6,6 @@ Javascript,https://github.com/stanmaz/BBOalert/blob/master/Plugins/PBNcapture.js
 Javascript,https://github.com/Rick-Wilson/bbo-pbs/blob/master/Plugins/BBAcompare.js
 Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 
-// --- Late-arriving BBO tabs -------------------------------------------------
-// The host extension binds an onmousedown handler to each tab present when
-// setTabEvents() runs; that handler is what calls setOptionsOff() to hide the
-// extension's panel so BBO's own panel can show. BBO adds tabs at runtime - a
-// "Tables" tab appears once a table is created - and such a tab gets no handler,
-// so clicking it never hides the panel. The panel stays on top of BBO's, the tab
-// highlights but shows nothing, and the right-hand side looks frozen while CPU
-// sits at 0%. It self-heals confusingly: clicking the PBS tab re-runs
-// setTabEvents() and finally binds the new tab, so it comes and goes with click
-// order.
-//
-// Fixed here rather than in the extension so it ships by pushing this file, with
-// no store release - and because BBOalert loads this same file, one fix repairs
-// both extensions in their own iframes.
-//
-// addEventListener, not onmousedown: both extensions bind the same element, and
-// assigning would clobber whichever bound first. document.title tells us which
-// host we are in, so each instance leaves its own tab alone.
-Script,onDataLoad
-(function () {
-    if (window.__pbsTabDelegationInstalled) return;
-    var doc, vt;
-    try {
-        doc = parent.document;
-        vt = doc.querySelector('#rightDiv .verticalTabBarClass');
-    } catch (e) {
-        return;
-    }
-    if (!vt) return;
-
-    var myTab = (document.title || '').indexOf('PBS') !== -1 ? 'PBS' : 'BBOalert';
-
-    vt.addEventListener('mousedown', function (ev) {
-        var btn = (ev && ev.target && ev.target.closest) ? ev.target.closest('tab-bar-button') : null;
-        if (btn == null) return;
-        if (btn.textContent.indexOf(myTab) !== -1) return;
-        if (typeof setOptionsOff === 'function') setOptionsOff();
-    }, true);
-
-    window.__pbsTabDelegationInstalled = true;
-    console.log('[PBS] tab delegation installed for ' + myTab);
-})();
-Script
-
 // Display HCP for visible hands
 Script,onDataLoad
 displayHCP = function () {

--- a/-PBS.txt
+++ b/-PBS.txt
@@ -6,6 +6,50 @@ Javascript,https://github.com/stanmaz/BBOalert/blob/master/Plugins/PBNcapture.js
 Javascript,https://github.com/Rick-Wilson/bbo-pbs/blob/master/Plugins/BBAcompare.js
 Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 
+// --- Late-arriving BBO tabs -------------------------------------------------
+// The host extension binds an onmousedown handler to each tab present when
+// setTabEvents() runs; that handler is what calls setOptionsOff() to hide the
+// extension's panel so BBO's own panel can show. BBO adds tabs at runtime - a
+// "Tables" tab appears once a table is created - and such a tab gets no handler,
+// so clicking it never hides the panel. The panel stays on top of BBO's, the tab
+// highlights but shows nothing, and the right-hand side looks frozen while CPU
+// sits at 0%. It self-heals confusingly: clicking the PBS tab re-runs
+// setTabEvents() and finally binds the new tab, so it comes and goes with click
+// order.
+//
+// Fixed here rather than in the extension so it ships by pushing this file, with
+// no store release - and because BBOalert loads this same file, one fix repairs
+// both extensions in their own iframes.
+//
+// addEventListener, not onmousedown: both extensions bind the same element, and
+// assigning would clobber whichever bound first. document.title tells us which
+// host we are in, so each instance leaves its own tab alone.
+Script,onDataLoad
+(function () {
+    if (window.__pbsTabDelegationInstalled) return;
+    var doc, vt;
+    try {
+        doc = parent.document;
+        vt = doc.querySelector('#rightDiv .verticalTabBarClass');
+    } catch (e) {
+        return;
+    }
+    if (!vt) return;
+
+    var myTab = (document.title || '').indexOf('PBS') !== -1 ? 'PBS' : 'BBOalert';
+
+    vt.addEventListener('mousedown', function (ev) {
+        var btn = (ev && ev.target && ev.target.closest) ? ev.target.closest('tab-bar-button') : null;
+        if (btn == null) return;
+        if (btn.textContent.indexOf(myTab) !== -1) return;
+        if (typeof setOptionsOff === 'function') setOptionsOff();
+    }, true);
+
+    window.__pbsTabDelegationInstalled = true;
+    console.log('[PBS] tab delegation installed for ' + myTab);
+})();
+Script
+
 // Display HCP for visible hands
 Script,onDataLoad
 displayHCP = function () {


### PR DESCRIPTION
BBO adds a **Tables** tab once a table is created. The host extension only binds its tab handler to tabs present when `setTabEvents()` ran, so that one never gets it — and that handler is what calls `setOptionsOff()` to hide our panel.

Result: clicking **Tables** highlights it but shows nothing, because `pbs-panel0` is still sitting on top of BBO's panel. It reads as a frozen right-hand side while CPU is at 0%. It also self-heals confusingly — clicking the PBS tab re-runs `setTabEvents()` and finally binds the new tab. **Confirmed by hand.**

Fixed in the data file rather than the extension so it ships by pushing, with no store release. Because BBOalert loads this file too, one fix repairs both extensions inside their own iframes.

Beta gets the same block via `runtime/tabDelegation.js` (bridge-craftwork/pbs-bbo-extension#8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)