### PR TITLE
Say what each of the two version numbers is for

### DIFF
--- a/-PBS-toggle.txt
+++ b/-PBS-toggle.txt
@@ -26,8 +26,26 @@ Javascript,https://github.com/stanmaz/BBOalert/blob/master/Plugins/PBNcapture.js
 Javascript,https://github.com/bridge-craftwork/bbo-pbs/blob/master/Plugins/BBAcompare.js
 Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 
-// Channel identity. runtime/ is shared by both channels and carries no version
+// Channel identity. runtime/ is shared by every channel and carries no version
 // of its own, so the data file - the one per-channel artefact - declares it.
+//
+// The two numbers below are different things and move independently:
+//
+//   pbsVersionLabel   The PBS package version - the same number as line 2 of
+//                     this file. Printed in the console banner on startup:
+//                     "PBS <label>: Initializing...". Human-facing, and the
+//                     first thing anyone reads in a bug report.
+//
+//   pbsClientVersion  The plug-in version - the same number BBAcompare.js
+//                     carries as CLIENT_VERSION. Sent as the X-Client-Version
+//                     header to bba.harmonicsystems.com/api/scenario/select on
+//                     EVERY scenario click. Machine-facing: this is what the
+//                     telemetry counts, and what tells release traffic apart
+//                     from beta and toggle.
+//
+// Keep them in step with line 2 and with BBAcompare respectively. runtime/
+// falls back to "unset" rather than to a real version, so forgetting either
+// shows up as obviously missing instead of as a wrong channel.
 // The -toggle suffix is deliberate and load-bearing: it is POSTed as
 // X-Client-Version on every scenario click, so whether anyone is still pointed
 // at this file becomes a thing you can look up rather than a thing you guess.

--- a/-PBS.txt
+++ b/-PBS.txt
@@ -17,8 +17,26 @@ Javascript,https://github.com/stanmaz/BBOalert/blob/master/Plugins/PBNcapture.js
 Javascript,https://github.com/bridge-craftwork/bbo-pbs/blob/master/Plugins/BBAcompare.js
 Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 
-// Channel identity. runtime/ is shared by both channels and carries no version
+// Channel identity. runtime/ is shared by every channel and carries no version
 // of its own, so the data file - the one per-channel artefact - declares it.
+//
+// The two numbers below are different things and move independently:
+//
+//   pbsVersionLabel   The PBS package version - the same number as line 2 of
+//                     this file. Printed in the console banner on startup:
+//                     "PBS <label>: Initializing...". Human-facing, and the
+//                     first thing anyone reads in a bug report.
+//
+//   pbsClientVersion  The plug-in version - the same number BBAcompare.js
+//                     carries as CLIENT_VERSION. Sent as the X-Client-Version
+//                     header to bba.harmonicsystems.com/api/scenario/select on
+//                     EVERY scenario click. Machine-facing: this is what the
+//                     telemetry counts, and what tells release traffic apart
+//                     from beta and toggle.
+//
+// Keep them in step with line 2 and with BBAcompare respectively. runtime/
+// falls back to "unset" rather than to a real version, so forgetting either
+// shows up as obviously missing instead of as a wrong channel.
 Script,onDataLoad,window.pbsVersionLabel='v4.1.11'; window.pbsClientVersion='1.9.26'; R='';
 
 // Host-conflict guard - must load before the blocks that call it.


### PR DESCRIPTION
The data file sets two globals on one line, and the comment above them explained only *why* they live there, not *what they are*. They're different things that move independently:

| global | consumed at | facing |
|---|---|---|
| `pbsVersionLabel` | `pbsDynamicLayout.js:828` — console banner, `PBS <label>: Initializing...` | **human** — first thing read in a bug report; same number as line 2 of the file |
| `pbsClientVersion` | `pbsDynamicLayout.js:338` — `X-Client-Version` header POSTed to `bba.harmonicsystems.com/api/scenario/select` on **every scenario click** | **machine** — what the telemetry counts, and what separates release traffic from beta and toggle |

`pbsClientVersion` is also the number BBAcompare.js carries as `CLIENT_VERSION`, so the two are meant to stay in step.

Also notes that `runtime/` now falls back to `"unset"` rather than to a real version (bridge-craftwork/pbs-bbo-extension#17), so forgetting either shows up as obviously missing rather than as the wrong channel.

Comment only — no behaviour change. `-PBS-beta.txt` picks up the same text on the beta branch, since it's generated from `-PBS.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)