### PR TITLE
Manifest chat: keep commas plain

### DIFF
--- a/.claude/skills/dealer/SKILL.md
+++ b/.claude/skills/dealer/SKILL.md
@@ -28,7 +28,7 @@ Always edit **btn files**, never dlr files directly.
 
 /*@chat
 Description text for BBO display.
-Use plain regular commas here; the pipeline converts them to wide commas (，) downstream. Do NOT hand-type wide commas in .btn files.
+Use plain regular commas here. Do NOT hand-type wide commas (，) in .btn files.
 @chat*/
 
 dealer south|west|north|east

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,7 +250,7 @@ Central configuration in [build-scripts-mac/config.py](build-scripts-mac/config.
   - Optional filtering rules for auction patterns
 - The `-PBS.txt` file lists all scenarios and their organization
 - When creating new scenarios, follow the existing `.btn` structure
-- **Commas in scenario chat**: Use plain regular commas in `.btn` files. `py/build_manifest.py` converts them to wide commas (，) in the manifest's chat; do not hand-type wide commas in `.btn` files.
+- **Commas in scenario chat**: Use plain regular commas in `.btn` files; they reach BBO chat as plain commas. Do not hand-type wide commas (，) in `.btn` files.
 
 ### Working with the Pipeline
 

--- a/manifest/README.md
+++ b/manifest/README.md
@@ -53,7 +53,7 @@ Bridge-Classroom-served coaching collection (`coaching-non-rotated/`). The
   "scenarios": {                 // keyed by .btn/.dlr filename (= layout "name")
     "Smolen": {
       "buttonText": "Smolen",    // on-screen label (from the .dlr header)
-      "chat": "\\n--- Smolen\\n...",  // raw chat w/ \n tokens, wide commas, !S suit codes
+      "chat": "\\n--- Smolen\\n...",  // raw chat w/ \n tokens, !S suit codes
       "alias": "Smolen",
       "gibWorks": true,          // from .btn  (NOT available in the menu today)
       "bbaWorks": true,          // from .btn  (NOT available in the menu today)
@@ -84,9 +84,10 @@ Bridge-Classroom-served coaching collection (`coaching-non-rotated/`). The
 }
 ```
 
-`buttonText`/`chat`/`alias` are taken from the `.dlr` header, in the form the old
-`.pbs` `Button,` line carried them: wide commas, `!C` suit tokens and `\n`
-tokens for line breaks, so the menu reads exactly as it did.
+`buttonText`/`chat`/`alias` are taken from the `.dlr` header. Chat keeps `!C`
+suit tokens and uses `\n` tokens for line breaks; commas stay plain. The old
+`.pbs` `Button,` line needed wide commas (，) because commas separated its
+fields, but BBO chat takes plain ones.
 `gibWorks`/`bbaWorks`/convention cards come from the `.btn` header.
 
 ### `lessons` roster (v2)

--- a/py/build_manifest.py
+++ b/py/build_manifest.py
@@ -129,16 +129,16 @@ def load_all_btn_metadata():
 def parse_dlr_button(dlr_path):
     """Return {'buttonText','chat','alias'} from a .dlr header.
 
-    Chat comes out in the form the BBO extension renders: literal `\\n` tokens
-    for line breaks, and wide commas, because the .pbs Button record it used to
-    come from separated its fields with commas. The extension's dealerFromDlr
-    produces the same string.
+    Chat comes out in the form the BBO extension sends to chat: literal `\\n`
+    tokens for line breaks, commas left plain. (It used to carry wide commas,
+    which were only needed inside the .pbs Button record.) The extension's
+    dealerFromDlr produces the same string.
     """
     with open(dlr_path, "r", encoding="utf-8") as fh:
         parsed = parse_dlr_file(fh.read())
     chat = parsed["chat"]
     if chat:
-        chat = "\\n" + "\\n".join(chat.replace(", ", "，").split("\n")) + "\\n"
+        chat = "\\n" + "\\n".join(chat.split("\n")) + "\\n"
     alias = parsed["alias"] or "Unknown"
     return {
         "buttonText": parsed["button_text"] or alias,


### PR DESCRIPTION
Part of #321. With `pbs-test/` and the `pbs` operation gone (#325), the last wide-comma conversion was `py/build_manifest.py`: it still turned `, ` into `，` in each scenario's chat.

Wide commas were only ever needed inside the `.pbs` `Button,` record, where commas separated its fields. The BBO extension now passes manifest chat straight to `setChatMessage`, which splits only on `\n`, and plain commas have been confirmed in live BBO chat (bridge-craftwork/pbs-bbo-extension#35, already on `release`).

## Changes
- `py/build_manifest.py`: chat keeps plain commas.
- `manifest/README.md`, `CLAUDE.md`, `.claude/skills/dealer/SKILL.md`: stop saying the build converts commas. They still say not to hand-type wide commas in `.btn` files.

## Checked
I rebuilt both manifests into a scratch folder and compared them with the committed ones:
- `manifest-release.json` and `manifest-beta.json`: 196 scenario chats changed in each, and every change is a wide comma turned plain. No other field differs, and no wide commas are left.

The manifests aren't in this PR. The build-manifest workflow triggers on `py/build_manifest.py` and will regenerate them after the merge.

Other readers of the manifest are unaffected: pbs-bbo-extension's `tools/check-dlr-strip.mjs` accepts either comma, and Bridge Classroom already turns `，` back into `,` when it reads chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
