### PR TITLE
Promote the Phoenix dropdown fix to release

### DIFF
--- a/-PBS-beta.txt
+++ b/-PBS-beta.txt
@@ -1,5 +1,5 @@
 //BBOalert, Bidding Scenarios
-//BBOalert, Bidding Scenarios - version 4.1.11-beta
+//BBOalert, Bidding Scenarios - version 4.1.12-beta
 //
 // BETA channel. This file is a mirror of -PBS.txt and is meant to stay one:
 // same records, same order, differing ONLY in the three things that make it
@@ -43,7 +43,7 @@ Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 // Keep them in step with line 2 and with BBAcompare respectively. runtime/
 // falls back to "unset" rather than to a real version, so forgetting either
 // shows up as obviously missing instead of as a wrong channel.
-Script,onDataLoad,window.pbsVersionLabel='v4.1.11-beta'; window.pbsClientVersion='1.9.26-beta'; R='';
+Script,onDataLoad,window.pbsVersionLabel='v4.1.12-beta'; window.pbsClientVersion='1.9.26-beta'; R='';
 
 // Development loader - BETA ONLY, never add this to -PBS.txt.
 // Paste runtime JavaScript and Run it, without pushing to GitHub.
@@ -64,10 +64,9 @@ Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/d
 
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/onAnyMutation-hcp.js
 
-// UNDER TEST IN BETA. Lets BBO's Phoenix dropdowns paint above our panel -
-// without it, the name-tag menu (Show profile / BBO Store / Help / Sign out) is
-// covered by pbs-panel0 and Sign out cannot be clicked while the PBS tab shows.
-// Promote to -PBS.txt once it has run in beta.
+// Let BBO's Phoenix dropdowns paint above our panel. Without this the name-tag
+// menu (Show profile / BBO Store / Help / Sign out) is covered by pbs-panel0
+// whenever the PBS tab is showing, and Sign out cannot be clicked at all.
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/onAnyMutation-dropdown.js
 
 // Start BBA Auction Compare panel (called by Auction Compare button)

--- a/-PBS-toggle.txt
+++ b/-PBS-toggle.txt
@@ -1,5 +1,5 @@
 //BBOalert, Bidding Scenarios Toggle
-//BBOalert, Bidding Scenarios Toggle - version 4.1.11
+//BBOalert, Bidding Scenarios Toggle - version 4.1.12
 //
 // RETIRED. This variant is no longer maintained separately: it was a stale copy
 // of release (v4.1.8, still on the pre-polling js/setDealerCode.js) that missed
@@ -51,7 +51,7 @@ Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 // at this file becomes a thing you can look up rather than a thing you guess.
 // If nothing reports -toggle for a good while, this file can be left to rot
 // safely - though still not deleted.
-Script,onDataLoad,window.pbsVersionLabel='v4.1.11-toggle'; window.pbsClientVersion='1.9.26-toggle'; R='';
+Script,onDataLoad,window.pbsVersionLabel='v4.1.12-toggle'; window.pbsClientVersion='1.9.26-toggle'; R='';
 
 // Host-conflict guard - must load before the blocks that call it.
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/deferGuard.js
@@ -68,6 +68,11 @@ Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtim
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/displayHCP.js
 
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/onAnyMutation-hcp.js
+
+// Let BBO's Phoenix dropdowns paint above our panel. Without this the name-tag
+// menu (Show profile / BBO Store / Help / Sign out) is covered by pbs-panel0
+// whenever the PBS tab is showing, and Sign out cannot be clicked at all.
+Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/onAnyMutation-dropdown.js
 
 // Start BBA Auction Compare panel (called by Auction Compare button)
 Script,startBBACompare,window.startBBACompare(); R='';

--- a/-PBS.txt
+++ b/-PBS.txt
@@ -1,5 +1,5 @@
 //BBOalert, Bidding Scenarios
-//BBOalert, Bidding Scenarios - version 4.1.11
+//BBOalert, Bidding Scenarios - version 4.1.12
 //
 // RELEASE channel. The JavaScript this file used to carry inline now lives in
 // runtime/ in bridge-craftwork/pbs-bbo-extension, fetched at run time. Release
@@ -37,7 +37,7 @@ Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 // Keep them in step with line 2 and with BBAcompare respectively. runtime/
 // falls back to "unset" rather than to a real version, so forgetting either
 // shows up as obviously missing instead of as a wrong channel.
-Script,onDataLoad,window.pbsVersionLabel='v4.1.11'; window.pbsClientVersion='1.9.26'; R='';
+Script,onDataLoad,window.pbsVersionLabel='v4.1.12'; window.pbsClientVersion='1.9.26'; R='';
 
 // Host-conflict guard - must load before the blocks that call it.
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/deferGuard.js
@@ -54,6 +54,11 @@ Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtim
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/displayHCP.js
 
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/onAnyMutation-hcp.js
+
+// Let BBO's Phoenix dropdowns paint above our panel. Without this the name-tag
+// menu (Show profile / BBO Store / Help / Sign out) is covered by pbs-panel0
+// whenever the PBS tab is showing, and Sign out cannot be clicked at all.
+Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/onAnyMutation-dropdown.js
 
 // Start BBA Auction Compare panel (called by Auction Compare button)
 Script,startBBACompare,window.startBBACompare(); R='';


### PR DESCRIPTION
`runtime/onAnyMutation-dropdown.js` has run in beta and is verified there:

```
menu open -> {"panelZ":"9","signOutCovered":false}
```

Panel z drops to 9 while the menu is open, `"Sign out"` hit-tests to the dropdown rather than to `pbs-iframe`, and it returns to 5000 when the menu closes. Page responsive throughout — the check that matters, since the block runs on every mutation and writes to the parent document.

**Promotion was the merge the channel design promised** — `main → release` in the extension repo — plus the one import line here. No code was copied between channels.

## Also in this change

- **`-PBS-toggle.txt` gets it too.** That file is supposed to load exactly what release loads; leaving it behind would restart the drift it was retired for two commits ago.
- **Package version `4.1.11 → 4.1.12`** in all three files. A user-visible behaviour change reaching every release user, so a bug report should be able to say which side of it the reporter is on. The **plug-in version stays `1.9.26`** — it tracks BBAcompare's `CLIENT_VERSION`, which hasn't moved.

Beta returns to exactly the three documented differences from `-PBS.txt`: branch, devLoader, and its own version strings.

All 13 release-channel imports return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)