### PR TITLE
Both channels load BBAcompare from runtime/plugins/

### DIFF
--- a/-PBS-beta.txt
+++ b/-PBS-beta.txt
@@ -20,11 +20,10 @@
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/setDealerCode-polling.js
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/toggleRotate.js
 Javascript,https://github.com/stanmaz/BBOalert/blob/master/Plugins/PBNcapture.js
-// UNDER TEST IN BETA. BBAcompare now lives in runtime/plugins/ like every
-// other file we fetch at run time, so it finally has a beta channel - it used
-// to ship straight to release. This copy also carries the dealer fix: the old
-// one read the dealer letter from the auction headers, which BBO translates,
-// so a Turkish user sent K/G instead of N/S. Promote to -PBS.txt once soaked.
+// BBAcompare lives in runtime/plugins/ with everything else fetched at run
+// time, so it has a release/beta channel like the rest. It used to be loaded
+// straight from bbo-pbs/master by both files, which meant every change to it
+// shipped to release with no beta stage.
 Javascript,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/main/runtime/plugins/BBAcompare.js
 Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 

--- a/-PBS.txt
+++ b/-PBS.txt
@@ -14,7 +14,11 @@
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/setDealerCode-polling.js
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/toggleRotate.js
 Javascript,https://github.com/stanmaz/BBOalert/blob/master/Plugins/PBNcapture.js
-Javascript,https://github.com/bridge-craftwork/bbo-pbs/blob/master/Plugins/BBAcompare.js
+// BBAcompare lives in runtime/plugins/ with everything else fetched at run
+// time, so it has a release/beta channel like the rest. It used to be loaded
+// straight from bbo-pbs/master by both files, which meant every change to it
+// shipped to release with no beta stage.
+Javascript,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/plugins/BBAcompare.js
 Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 
 // Channel identity. runtime/ is shared by every channel and carries no version


### PR DESCRIPTION
Finishes the move. Beta was pointed at `runtime/plugins/` earlier; **release was still loading `bbo-pbs/master`**, so the file had a channel but release wasn't using it.

Safe to switch release now because the two copies are **byte-identical** — bridge-craftwork/bbo-pbs#3 merged minutes ago — so this changes which URL serves the file and nothing else. At any other moment it would have meant promoting a code change and a path change together.

| file | loads BBAcompare from |
|---|---|
| `-PBS.txt` | `pbs-bbo-extension/blob/release/runtime/plugins/` |
| `-PBS-beta.txt` | `pbs-bbo-extension/blob/main/runtime/plugins/` |

Only that one file was promoted to the `release` branch, not a branch sync — `main` also carries the startTable interface-language fixes, which are deliberately still soaking in beta. Verified: `release/runtime/startTable.js` has no `navButton`.

Beta is back to exactly the three documented differences from `-PBS.txt`: branch, devLoader, version strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)