### PR TITLE
Beta: actually load the fixed setDealerCode and toggleRotate

### DIFF
--- a/-PBS-beta.txt
+++ b/-PBS-beta.txt
@@ -1,7 +1,11 @@
 //BBOalert, Bidding Scenarios
 //BBOalert, Bidding Scenarios - version 4.1.11-beta-autostart
-Import,https://github.com/bridge-craftwork/Practice-Bidding-Scenarios/blob/main/js/setDealerCode-polling.js
-Import,https://github.com/bridge-craftwork/Practice-Bidding-Scenarios/blob/main/js/toggleRotate.js
+// setDealerCode and the rotate toggle, from runtime/ like every other block.
+// These two were copied into runtime/ during the split but the imports below
+// were left pointing at the originals in this repo, so beta went on loading the
+// UNFIXED copies: the 5s dead wait in setDealerCode and no sticky rotate.
+Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/setDealerCode-polling.js
+Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/toggleRotate.js
 Javascript,https://github.com/stanmaz/BBOalert/blob/master/Plugins/PBNcapture.js
 Javascript,https://github.com/bridge-craftwork/bbo-pbs/blob/master/Plugins/BBAcompare.js
 Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js

--- a/-PBS-beta.txt
+++ b/-PBS-beta.txt
@@ -10,6 +10,10 @@ Javascript,https://github.com/stanmaz/BBOalert/blob/master/Plugins/PBNcapture.js
 Javascript,https://github.com/bridge-craftwork/bbo-pbs/blob/master/Plugins/BBAcompare.js
 Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 
+// Channel identity. runtime/ is shared by both channels and carries no version
+// of its own, so the data file - the one per-channel artefact - declares it.
+Script,onDataLoad,window.pbsVersionLabel='v4.1.11-beta-autostart'; window.pbsClientVersion='1.9.26-beta'; R='';
+
 // Development loader - BETA ONLY, never add this to -PBS.txt.
 // Paste runtime JavaScript and Run it, without pushing to GitHub.
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/devLoader.js


### PR DESCRIPTION
The split moved every script block to `runtime/`, but these two imports were left pointing at the originals in this repo. Both files were copied to `runtime/` **and then fixed there**, so beta has been loading the unfixed originals ever since — the copies carrying the fixes were imported by nothing.

Measured against the live raw URLs beta actually fetches:

| file beta loaded | state |
|---|---|
| `PBS/main/js/setDealerCode-polling.js` | `ready: () => $("mat-option", doc).length === 0` — **the 5s dead wait, still there** |
| `PBS/main/js/toggleRotate.js` | no `pbsGetRotatePref` — **sticky rotate absent** |

So beta was still paying the 5552ms stall on every scenario click and still losing the rotate preference, both of which were believed fixed. It was in fact *behind* `beta/phoenix-plus-sticky-rotate`, which imported these two from its own branch and therefore did carry them.

Also declares `window.pbsVersionLabel` / `window.pbsClientVersion`, which `runtime/pbsDynamicLayout.js` now reads instead of hardcoding `-beta` strings. Values are identical to what was hardcoded, so beta's banner and telemetry are unchanged.

## Verified on a live BBO session

Both extensions loaded — the freeze reproduction — pointing `PBSCache` and `BBOalertCache` at this branch. Which copy is loaded is **proven by reading `setDealerCode.toString()` in the iframe**, not by trusting the URL:

```json
{ "deadWaitPresent": false, "stickyRotate": "function",
  "versionLabel": "v4.1.11-beta-autostart", "clientVersion": "1.9.26-beta" }

[PBS watcher] PBS -> ACTIVE (startup)
[PBS watcher] BBOalert -> standby (startup)
[PBS] startTable(bidding) DONE in 5347ms
[PBS] setDealerCode DONE in 551ms          <- was 5552ms
```

No freeze, page still responsive afterwards.

Rotate persistence, from a cleared preference:

| step | stored | in memory | button |
|---|---|---|---|
| before | `null` | — | `↓` |
| after toggle | `true` | `true` | `↕` |
| **after reload** | `true` | `true` | `↕` |
| **after scenario click** | `true` | `true` | `↕` |

Both halves of the old bug — lost on reload, clobbered by the scenario's constant `true` — are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)