### PR TITLE
Beta: test the Phoenix dropdown z-index fix

### DIFF
--- a/-PBS-beta.txt
+++ b/-PBS-beta.txt
@@ -64,6 +64,12 @@ Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/d
 
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/onAnyMutation-hcp.js
 
+// UNDER TEST IN BETA. Lets BBO's Phoenix dropdowns paint above our panel -
+// without it, the name-tag menu (Show profile / BBO Store / Help / Sign out) is
+// covered by pbs-panel0 and Sign out cannot be clicked while the PBS tab shows.
+// Promote to -PBS.txt once it has run in beta.
+Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/onAnyMutation-dropdown.js
+
 // Start BBA Auction Compare panel (called by Auction Compare button)
 Script,startBBACompare,window.startBBACompare(); R='';
 Script,toggleRotate,window.toggleRandomlyRotate(); R='';


### PR DESCRIPTION
Imports `runtime/onAnyMutation-dropdown.js` (bridge-craftwork/pbs-bbo-extension#18). Without it, clicking the name tag with the PBS tab showing opens a menu that `pbs-panel0` covers — **Sign out isn't clickable at all**. Pre-existing, not caused by the split.

## Verified on the live page

| menu state | panel z-index | "Sign out" covered by panel | top element at its centre |
|---|---|---|---|
| closed | `5000` | — | — |
| **open** | **`9`** | **no** | the dropdown |
| closed again | `5000` | — | — |

The `9` is derived from the dropdown's own `z-index:10` at runtime, not hardcoded, so it survives BBO changing the value.

Page still responsive afterwards (`alive` in 1ms), which is the check that matters here: the block runs on every mutation and writes to the parent document, so an unguarded version would feed back into the observer and wedge the renderer.

Beta only for now, so this is a fourth difference from `-PBS.txt` on top of the documented three. That's what the beta channel is for; it goes away when the import is promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)