### PR TITLE
Release: import the runtime build stamp

### DIFF
--- a/-PBS.txt
+++ b/-PBS.txt
@@ -43,6 +43,14 @@ Import,https://github.com/stanmaz/BBOalert/blob/master/Scripts/PBStooltips.js
 // shows up as obviously missing instead of as a wrong channel.
 Script,onDataLoad,window.pbsVersionLabel='v4.1.12'; window.pbsClientVersion='1.9.26'; R='';
 
+// Build stamp - publishes the content hash of every runtime/ file into the page.
+// Not a feature: it exists so a stale fetch says so. runtime/ is served from a
+// CDN that caches for minutes, and the cost of that was never the wait - it was
+// hours spent chasing a bug that had already been fixed, in code the browser had
+// not picked up yet. First in the list, so the stamp is there even if a later
+// import fails.
+Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/buildStamp.js
+
 // Host-conflict guard - must load before the blocks that call it.
 Import,https://github.com/bridge-craftwork/pbs-bbo-extension/blob/release/runtime/deferGuard.js
 


### PR DESCRIPTION
Publishes the content hash of every `runtime/` file into the page, so a stale fetch announces itself instead of looking like a bug.

The five-minute CDN cache was never the expensive part. The expensive part was **hours spent debugging code that had already been fixed**, because nothing in the page said which revision it was running — three times in one day, twice after the trap had been written into the docs. A warning you have to remember isn't a defence.

Both channels now carry it, so a bug report from either can be pinned to an exact revision of `runtime/`:

```
[PBS] runtime build afd8f11b (15 files)
```

Beta's three documented differences from release are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)