### PR TITLE
Beta: load BBAcompare from runtime/plugins/

### DIFF
--- a/-PBS-beta.txt
+++ b/-PBS-beta.txt
@@ -20,7 +20,12 @@
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/setDealerCode-polling.js
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/toggleRotate.js
 Javascript,https://github.com/stanmaz/BBOalert/blob/master/Plugins/PBNcapture.js
-Javascript,https://github.com/bridge-craftwork/bbo-pbs/blob/master/Plugins/BBAcompare.js
+// UNDER TEST IN BETA. BBAcompare now lives in runtime/plugins/ like every
+// other file we fetch at run time, so it finally has a beta channel - it used
+// to ship straight to release. This copy also carries the dealer fix: the old
+// one read the dealer letter from the auction headers, which BBO translates,
+// so a Turkish user sent K/G instead of N/S. Promote to -PBS.txt once soaked.
+Javascript,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/plugins/BBAcompare.js
 Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 
 // Channel identity. runtime/ is shared by every channel and carries no version


### PR DESCRIPTION
BBAcompare had **no channel** — both data files fetched it from `bbo-pbs/master`, so every change went straight to release. It now lives in `runtime/plugins/` with everything else we fetch at run time, and beta points at `main` so it finally gets a soak.

This copy also carries the dealer fix: the old code read the dealer letter from the auction column headers, which BBO translates, so a Turkish user sent `K` (Kuzey) or `G` (Güney) instead of `N`/`S` — and the server parsed both as North.

Release still loads the `bbo-pbs` copy until this is promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)