### PR TITLE
Store GIB captures in BBA notation (1N, not 1NT)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ Extension provides:
 - `bba-filtered/` - Filtered BBA files by auction pattern
 - `bba-filtered-out/` - BBA files that were filtered out
 - `bba-summary/` - Statistics summaries
-- `GIB/` - Auctions bid by BBO's GIB robots, one PBN capture per scenario: older ones hand-collected, new ones from `py/gib_capture.py` (issue #323)
+- `GIB/` - Auctions bid by BBO's GIB robots, one PBN capture per scenario: older ones hand-collected, new ones from `py/gib_capture.py` (issue #323). Stored in BBA's notation (`1N`, `[Contract "3N"]`, not `1NT`), so one `auction-filter` works on both BBA and GIB auctions
 - `GIB-filtered/`, `GIB-filtered-out/`, `GIB-report/` - `gibReport` output: the capture split by `auction-filter` (PBN + PDF), and a match report per scenario
 
 **Generated (Final Output):**

--- a/GIB-filtered-out/Drury.pbn
+++ b/GIB-filtered-out/Drury.pbn
@@ -1240,8 +1240,8 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1S      Pass
 2C      Pass    3S      Pass
-4C      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+4C      Pass    4N     Pass
+5S      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -1645,7 +1645,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    Pass    Pass
 
 
@@ -2020,12 +2020,12 @@ Pass    Pass
 {HCP 16 7 10 7}
 {TP 17 7 10 9}
 {Losers 4 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2231,12 +2231,12 @@ Pass    Pass
 {HCP 17 5 10 8}
 {TP 19 7 10 9}
 {Losers 4 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-1NT     Pass    2H      Pass
-3D      Pass    3NT     Pass
+1N     Pass    2H      Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2744,7 +2744,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 Pass    Pass    
 
 
@@ -3530,9 +3530,9 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1C      Pass
 1H      Pass    2S      Pass
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 3D      Pass    3S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 5S      Pass    Pass    Pass
 
 
@@ -3978,7 +3978,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    4H      Pass
 Pass    Pass    
 
@@ -4465,7 +4465,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1S      Pass
 2C      Pass    3H      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -5476,8 +5476,8 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1H      Pass
 2D      Pass    2S      Pass
-2NT     Pass    3H      Pass
-3NT     Pass    4S      Pass
+2N     Pass    3H      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -5498,7 +5498,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 Pass    Pass    
 
 
@@ -5794,7 +5794,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1H      Pass
 2C      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    6H      Pass
 Pass    Pass    
 
@@ -7342,8 +7342,8 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1S      Pass
 2C      Pass    3H      Pass
-4H      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5H      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -7429,7 +7429,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    3H      Pass
+1N     Pass    3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -9455,7 +9455,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9817,7 +9817,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1S      Pass
 2C      Pass    3D      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -10133,8 +10133,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    3H      Pass
-3NT     Pass    4H      Pass
+1N     Pass    3H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 

--- a/GIB-filtered-out/Opps_Preempt_4M.pbn
+++ b/GIB-filtered-out/Opps_Preempt_4M.pbn
@@ -58,7 +58,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      Pass    1NT     2H
+1S      Pass    1N     2H
 2S      4H      4S      Pass
 Pass    Pass    
 
@@ -79,7 +79,7 @@ Pass    Pass
 [Contract "5CX"]
 [Declarer "N"]
 [Auction "E"]
-1H      2NT     3D      4C
+1H      2N     3D      4C
 4H      Pass    Pass    5C
 X       Pass    Pass    Pass
 
@@ -165,7 +165,7 @@ X       Pass    Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1S      Pass    2H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -207,7 +207,7 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "E"]
 [Auction "E"]
-1H      Pass    1NT     4S
+1H      Pass    1N     4S
 Pass    Pass    5H      Pass
 Pass    Pass    
 
@@ -315,7 +315,7 @@ Pass    Pass    Pass
 [Auction "E"]
 1S      Pass    2D      Pass
 2S      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -338,7 +338,7 @@ Pass    Pass    Pass
 [Auction "E"]
 1H      Pass    1S      Pass
 2H      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -446,7 +446,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2H      Pass    Pass    2S
 Pass    4S      Pass    Pass
 Pass    
@@ -465,11 +465,11 @@ Pass
 {HCP 12 10 11 7}
 {TP 14 13 12 8}
 {Losers 5 5 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "E"]
 1H      1S      Pass    3D
-Pass    3H      Pass    3NT
+Pass    3H      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -573,7 +573,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      X       2NT     Pass
+1H      X       2N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -594,7 +594,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -637,7 +637,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3C      3D
+1H      2N     3C      3D
 4H      Pass    Pass    Pass
 
 
@@ -658,8 +658,8 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1S      Pass    1NT     2S
-Pass    2NT     Pass    3D
+1S      Pass    1N     2S
+Pass    2N     Pass    3D
 Pass    3H      Pass    Pass
 Pass    
 
@@ -746,7 +746,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2S      Pass    Pass    Pass
 
 
@@ -768,7 +768,7 @@ Pass
 [Declarer "E"]
 [Auction "E"]
 1H      Pass    2C      2S
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -831,7 +831,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "E"]
 1S      2H      2S      3H
-3S      4H      4S      4NT
+3S      4H      4S      4N
 Pass    6H      Pass    Pass
 Pass    
 
@@ -958,8 +958,8 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-1S      2NT     Pass    3S
-Pass    4NT     Pass    5C
+1S      2N     Pass    3S
+Pass    4N     Pass    5C
 Pass    5D      Pass    Pass
 Pass    
 
@@ -980,7 +980,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      Pass    1NT     X
+1S      Pass    1N     X
 2S      3D      4S      Pass
 Pass    Pass    
 
@@ -1001,7 +1001,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1H      Pass    1NT     X
+1H      Pass    1N     X
 2H      3H      Pass    4C
 Pass    4S      Pass    Pass
 Pass    
@@ -1170,7 +1170,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2S      X       2NT
+1S      2S      X       2N
 4S      Pass    Pass    Pass
 
 
@@ -1235,7 +1235,7 @@ Pass
 [Auction "E"]
 1H      Pass    1S      Pass
 2H      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -1405,7 +1405,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1S      2C      Pass    Pass
-2S      Pass    4NT     Pass
+2S      Pass    4N     Pass
 6C      Pass    6S      Pass
 Pass    Pass    
 
@@ -1491,7 +1491,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1S      2C      2D      Pass
-2S      3C      3NT     Pass
+2S      3C      3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -1512,7 +1512,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2H      Pass    Pass    2S
 Pass    3S      Pass    4S
 Pass    Pass    Pass    

--- a/GIB-filtered-out/Smolen.pbn
+++ b/GIB-filtered-out/Smolen.pbn
@@ -12,12 +12,12 @@
 {HCP 11 5 16 8}
 {TP 12 5 16 9}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -37,9 +37,9 @@
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5H      Pass    6H      Pass
 Pass    Pass    
 
@@ -57,12 +57,12 @@ Pass    Pass
 {HCP 11 11 15 3}
 {TP 13 12 15 4}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -82,7 +82,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -101,12 +101,12 @@ Pass    Pass
 {HCP 14 7 16 3}
 {TP 16 7 16 4}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -123,12 +123,12 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 12 9 16 7}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -148,7 +148,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -170,7 +170,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -192,7 +192,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -214,7 +214,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -236,7 +236,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -258,7 +258,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -280,7 +280,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -299,12 +299,12 @@ Pass    Pass
 {HCP 15 3 15 7}
 {TP 16 4 16 7}
 {Losers 6 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -321,12 +321,12 @@ Pass    Pass
 {HCP 14 8 15 3}
 {TP 14 9 15 4}
 {Losers 6 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -346,7 +346,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -368,7 +368,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -390,7 +390,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -412,7 +412,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -434,7 +434,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -456,7 +456,7 @@ Pass    Pass
 [Contract "2SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -477,7 +477,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -499,7 +499,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -521,7 +521,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -543,7 +543,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -562,12 +562,12 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 13 9 15 7}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -587,7 +587,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -609,7 +609,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -628,12 +628,12 @@ Pass    Pass
 {HCP 11 7 16 6}
 {TP 11 7 16 7}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -653,10 +653,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6C      Pass    6H      Pass
 Pass    Pass    
 
@@ -677,7 +677,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -699,7 +699,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -718,12 +718,12 @@ Pass    Pass
 {HCP 15 6 16 3}
 {TP 16 6 16 3}
 {Losers 5 10 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -740,12 +740,12 @@ Pass    Pass
 {HCP 11 9 17 3}
 {TP 11 10 17 5}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -762,12 +762,12 @@ Pass    Pass
 {HCP 15 7 15 3}
 {TP 17 9 15 3}
 {Losers 5 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -787,7 +787,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -809,7 +809,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -831,7 +831,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -853,9 +853,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -876,7 +876,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -898,7 +898,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -920,9 +920,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -944,9 +944,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -964,12 +964,12 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 13 9 15 7}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -989,7 +989,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1011,7 +1011,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1030,12 +1030,12 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 10 6 15 10}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1055,7 +1055,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4D      Pass
 5C      Pass    5H      Pass
@@ -1079,9 +1079,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -1099,12 +1099,12 @@ Pass    Pass
 {HCP 12 8 15 5}
 {TP 14 10 16 6}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1124,7 +1124,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1143,12 +1143,12 @@ Pass    Pass
 {HCP 14 10 15 1}
 {TP 15 10 16 2}
 {Losers 6 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1165,12 +1165,12 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 12 9 16 7}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1187,12 +1187,12 @@ Pass    Pass
 {HCP 10 7 16 7}
 {TP 11 7 17 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1212,7 +1212,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -1234,7 +1234,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1253,12 +1253,12 @@ Pass    Pass
 {HCP 13 3 16 8}
 {TP 15 4 16 8}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1278,7 +1278,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1300,10 +1300,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    6H      Pass
 Pass    Pass    
 
@@ -1324,7 +1324,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1343,12 +1343,12 @@ Pass    Pass
 {HCP 16 6 16 2}
 {TP 19 7 16 3}
 {Losers 5 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1368,7 +1368,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1387,12 +1387,12 @@ Pass    Pass
 {HCP 10 5 17 8}
 {TP 12 5 17 8}
 {Losers 6 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1412,7 +1412,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1431,12 +1431,12 @@ Pass    Pass
 {HCP 14 2 16 8}
 {TP 15 3 17 8}
 {Losers 6 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1456,7 +1456,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1475,12 +1475,12 @@ Pass    Pass
 {HCP 11 5 15 9}
 {TP 12 6 15 9}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1500,9 +1500,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -1524,7 +1524,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1546,7 +1546,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1565,12 +1565,12 @@ Pass    Pass
 {HCP 15 6 15 4}
 {TP 16 7 15 4}
 {Losers 6 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1590,7 +1590,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1612,7 +1612,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1634,7 +1634,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1656,7 +1656,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1678,9 +1678,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -1701,7 +1701,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1723,7 +1723,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1745,9 +1745,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -1768,7 +1768,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -1790,7 +1790,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1812,7 +1812,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1831,12 +1831,12 @@ Pass    Pass
 {HCP 14 7 16 3}
 {TP 14 8 17 4}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1853,12 +1853,12 @@ Pass    Pass
 {HCP 13 6 15 6}
 {TP 13 7 15 7}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1878,7 +1878,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1897,12 +1897,12 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 12 8 15 6}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1919,12 +1919,12 @@ Pass    Pass
 {HCP 10 13 15 2}
 {TP 10 15 15 3}
 {Losers 7 6 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1941,12 +1941,12 @@ Pass    Pass
 {HCP 15 8 15 2}
 {TP 16 9 15 3}
 {Losers 6 9 7 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -1966,7 +1966,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1988,7 +1988,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2010,7 +2010,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2032,7 +2032,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2051,12 +2051,12 @@ Pass    Pass
 {HCP 13 4 16 7}
 {TP 16 5 16 10}
 {Losers 5 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2076,9 +2076,9 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3H      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    5H      Pass
 Pass    Pass    
 
@@ -2099,7 +2099,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2118,12 +2118,12 @@ Pass    Pass
 {HCP 11 14 15 0}
 {TP 11 14 16 1}
 {Losers 8 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2143,7 +2143,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2165,7 +2165,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2187,7 +2187,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2209,7 +2209,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2231,7 +2231,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -2252,7 +2252,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2274,9 +2274,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -2297,7 +2297,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    5C      Pass
 6H      Pass    Pass    Pass
@@ -2320,7 +2320,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    5C      Pass
 5D      Pass    6S      Pass
@@ -2340,12 +2340,12 @@ Pass    Pass
 {HCP 12 7 15 6}
 {TP 12 9 16 7}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2365,7 +2365,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4D      Pass
 4S      Pass    Pass    Pass
@@ -2388,7 +2388,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2410,7 +2410,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2429,12 +2429,12 @@ Pass    Pass
 {HCP 14 6 15 5}
 {TP 14 7 15 6}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2451,12 +2451,12 @@ Pass    Pass
 {HCP 17 3 16 4}
 {TP 18 5 16 6}
 {Losers 5 9 7 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -2473,12 +2473,12 @@ Pass    Pass
 {HCP 13 8 15 4}
 {TP 14 8 16 4}
 {Losers 6 10 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2498,7 +2498,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2520,7 +2520,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2539,12 +2539,12 @@ Pass    Pass
 {HCP 12 5 16 7}
 {TP 13 7 16 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2564,7 +2564,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -2586,7 +2586,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -2608,7 +2608,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -2630,7 +2630,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2652,7 +2652,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2674,7 +2674,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2693,12 +2693,12 @@ Pass    Pass
 {HCP 12 7 16 5}
 {TP 13 8 16 5}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2718,7 +2718,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2740,7 +2740,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2759,12 +2759,12 @@ Pass    Pass
 {HCP 10 11 15 4}
 {TP 10 11 16 6}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2784,7 +2784,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2803,12 +2803,12 @@ Pass    Pass
 {HCP 10 7 15 8}
 {TP 12 8 15 8}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2828,7 +2828,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2850,7 +2850,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2872,7 +2872,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2894,7 +2894,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2916,7 +2916,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2938,7 +2938,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2960,7 +2960,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2979,12 +2979,12 @@ Pass    Pass
 {HCP 13 5 15 7}
 {TP 15 5 16 7}
 {Losers 6 11 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3004,7 +3004,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3026,7 +3026,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    5C      Pass
 5D      Pass    6H      Pass
@@ -3046,12 +3046,12 @@ Pass    Pass
 {HCP 12 11 15 2}
 {TP 13 12 15 3}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3068,12 +3068,12 @@ Pass    Pass
 {HCP 11 6 16 7}
 {TP 12 6 16 7}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3093,7 +3093,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3112,12 +3112,12 @@ Pass    Pass
 {HCP 12 5 16 7}
 {TP 14 5 16 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3134,12 +3134,12 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 12 9 15 7}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3159,7 +3159,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3178,12 +3178,12 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 13 8 15 7}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3203,7 +3203,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3222,12 +3222,12 @@ Pass    Pass
 {HCP 13 5 15 7}
 {TP 14 6 16 8}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3244,12 +3244,12 @@ Pass    Pass
 {HCP 14 4 17 5}
 {TP 15 6 17 8}
 {Losers 6 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3269,7 +3269,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3291,10 +3291,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    5H      Pass
 6H      Pass    Pass    Pass
 
@@ -3316,9 +3316,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -3336,12 +3336,12 @@ Pass    Pass
 {HCP 11 3 16 10}
 {TP 11 3 16 11}
 {Losers 8 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3361,7 +3361,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3383,7 +3383,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3402,12 +3402,12 @@ Pass    Pass
 {HCP 12 5 16 7}
 {TP 13 6 16 8}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3427,7 +3427,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3446,11 +3446,11 @@ Pass    Pass
 {HCP 12 8 15 5}
 {TP 13 11 15 7}
 {Losers 6 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
-Pass    3D      3NT     Pass
+1N     Pass    2C      2D
+Pass    3D      3N     Pass
 Pass    Pass    
 
 
@@ -3467,12 +3467,12 @@ Pass    Pass
 {HCP 10 12 15 3}
 {TP 11 12 16 4}
 {Losers 8 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3492,7 +3492,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3511,12 +3511,12 @@ Pass    Pass
 {HCP 14 9 15 2}
 {TP 16 10 16 4}
 {Losers 6 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3536,7 +3536,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3558,7 +3558,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3580,9 +3580,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
-4NT     Pass    6D      Pass
+4N     Pass    6D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -3603,7 +3603,7 @@ Pass    Pass    4S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3622,12 +3622,12 @@ Pass    Pass    4S      Pass
 {HCP 15 6 15 4}
 {TP 15 8 15 5}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3647,7 +3647,7 @@ Pass    Pass    4S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -3669,7 +3669,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -3691,7 +3691,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3713,7 +3713,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3735,7 +3735,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3757,7 +3757,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3776,12 +3776,12 @@ Pass    Pass    3H      Pass
 {HCP 10 11 15 4}
 {TP 12 13 15 5}
 {Losers 7 5 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3798,12 +3798,12 @@ Pass    Pass
 {HCP 15 4 17 4}
 {TP 17 5 18 5}
 {Losers 6 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3820,12 +3820,12 @@ Pass    Pass
 {HCP 12 6 15 7}
 {TP 13 6 16 7}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3845,7 +3845,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3867,7 +3867,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3889,7 +3889,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3911,10 +3911,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5H      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -3935,7 +3935,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3957,7 +3957,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3976,12 +3976,12 @@ Pass    Pass
 {HCP 14 4 16 6}
 {TP 15 6 17 6}
 {Losers 6 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4001,7 +4001,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4023,9 +4023,9 @@ Pass    Pass
 [Contract "5S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
 5S      Pass    Pass    Pass
 
@@ -4044,12 +4044,12 @@ Pass    Pass
 {HCP 10 7 15 8}
 {TP 10 7 15 8}
 {Losers 7 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4069,7 +4069,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    5C      Pass
 5D      Pass    5S      Pass
@@ -4090,12 +4090,12 @@ Pass    Pass
 {HCP 13 5 16 6}
 {TP 14 6 16 6}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4115,7 +4115,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4134,12 +4134,12 @@ Pass    Pass
 {HCP 13 3 15 9}
 {TP 14 4 15 9}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4159,7 +4159,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4181,10 +4181,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
 6C      Pass    6S      Pass
 Pass    Pass    
@@ -4206,7 +4206,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4228,7 +4228,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4250,7 +4250,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4269,12 +4269,12 @@ Pass    Pass
 {HCP 13 4 17 6}
 {TP 14 4 17 6}
 {Losers 7 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4294,7 +4294,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4313,12 +4313,12 @@ Pass    Pass
 {HCP 11 10 16 3}
 {TP 12 10 16 4}
 {Losers 7 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4335,12 +4335,12 @@ Pass    Pass
 {HCP 11 10 17 2}
 {TP 13 11 17 3}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3S      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4357,12 +4357,12 @@ Pass    Pass    3S      X
 {HCP 12 9 15 4}
 {TP 13 9 15 5}
 {Losers 7 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4379,12 +4379,12 @@ Pass    Pass    3S      X
 {HCP 12 6 15 7}
 {TP 13 6 15 7}
 {Losers 7 10 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4401,12 +4401,12 @@ Pass    Pass    3S      X
 {HCP 15 6 15 4}
 {TP 18 6 15 5}
 {Losers 4 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4426,9 +4426,9 @@ Pass    Pass    3S      X
 [Contract "5S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
 5S      Pass    Pass    Pass
 
@@ -4450,7 +4450,7 @@ Pass    Pass    3S      X
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -4469,12 +4469,12 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 12 8 15 6}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4494,7 +4494,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4516,7 +4516,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4535,12 +4535,12 @@ Pass    Pass
 {HCP 12 6 16 6}
 {TP 14 6 16 7}
 {Losers 6 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4560,7 +4560,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -4582,7 +4582,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4604,7 +4604,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4626,7 +4626,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4645,12 +4645,12 @@ Pass    Pass    3H      Pass
 {HCP 10 11 16 3}
 {TP 10 11 16 5}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4670,7 +4670,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4692,7 +4692,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4714,7 +4714,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4736,7 +4736,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4755,12 +4755,12 @@ Pass    Pass    3H      Pass
 {HCP 15 1 15 9}
 {TP 17 2 15 10}
 {Losers 5 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4780,7 +4780,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4802,7 +4802,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4821,12 +4821,12 @@ Pass    Pass    3H      Pass
 {HCP 10 8 15 7}
 {TP 12 9 15 7}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4846,7 +4846,7 @@ Pass    Pass    3H      Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 XX      Pass    3S      Pass
 4S      Pass    5D      Pass
 5H      Pass    5S      Pass
@@ -4870,7 +4870,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4892,7 +4892,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4914,7 +4914,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4H      Pass
 5C      Pass    6S      Pass
@@ -4937,9 +4937,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -4960,7 +4960,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4982,7 +4982,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5001,12 +5001,12 @@ Pass    Pass
 {HCP 11 9 17 3}
 {TP 12 10 17 5}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5023,12 +5023,12 @@ Pass    Pass
 {HCP 10 5 17 8}
 {TP 12 5 17 8}
 {Losers 7 10 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5045,12 +5045,12 @@ Pass    Pass
 {HCP 12 7 16 5}
 {TP 12 8 17 6}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5070,7 +5070,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5089,12 +5089,12 @@ Pass    Pass
 {HCP 16 5 15 4}
 {TP 19 6 15 4}
 {Losers 4 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5111,12 +5111,12 @@ Pass    Pass
 {HCP 12 8 15 5}
 {TP 12 8 16 5}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5136,7 +5136,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -5155,12 +5155,12 @@ Pass    Pass
 {HCP 11 10 15 4}
 {TP 12 10 15 5}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5177,12 +5177,12 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 12 8 16 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5202,7 +5202,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5221,12 +5221,12 @@ Pass    Pass
 {HCP 12 9 16 3}
 {TP 14 10 16 3}
 {Losers 6 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5246,7 +5246,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5268,7 +5268,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 XX      Pass    3H      Pass
 4H      Pass    6H      Pass
 Pass    Pass    
@@ -5290,7 +5290,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    5C      Pass
 5D      Pass    6H      Pass
@@ -5313,7 +5313,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5335,7 +5335,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5357,7 +5357,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5379,7 +5379,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -5401,7 +5401,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5420,12 +5420,12 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 12 8 16 6}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5442,12 +5442,12 @@ Pass    Pass
 {HCP 13 4 15 8}
 {TP 14 5 15 8}
 {Losers 6 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5464,12 +5464,12 @@ Pass    Pass
 {HCP 12 4 17 7}
 {TP 13 5 17 8}
 {Losers 6 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5489,7 +5489,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5508,12 +5508,12 @@ Pass    Pass
 {HCP 11 9 15 5}
 {TP 12 11 15 6}
 {Losers 6 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5530,12 +5530,12 @@ Pass    Pass
 {HCP 11 10 15 4}
 {TP 12 12 16 5}
 {Losers 7 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5555,7 +5555,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5577,7 +5577,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -5599,7 +5599,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -5621,10 +5621,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 6H      Pass    Pass    Pass
 
 
@@ -5645,7 +5645,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -5664,12 +5664,12 @@ Pass    Pass
 {HCP 11 10 16 3}
 {TP 11 11 16 3}
 {Losers 7 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5686,11 +5686,11 @@ Pass    Pass
 {HCP 13 9 15 3}
 {TP 13 12 16 4}
 {Losers 6 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3C
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3C
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5707,12 +5707,12 @@ Pass    Pass
 {HCP 14 7 15 4}
 {TP 15 8 15 5}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5732,7 +5732,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4C      Pass
 4D      Pass    4H      Pass
@@ -5754,11 +5754,11 @@ Pass    Pass
 {HCP 12 12 16 0}
 {TP 13 14 16 2}
 {Losers 7 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2D
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5775,12 +5775,12 @@ Pass    Pass
 {HCP 11 7 16 6}
 {TP 12 7 16 7}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5800,7 +5800,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -5822,7 +5822,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -5844,7 +5844,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5863,12 +5863,12 @@ Pass    Pass
 {HCP 11 8 17 4}
 {TP 11 10 17 6}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5888,7 +5888,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5910,7 +5910,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
 5C      Pass    6H      Pass
@@ -5933,7 +5933,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5955,10 +5955,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5S      Pass    5N     Pass
 6H      Pass    6S      Pass
 Pass    Pass    
 
@@ -5979,7 +5979,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6001,7 +6001,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6020,12 +6020,12 @@ Pass    Pass
 {HCP 11 11 15 3}
 {TP 12 11 15 4}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6042,12 +6042,12 @@ Pass    Pass
 {HCP 12 3 16 9}
 {TP 15 4 17 9}
 {Losers 6 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6067,7 +6067,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6086,12 +6086,12 @@ Pass    Pass
 {HCP 13 4 16 7}
 {TP 14 5 16 7}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6111,7 +6111,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6133,7 +6133,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6152,12 +6152,12 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 12 6 15 9}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6177,7 +6177,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6196,12 +6196,12 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 12 6 15 11}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6218,12 +6218,12 @@ Pass    Pass
 {HCP 11 7 16 6}
 {TP 13 7 16 6}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6240,12 +6240,12 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 11 9 16 8}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6265,7 +6265,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6287,7 +6287,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6309,7 +6309,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -6331,7 +6331,7 @@ Pass    Pass    3S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6353,7 +6353,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6375,7 +6375,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6397,7 +6397,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6416,12 +6416,12 @@ Pass    Pass    3S      Pass
 {HCP 10 7 15 8}
 {TP 10 8 15 8}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6441,7 +6441,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6463,7 +6463,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6485,7 +6485,7 @@ Pass    Pass    3S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6507,7 +6507,7 @@ Pass    Pass    3S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6529,7 +6529,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6548,12 +6548,12 @@ Pass    Pass    3S      Pass
 {HCP 10 9 16 5}
 {TP 11 9 16 5}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6573,7 +6573,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6592,12 +6592,12 @@ Pass    Pass    3S      Pass
 {HCP 12 1 17 10}
 {TP 14 1 17 10}
 {Losers 6 12 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6617,7 +6617,7 @@ Pass    Pass    3S      Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    5H      Pass
 5S      Pass    6S      Pass
@@ -6640,7 +6640,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6662,7 +6662,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6681,12 +6681,12 @@ Pass    Pass
 {HCP 10 11 17 2}
 {TP 12 12 17 3}
 {Losers 7 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6706,9 +6706,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5H      Pass    6H      Pass
 Pass    Pass    
 
@@ -6726,12 +6726,12 @@ Pass    Pass
 {HCP 10 9 16 5}
 {TP 10 10 17 5}
 {Losers 7 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6748,12 +6748,12 @@ Pass    Pass
 {HCP 13 3 16 8}
 {TP 15 3 17 8}
 {Losers 6 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6770,12 +6770,12 @@ Pass    Pass
 {HCP 16 2 16 6}
 {TP 16 3 16 6}
 {Losers 5 10 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6792,12 +6792,12 @@ Pass    Pass
 {HCP 11 4 15 10}
 {TP 13 5 16 10}
 {Losers 6 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6817,7 +6817,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6836,12 +6836,12 @@ Pass    Pass
 {HCP 11 9 15 5}
 {TP 11 9 15 6}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6861,7 +6861,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6883,7 +6883,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6902,12 +6902,12 @@ Pass    Pass
 {HCP 10 9 17 4}
 {TP 11 10 17 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6927,7 +6927,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
 5C      Pass    5H      Pass
@@ -6951,7 +6951,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6973,7 +6973,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6995,7 +6995,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7017,7 +7017,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7039,9 +7039,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -7062,7 +7062,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7081,12 +7081,12 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 12 8 16 5}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7106,7 +7106,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
 5H      Pass    6H      Pass
@@ -7126,12 +7126,12 @@ Pass    Pass
 {HCP 13 10 15 2}
 {TP 14 10 15 3}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7148,12 +7148,12 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 13 9 15 6}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7170,12 +7170,12 @@ Pass    Pass
 {HCP 14 8 16 2}
 {TP 14 9 16 3}
 {Losers 6 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7192,12 +7192,12 @@ Pass    Pass
 {HCP 11 11 15 3}
 {TP 14 11 15 3}
 {Losers 5 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7217,9 +7217,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    6H      Pass
 Pass    Pass    
 
@@ -7237,12 +7237,12 @@ Pass    Pass
 {HCP 14 5 16 5}
 {TP 16 5 16 6}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7262,7 +7262,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7284,7 +7284,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7303,12 +7303,12 @@ Pass    Pass
 {HCP 12 6 16 6}
 {TP 14 7 16 6}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7325,12 +7325,12 @@ Pass    Pass
 {HCP 12 12 15 1}
 {TP 15 12 15 2}
 {Losers 6 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7347,12 +7347,12 @@ Pass    Pass
 {HCP 14 4 17 5}
 {TP 14 5 17 5}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7372,7 +7372,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7391,12 +7391,12 @@ Pass    Pass
 {HCP 13 4 17 6}
 {TP 13 5 17 7}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7416,10 +7416,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    5H      Pass
 6H      Pass    Pass    Pass
 
@@ -7441,7 +7441,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7463,7 +7463,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7485,9 +7485,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -7505,12 +7505,12 @@ Pass    Pass
 {HCP 10 7 17 6}
 {TP 13 7 17 7}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7530,7 +7530,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7549,12 +7549,12 @@ Pass    Pass
 {HCP 10 12 17 1}
 {TP 12 13 18 3}
 {Losers 7 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7574,7 +7574,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7593,12 +7593,12 @@ Pass    Pass
 {HCP 10 6 17 7}
 {TP 11 6 17 8}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7615,12 +7615,12 @@ Pass    Pass
 {HCP 13 8 16 3}
 {TP 14 8 17 4}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7637,12 +7637,12 @@ Pass    Pass
 {HCP 13 5 16 6}
 {TP 15 5 16 6}
 {Losers 7 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7659,12 +7659,12 @@ Pass    Pass
 {HCP 11 3 17 9}
 {TP 12 4 17 9}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7684,7 +7684,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7706,7 +7706,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7728,7 +7728,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7750,7 +7750,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7769,12 +7769,12 @@ Pass    Pass
 {HCP 16 5 15 4}
 {TP 16 6 16 5}
 {Losers 5 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7791,12 +7791,12 @@ Pass    Pass
 {HCP 10 7 16 7}
 {TP 12 8 17 8}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7816,7 +7816,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 XX      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -7835,12 +7835,12 @@ XX      Pass    3H      Pass
 {HCP 10 4 16 10}
 {TP 11 5 16 11}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7857,12 +7857,12 @@ XX      Pass    3H      Pass
 {HCP 10 3 17 10}
 {TP 12 4 17 10}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7882,7 +7882,7 @@ XX      Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7904,7 +7904,7 @@ XX      Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7923,12 +7923,12 @@ XX      Pass    3H      Pass
 {HCP 10 10 17 3}
 {TP 11 11 18 3}
 {Losers 7 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7945,12 +7945,12 @@ XX      Pass    3H      Pass
 {HCP 11 10 17 2}
 {TP 14 11 18 2}
 {Losers 5 7 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7970,7 +7970,7 @@ XX      Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7992,7 +7992,7 @@ XX      Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8011,12 +8011,12 @@ XX      Pass    3H      Pass
 {HCP 10 9 16 5}
 {TP 11 10 16 6}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8036,10 +8036,10 @@ Pass    Pass    3S      Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5C      Pass    5N     Pass
 6H      Pass    6S      Pass
 Pass    Pass    
 
@@ -8060,7 +8060,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8082,9 +8082,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    6H      Pass
 Pass    Pass    
 
@@ -8105,9 +8105,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5S      Pass    6H      Pass
 Pass    Pass    
 
@@ -8128,7 +8128,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8150,7 +8150,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8172,7 +8172,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -8191,12 +8191,12 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 13 7 16 7}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8216,7 +8216,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8238,7 +8238,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8260,7 +8260,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8279,12 +8279,12 @@ Pass    Pass
 {HCP 10 9 16 5}
 {TP 12 10 16 5}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8301,12 +8301,12 @@ Pass    Pass
 {HCP 11 10 15 4}
 {TP 11 11 15 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8323,12 +8323,12 @@ Pass    Pass
 {HCP 11 4 16 9}
 {TP 13 4 16 10}
 {Losers 7 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8348,7 +8348,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    6S      Pass
 Pass    Pass    
@@ -8370,7 +8370,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8392,9 +8392,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -8416,7 +8416,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8438,7 +8438,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8460,9 +8460,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -8480,12 +8480,12 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 13 8 16 5}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8505,7 +8505,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8524,12 +8524,12 @@ Pass    Pass
 {HCP 15 5 17 3}
 {TP 17 5 17 4}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8549,7 +8549,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8571,7 +8571,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8593,7 +8593,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4H      Pass
 5C      Pass    6S      Pass
@@ -8616,7 +8616,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8638,7 +8638,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8660,7 +8660,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8682,7 +8682,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8704,7 +8704,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -8723,12 +8723,12 @@ Pass    Pass
 {HCP 15 7 16 2}
 {TP 16 9 16 3}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8748,7 +8748,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8770,7 +8770,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8792,7 +8792,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8814,7 +8814,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8836,7 +8836,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3H      Pass
 4H      Pass    5C      Pass
 5D      Pass    6H      Pass
@@ -8856,12 +8856,12 @@ Pass    Pass
 {HCP 17 8 15 0}
 {TP 19 8 16 1}
 {Losers 5 9 7 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -8881,7 +8881,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8900,12 +8900,12 @@ Pass    Pass
 {HCP 10 6 16 8}
 {TP 11 7 17 8}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8922,12 +8922,12 @@ Pass    Pass
 {HCP 12 7 16 5}
 {TP 12 7 16 5}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8947,7 +8947,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8966,12 +8966,12 @@ Pass    Pass
 {HCP 10 4 16 10}
 {TP 12 5 17 11}
 {Losers 7 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8991,7 +8991,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -9013,7 +9013,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -9035,7 +9035,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 Pass    Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -9057,10 +9057,10 @@ Pass    Pass    3H      Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -9081,7 +9081,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9100,12 +9100,12 @@ Pass    Pass    3H      Pass
 {HCP 13 5 15 7}
 {TP 14 7 15 8}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9125,7 +9125,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9144,12 +9144,12 @@ Pass    Pass    3H      Pass
 {HCP 18 0 16 6}
 {TP 18 0 16 6}
 {Losers 5 12 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -9169,7 +9169,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9188,12 +9188,12 @@ Pass    Pass
 {HCP 13 4 16 7}
 {TP 14 6 16 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9210,11 +9210,11 @@ Pass    Pass
 {HCP 12 13 15 0}
 {TP 14 16 15 2}
 {Losers 6 5 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9234,7 +9234,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9256,9 +9256,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -9276,12 +9276,12 @@ Pass    Pass
 {HCP 10 7 16 7}
 {TP 12 7 16 8}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9298,12 +9298,12 @@ Pass    Pass
 {HCP 15 6 16 3}
 {TP 16 7 16 3}
 {Losers 7 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9323,7 +9323,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -9345,7 +9345,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -9367,7 +9367,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -9386,12 +9386,12 @@ Pass    Pass
 {HCP 14 9 15 2}
 {TP 14 9 15 2}
 {Losers 7 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9408,12 +9408,12 @@ Pass    Pass
 {HCP 15 8 15 2}
 {TP 16 8 15 2}
 {Losers 6 10 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9430,12 +9430,12 @@ Pass    Pass
 {HCP 10 8 17 5}
 {TP 12 9 18 6}
 {Losers 6 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9455,7 +9455,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9477,7 +9477,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -9499,7 +9499,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9518,12 +9518,12 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 12 9 15 10}
 {Losers 7 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9543,7 +9543,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9565,7 +9565,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -9587,9 +9587,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3S      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 6D      Pass    6S      Pass
 Pass    Pass    
@@ -9611,9 +9611,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -9634,7 +9634,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9656,7 +9656,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 XX      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -9675,12 +9675,12 @@ XX      Pass    3S      Pass
 {HCP 12 6 16 6}
 {TP 13 6 16 7}
 {Losers 8 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9697,12 +9697,12 @@ XX      Pass    3S      Pass
 {HCP 11 6 15 8}
 {TP 12 6 15 9}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9722,7 +9722,7 @@ XX      Pass    3S      Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    5D      Pass
 6H      Pass    Pass    Pass
@@ -9745,7 +9745,7 @@ XX      Pass    3S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9767,9 +9767,9 @@ XX      Pass    3S      Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -9787,12 +9787,12 @@ Pass    Pass
 {HCP 10 4 17 9}
 {TP 10 5 17 10}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9809,12 +9809,12 @@ Pass    Pass
 {HCP 13 5 15 7}
 {TP 15 6 16 8}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9834,7 +9834,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9856,10 +9856,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6H      Pass    Pass    Pass
 
 
@@ -9877,12 +9877,12 @@ Pass    Pass
 {HCP 12 4 15 9}
 {TP 13 5 15 9}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9902,7 +9902,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    5C      Pass
 5H      Pass    6S      Pass
@@ -9925,10 +9925,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    5H      Pass
 6H      Pass    Pass    Pass
 
@@ -9950,7 +9950,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9969,12 +9969,12 @@ Pass    Pass
 {HCP 10 8 16 6}
 {TP 11 8 16 6}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9991,12 +9991,12 @@ Pass    Pass
 {HCP 12 12 15 1}
 {TP 12 12 15 2}
 {Losers 7 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10013,12 +10013,12 @@ Pass    Pass
 {HCP 13 9 17 1}
 {TP 15 9 17 3}
 {Losers 6 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10035,12 +10035,12 @@ Pass    Pass
 {HCP 13 2 15 10}
 {TP 15 3 16 11}
 {Losers 5 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10060,7 +10060,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10082,7 +10082,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10101,12 +10101,12 @@ Pass    Pass
 {HCP 13 10 16 1}
 {TP 13 11 16 2}
 {Losers 7 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10123,12 +10123,12 @@ Pass    Pass
 {HCP 10 11 16 3}
 {TP 12 12 16 5}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10148,7 +10148,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10170,9 +10170,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    6H      Pass
 Pass    Pass    
 
@@ -10193,7 +10193,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10212,12 +10212,12 @@ Pass    Pass
 {HCP 13 7 16 4}
 {TP 15 7 16 5}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10237,7 +10237,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10259,7 +10259,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10281,10 +10281,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    6S      Pass
 Pass    Pass    
 
@@ -10305,10 +10305,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 XX      Pass    3S      Pass
-4S      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5S      Pass    5N     Pass
 6C      Pass    6S      Pass
 Pass    Pass    
 
@@ -10326,12 +10326,12 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 11 9 15 6}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10351,7 +10351,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10370,12 +10370,12 @@ Pass    Pass
 {HCP 13 8 17 2}
 {TP 14 9 17 4}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10392,12 +10392,12 @@ Pass    Pass
 {HCP 10 11 15 4}
 {TP 11 12 15 4}
 {Losers 7 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10417,7 +10417,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10439,7 +10439,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10461,7 +10461,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10483,7 +10483,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10505,7 +10505,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10527,9 +10527,9 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -10547,12 +10547,12 @@ Pass    Pass    4H      Pass
 {HCP 10 4 16 10}
 {TP 10 6 17 10}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10572,7 +10572,7 @@ Pass    Pass    4H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -10594,7 +10594,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10613,12 +10613,12 @@ Pass    Pass
 {HCP 13 8 15 4}
 {TP 15 8 15 4}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10638,7 +10638,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10660,7 +10660,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10682,7 +10682,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10704,7 +10704,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10726,7 +10726,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4H      Pass
 4S      Pass    Pass    Pass
@@ -10746,12 +10746,12 @@ Pass    Pass
 {HCP 10 11 15 4}
 {TP 11 11 15 4}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10771,9 +10771,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -10795,7 +10795,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10817,7 +10817,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10839,7 +10839,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10861,7 +10861,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4C      Pass
 4H      Pass    6S      Pass
@@ -10884,10 +10884,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4C      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -10906,12 +10906,12 @@ Pass    Pass
 {HCP 10 6 17 7}
 {TP 11 6 17 8}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10931,7 +10931,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10953,9 +10953,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -10977,7 +10977,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10999,7 +10999,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -11021,10 +11021,10 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5D      Pass    5N     Pass
 6C      Pass    7S      Pass
 Pass    Pass    
 
@@ -11042,11 +11042,11 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 10 12 15 8}
 {Losers 7 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3D
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3D
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -11066,7 +11066,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -11085,11 +11085,11 @@ Pass    Pass
 {HCP 10 4 17 9}
 {TP 12 5 17 9}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 

--- a/GIB-filtered/Opps_Preempt_4M.pbn
+++ b/GIB-filtered/Opps_Preempt_4M.pbn
@@ -941,7 +941,7 @@ Pass
 [Declarer "N"]
 [Auction "E"]
 4H      Pass    Pass    X
-Pass    4NT     Pass    5C
+Pass    4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -981,7 +981,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -1081,7 +1081,7 @@ Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -1102,7 +1102,7 @@ Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -1323,7 +1323,7 @@ Pass    Pass    Pass
 [Contract "5S"]
 [Declarer "E"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      5S      Pass
 Pass    Pass    
 
@@ -1506,7 +1506,7 @@ Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -1546,7 +1546,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -1588,7 +1588,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -2071,7 +2071,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -2273,7 +2273,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -2775,7 +2775,7 @@ Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4H      4NT     Pass    5C
+4H      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -2914,10 +2914,10 @@ Pass
 {HCP 16 7 10 7}
 {TP 18 11 13 9}
 {Losers 5 6 6 8}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "E"]
-4S      5H      Pass    6NT
+4S      5H      Pass    6N
 Pass    Pass    Pass    
 
 
@@ -2977,7 +2977,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -2998,7 +2998,7 @@ Pass
 [Contract "6D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    6D
+4S      4N     Pass    6D
 Pass    Pass    Pass    
 
 
@@ -3019,7 +3019,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "E"]
 4H      Pass    Pass    X
-Pass    4NT     Pass    5C
+Pass    4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -3039,7 +3039,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4H      X       Pass    4NT
+4H      X       Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -3382,7 +3382,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -3402,7 +3402,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -3725,7 +3725,7 @@ Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -3946,7 +3946,7 @@ Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -4046,7 +4046,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -4209,7 +4209,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -4672,7 +4672,7 @@ Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -4712,7 +4712,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -4733,7 +4733,7 @@ Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -4976,7 +4976,7 @@ Pass
 [Declarer "N"]
 [Auction "E"]
 4H      Pass    Pass    X
-Pass    4NT     Pass    5C
+Pass    4N     Pass    5C
 Pass    5D      Pass    6C
 Pass    Pass    Pass    
 
@@ -4997,7 +4997,7 @@ Pass    Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "E"]
-4H      4S      Pass    4NT
+4H      4S      Pass    4N
 Pass    5S      Pass    6S
 Pass    Pass    Pass    
 
@@ -5158,7 +5158,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4H      X       Pass    4NT
+4H      X       Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -5199,7 +5199,7 @@ Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4H      Pass    Pass    4NT
+4H      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -5382,7 +5382,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -5443,8 +5443,8 @@ Pass    Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "E"]
-4H      4S      Pass    4NT
-Pass    5NT     Pass    6S
+4H      4S      Pass    4N
+Pass    5N     Pass    6S
 Pass    Pass    Pass    
 
 
@@ -5524,7 +5524,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -5724,7 +5724,7 @@ Pass    Pass    Pass
 [Contract "6C"]
 [Declarer "N"]
 [Auction "E"]
-4H      X       Pass    4NT
+4H      X       Pass    4N
 Pass    5D      Pass    6C
 Pass    Pass    Pass    
 
@@ -5988,7 +5988,7 @@ Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4H      X       Pass    4NT
+4H      X       Pass    4N
 Pass    5C      Pass    5D
 Pass    Pass    Pass    
 
@@ -6152,7 +6152,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -6273,7 +6273,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -6313,7 +6313,7 @@ Pass    Pass    Pass
 [Contract "5S"]
 [Declarer "S"]
 [Auction "E"]
-4H      4S      Pass    4NT
+4H      4S      Pass    4N
 Pass    5S      Pass    Pass
 Pass    
 
@@ -6538,7 +6538,7 @@ Pass
 [Declarer "N"]
 [Auction "E"]
 4H      Pass    Pass    X
-Pass    4NT     Pass    5D
+Pass    4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -6902,7 +6902,7 @@ Pass    Pass    Pass
 [Contract "6S"]
 [Declarer "E"]
 [Auction "E"]
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -6943,7 +6943,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -7004,7 +7004,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4H      X       Pass    4NT
+4H      X       Pass    4N
 Pass    5C      Pass    5D
 Pass    Pass    Pass    
 
@@ -7245,7 +7245,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -7326,7 +7326,7 @@ Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4H      Pass    Pass    4NT
+4H      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -7429,7 +7429,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "E"]
 4H      Pass    Pass    4S
-Pass    4NT     Pass    5C
+Pass    4N     Pass    5C
 Pass    5D      Pass    5S
 Pass    Pass    Pass    
 
@@ -7530,7 +7530,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4H      Pass    Pass    4NT
+4H      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -8013,7 +8013,7 @@ Pass    Pass    Pass
 [Contract "5H"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5H
+4S      4N     Pass    5H
 Pass    Pass    Pass    
 
 
@@ -8295,7 +8295,7 @@ Pass
 [Declarer "S"]
 [Auction "E"]
 4H      Pass    Pass    X
-Pass    4NT     Pass    5C
+Pass    4N     Pass    5C
 Pass    5D      Pass    Pass
 Pass    
 
@@ -8316,7 +8316,7 @@ Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -8377,7 +8377,7 @@ Pass    Pass    Pass
 [Contract "5H"]
 [Declarer "E"]
 [Auction "E"]
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    5H      Pass
 Pass    Pass    
 
@@ -8498,7 +8498,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -8559,7 +8559,7 @@ Pass
 [Contract "6H"]
 [Declarer "E"]
 [Auction "E"]
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    6H      Pass
 Pass    Pass    
 

--- a/GIB-filtered/Weak_2_Bids_Leveled.pbn
+++ b/GIB-filtered/Weak_2_Bids_Leveled.pbn
@@ -14,7 +14,7 @@
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    2NT     Pass
+2H      Pass    2N     Pass
 3H      Pass    Pass    Pass
 
 [Event "autoCapture"]
@@ -33,7 +33,7 @@
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-2H      X       Pass    2NT
+2H      X       Pass    2N
 Pass    3C      Pass    3D
 Pass    Pass    Pass
 
@@ -50,11 +50,11 @@ Pass    Pass    Pass
 {HCP 18 6 9 7}
 {TP 20 8 10 10}
 {Losers 4 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 2H      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass
 
 [Event "autoCapture"]
@@ -70,10 +70,10 @@ Pass    Pass
 {HCP 6 17 7 10}
 {TP 7 17 8 12}
 {Losers 9 7 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-2H      2S      Pass    3NT
+2H      2S      Pass    3N
 Pass    Pass    Pass
 
 [Event "autoCapture"]
@@ -171,8 +171,8 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 2S      X       3S      X
-Pass    4H      Pass    4NT
-Pass    5NT     Pass    6H
+Pass    4H      Pass    4N
+Pass    5N     Pass    6H
 Pass    Pass    Pass
 
 [Event "autoCapture"]
@@ -246,10 +246,10 @@ Pass
 {HCP 3 22 6 9}
 {TP 3 22 7 10}
 {Losers 11 5 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-2S      Pass    Pass    3NT
+2S      Pass    Pass    3N
 Pass    Pass    Pass
 
 [Event "autoCapture"]
@@ -362,11 +362,11 @@ Pass    Pass
 {HCP 21 6 9 4}
 {TP 22 8 10 4}
 {Losers 4 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 2D      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass
 
 [Event "autoCapture"]
@@ -444,7 +444,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    2NT     Pass
+2S      Pass    2N     Pass
 3S      Pass    4S      Pass
 Pass    Pass
 
@@ -464,7 +464,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    2NT     Pass
+2S      Pass    2N     Pass
 3C      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -561,7 +561,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 2H      Pass    Pass    X
-Pass    2NT     Pass    3C
+Pass    2N     Pass    3C
 Pass    Pass    Pass
 
 [Event "autoCapture"]

--- a/GIB-report/Drury.md
+++ b/GIB-report/Drury.md
@@ -24,36 +24,36 @@ Match: 0/500 = 0.0%
     3  P-P-1S-P-2C-P-2D-P-3S-P-4S
     2  P-P-1H-P-2C-P-2H
     2  P-P-1H-P-3D-P-4H
-    2  P-P-1S-P-1NT-P-2H
+    2  P-P-1S-P-1N-P-2H
     2  P-P-1S-P-2C-P-3D-P-4D-P-4S
     2  P-P-1S-P-2C-P-3H-P-4S
     2  P-P-1S-P-2D-P-3H-P-4H
     2  P-P-1S-P-3D-P-4S
-    1  P-P-1C-P-1H-P-2S-P-2NT-P-3C-P-3D-P-3S-P-4NT-P-5H-P-5S
-    1  P-P-1D-P-1H-P-1S-P-1NT-P-2D-P-2S
-    1  P-P-1D-P-1NT-P-2H-P-3D-P-3NT
+    1  P-P-1C-P-1H-P-2S-P-2N-P-3C-P-3D-P-3S-P-4N-P-5H-P-5S
+    1  P-P-1D-P-1H-P-1S-P-1N-P-2D-P-2S
+    1  P-P-1D-P-1N-P-2H-P-3D-P-3N
     1  P-P-1H-P-2C-P-2D-P-2H-P-4H
     1  P-P-1H-P-2C-P-2D-P-4H
     1  P-P-1H-P-2C-P-2S-P-4H
     1  P-P-1H-P-2C-P-3H-P-4H-P-5C-P-6H
     1  P-P-1H-P-2C-P-3H-P-4H-P-6H
-    1  P-P-1H-P-2C-P-3S-P-4H-P-4NT-P-5D-P-6H
-    1  P-P-1H-P-2D-P-2S-P-2NT-P-3H-P-3NT-P-4S
-    1  P-P-1S-P-1NT-P-2H-P-2S-P-3NT
-    1  P-P-1S-P-1NT-P-2H-P-2S-P-4H
-    1  P-P-1S-P-1NT-P-2H-P-2S-P-4S
-    1  P-P-1S-P-1NT-P-3H-P-3NT-P-4H
-    1  P-P-1S-P-1NT-P-3H-P-4H
+    1  P-P-1H-P-2C-P-3S-P-4H-P-4N-P-5D-P-6H
+    1  P-P-1H-P-2D-P-2S-P-2N-P-3H-P-3N-P-4S
+    1  P-P-1S-P-1N-P-2H-P-2S-P-3N
+    1  P-P-1S-P-1N-P-2H-P-2S-P-4H
+    1  P-P-1S-P-1N-P-2H-P-2S-P-4S
+    1  P-P-1S-P-1N-P-3H-P-3N-P-4H
+    1  P-P-1S-P-1N-P-3H-P-4H
     1  P-P-1S-P-2C-P-2D-P-2H-P-2S
     1  P-P-1S-P-2C-P-2D-P-2S-P-4S
     1  P-P-1S-P-2C-P-2D-P-4S
     1  P-P-1S-P-2C-P-2S
-    1  P-P-1S-P-2C-P-3D-P-3NT-P-4S
+    1  P-P-1S-P-2C-P-3D-P-3N-P-4S
     1  P-P-1S-P-2C-P-3D-P-4D-P-6S
     1  P-P-1S-P-2C-P-3D-P-4S
-    1  P-P-1S-P-2C-P-3H-P-3NT-P-4S
-    1  P-P-1S-P-2C-P-3H-P-4H-P-4NT-P-5H-P-5NT-P-6S
-    1  P-P-1S-P-2C-P-3S-P-4C-P-4NT-P-5S-P-5NT-P-6S
+    1  P-P-1S-P-2C-P-3H-P-3N-P-4S
+    1  P-P-1S-P-2C-P-3H-P-4H-P-4N-P-5H-P-5N-P-6S
+    1  P-P-1S-P-2C-P-3S-P-4C-P-4N-P-5S-P-5N-P-6S
     1  P-P-1S-P-2C-P-3S-P-4S-P-5C-P-6S
 ```
 

--- a/GIB-report/Opps_Preempt_4M.md
+++ b/GIB-report/Opps_Preempt_4M.md
@@ -12,21 +12,21 @@ Match: 429/500 = 85.8%
 ```
     6  1S-P-2H-P-4S
     3  1H-P-2C-P-4H
-    2  1H-P-1S-P-2H-P-3C-P-3H-P-3NT-P-4H
+    2  1H-P-1S-P-2H-P-3C-P-3H-P-3N-P-4H
     2  1S-P-2C-P-4S
     2  1S-P-2S-X-4S
     1  1H-1S-P-2D
-    1  1H-1S-P-3D-P-3H-P-3NT
+    1  1H-1S-P-3D-P-3H-P-3N
     1  1H-2D-P-2H-P-3H-P-3S-P-4D-P-4S
     1  1H-2D-P-2S-P-3C-X-3D-4H-P-P-4S-P-P-5H-P-P-5S
     1  1H-2H-P-3H-P-4C-P-4S-P-5C-P-6S
-    1  1H-2NT-3C-3D-4H
-    1  1H-2NT-3D-4C-4H-P-P-5C-X
+    1  1H-2N-3C-3D-4H
+    1  1H-2N-3D-4C-4H-P-P-5C-X
     1  1H-4D-P-5D
-    1  1H-P-1NT-4S-P-P-5H
-    1  1H-P-1NT-P-2H-P-P-2S-P-3S-P-4S
-    1  1H-P-1NT-P-2H-P-P-2S-P-4S
-    1  1H-P-1NT-X-2H-3H-P-4C-P-4S
+    1  1H-P-1N-4S-P-P-5H
+    1  1H-P-1N-P-2H-P-P-2S-P-3S-P-4S
+    1  1H-P-1N-P-2H-P-P-2S-P-4S
+    1  1H-P-1N-X-2H-3H-P-4C-P-4S
     1  1H-P-1S-2C-2H-P-3H-X-4H
     1  1H-P-1S-P-2H-P-3C-P-3H-P-3S-P-4H
     1  1H-P-1S-P-2H-P-3C-P-3H-P-3S-P-4H-P-4S
@@ -34,36 +34,36 @@ Match: 429/500 = 85.8%
     1  1H-P-1S-X-2H
     1  1H-P-1S-X-3H-4D
     1  1H-P-2C-2S-3H-4S-X
-    1  1H-P-2C-2S-3H-P-3NT-P-4H
+    1  1H-P-2C-2S-3H-P-3N-P-4H
     1  1H-P-2D-P-4H
     1  1H-P-2H-X-4H-4S-P-P-5H-P-P-X
     1  1H-P-P-X-P-2S-P-4S
-    1  1H-X-2NT-P-4H
+    1  1H-X-2N-P-4H
     1  1H-X-P-2H-3H-3S-P-4S
-    1  1S-2C-2D-P-2S-3C-3NT-P-4S
-    1  1S-2C-P-P-2S-P-4NT-P-6C-P-6S
-    1  1S-2H-2S-3H-3S-4H-4S-4NT-P-6H
+    1  1S-2C-2D-P-2S-3C-3N-P-4S
+    1  1S-2C-P-P-2S-P-4N-P-6C-P-6S
+    1  1S-2H-2S-3H-3S-4H-4S-4N-P-6H
     1  1S-2H-2S-3H-3S-4H-4S-X-P-5H
     1  1S-2H-P-3D-P-3S-P-4H
     1  1S-2H-P-P-2S-3H-4S
     1  1S-2H-P-P-2S-X-P-3C
-    1  1S-2NT-P-3S-P-4NT-P-5C-P-5D
+    1  1S-2N-P-3S-P-4N-P-5C-P-5D
     1  1S-2S-3S-4C-P-5C
     1  1S-2S-3S-4H-4S
     1  1S-2S-4D-4H-4S
     1  1S-2S-P-4H
-    1  1S-2S-X-2NT-4S
+    1  1S-2S-X-2N-4S
     1  1S-3C-3S-4C-4S-P-P-5C-5S
     1  1S-3H-P-4H-4S
     1  1S-3H-X-4H-4S
-    1  1S-P-1NT-2H-2S-4H-4S
-    1  1S-P-1NT-2S-P-2NT-P-3D-P-3H
-    1  1S-P-1NT-P-2S
-    1  1S-P-1NT-P-2S-P-3S-P-4S
-    1  1S-P-1NT-X-2S-3D-4S
-    1  1S-P-2D-P-2S-P-3C-P-3S-P-3NT-P-4S
+    1  1S-P-1N-2H-2S-4H-4S
+    1  1S-P-1N-2S-P-2N-P-3D-P-3H
+    1  1S-P-1N-P-2S
+    1  1S-P-1N-P-2S-P-3S-P-4S
+    1  1S-P-1N-X-2S-3D-4S
+    1  1S-P-2D-P-2S-P-3C-P-3S-P-3N-P-4S
     1  1S-P-2D-P-4S
-    1  1S-P-2H-P-4S-P-4NT-P-5S-P-6S
+    1  1S-P-2H-P-4S-P-4N-P-5S-P-6S
     1  1S-P-3H-P-3S
     1  1S-P-3H-P-4H
     1  1S-P-P-X-P-3H-P-4H
@@ -83,61 +83,61 @@ Match: 429/500 = 85.8%
    17  4S-P-P-5H
    16  4H-P-P-4S
    13  4H-P-P-X
-   10  4S-4NT-P-5D
+   10  4S-4N-P-5D
     9  4H-4S
     8  4H-X
     7  4S-5H
-    6  4S-4NT-P-5C
-    6  4S-P-P-4NT-P-5D
+    6  4S-4N-P-5C
+    6  4S-P-P-4N-P-5D
     5  4H-X-P-5C
     5  4H-X-P-6S
     4  4H-P-P-X-P-5C
     4  4H-P-P-X-P-5D
-    4  4S-P-P-4NT-P-5C
+    4  4S-P-P-4N-P-5C
     3  4H-X-P-5D
-    2  4H-P-P-4NT-P-5C
-    2  4H-P-P-X-P-4NT-P-5C
-    2  4H-X-P-4NT-P-5C-P-5D
-    2  4H-X-P-4NT-P-5D
+    2  4H-P-P-4N-P-5C
+    2  4H-P-P-X-P-4N-P-5C
+    2  4H-X-P-4N-P-5C-P-5D
+    2  4H-X-P-4N-P-5D
     2  4H-X-P-4S-P-5D
     2  4H-X-P-4S-P-P-5H-X
     2  4S-P-P-5C-P-6C
     2  4S-P-P-5D
     2  4S-P-P-5D-P-6D
     2  4S-P-P-5H-P-6H
-    1  4H-4NT-P-5C
-    1  4H-4S-P-4NT-P-5NT-P-6S
-    1  4H-4S-P-4NT-P-5S
-    1  4H-4S-P-4NT-P-5S-P-6S
+    1  4H-4N-P-5C
+    1  4H-4S-P-4N-P-5N-P-6S
+    1  4H-4S-P-4N-P-5S
+    1  4H-4S-P-4N-P-5S-P-6S
     1  4H-4S-P-6C
     1  4H-4S-P-6S
     1  4H-4S-X
     1  4H-5H-P-5S
-    1  4H-P-4NT-P-5D-P-5H
-    1  4H-P-4NT-P-5D-P-6H
-    1  4H-P-P-4NT-P-5D
-    1  4H-P-P-4S-P-4NT-P-5C-P-5D-P-5S
+    1  4H-P-4N-P-5D-P-5H
+    1  4H-P-4N-P-5D-P-6H
+    1  4H-P-P-4N-P-5D
+    1  4H-P-P-4S-P-4N-P-5C-P-5D-P-5S
     1  4H-P-P-4S-P-5C-P-5D
     1  4H-P-P-4S-P-5D
     1  4H-P-P-4S-P-P-X
-    1  4H-P-P-X-P-4NT-P-5C-P-5D
-    1  4H-P-P-X-P-4NT-P-5C-P-5D-P-6C
-    1  4H-P-P-X-P-4NT-P-5D
-    1  4H-X-P-4NT-P-5D-P-6C
+    1  4H-P-P-X-P-4N-P-5C-P-5D
+    1  4H-P-P-X-P-4N-P-5C-P-5D-P-6C
+    1  4H-P-P-X-P-4N-P-5D
+    1  4H-X-P-4N-P-5D-P-6C
     1  4H-X-P-4S-P-5C
     1  4H-X-P-4S-P-5C-P-6C
     1  4H-X-P-5D-P-P-X
-    1  4S-4NT-P-5H
-    1  4S-4NT-P-6D
+    1  4S-4N-P-5H
+    1  4S-4N-P-6D
     1  4S-5C-P-6C
     1  4S-5D-P-6D
     1  4S-5H-P-6H
-    1  4S-5H-P-6NT
+    1  4S-5H-P-6N
     1  4S-5H-X
     1  4S-5H-X-P-P-6C-X
-    1  4S-P-4NT-P-5H-P-6S
+    1  4S-P-4N-P-5H-P-6S
     1  4S-P-5C-P-6S
-    1  4S-P-P-4NT-P-5D-5S
+    1  4S-P-P-4N-P-5D-5S
     1  4S-P-P-5H-P-6D
     1  4S-P-P-5S-P-6C
 ```
@@ -266,7 +266,7 @@ Match: 429/500 = 85.8%
 4H      Pass    Pass    Pass
 ```
 
-### 1H-P-1S-P-2H-P-3C-P-3H-P-3NT-P-4H (2)
+### 1H-P-1S-P-2H-P-3C-P-3H-P-3N-P-4H (2)
 
 ```
 [Event "autoCapture"]
@@ -287,7 +287,7 @@ Match: 429/500 = 85.8%
 [Auction "E"]
 1H      Pass    1S      Pass
 2H      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 [Event "autoCapture"]
@@ -308,7 +308,7 @@ Match: 429/500 = 85.8%
 [Auction "E"]
 1H      Pass    1S      Pass
 2H      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 ```
 
@@ -419,7 +419,7 @@ Match: 429/500 = 85.8%
 Pass    Pass    Pass
 ```
 
-### 1H-1S-P-3D-P-3H-P-3NT (1)
+### 1H-1S-P-3D-P-3H-P-3N (1)
 
 ```
 [Event "autoCapture"]
@@ -435,11 +435,11 @@ Pass    Pass    Pass
 {HCP 12 10 11 7}
 {TP 14 13 12 8}
 {Losers 5 5 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "E"]
 1H      1S      Pass    3D
-Pass    3H      Pass    3NT
+Pass    3H      Pass    3N
 Pass    Pass    Pass
 ```
 

--- a/GIB-report/Smolen.md
+++ b/GIB-report/Smolen.md
@@ -14,82 +14,82 @@ Match: 0/500 = 0.0%
 ## Not matched: 500 boards, by sequence
 
 ```
-  122  1NT-P-2C-P-2D-P-3S-P-4H
-  103  1NT-P-2C-P-2D-P-3H-P-4S
-   85  1NT-P-2C-P-2D-P-3S-P-3NT
-   71  1NT-P-2C-P-2D-P-3H-P-3NT
-   15  1NT-P-2C-P-2D-P-3H-P-3S-P-4S
-    7  1NT-P-2C-P-2D-P-3H-P-4S-P-4NT-P-5S-P-6S
-    6  1NT-P-2C-X-2D-P-3H-P-4S
-    4  1NT-P-2C-P-2D-P-3S-P-4H-P-4NT-P-5C-P-5D-P-5H-P-6H
-    4  1NT-P-2C-X-2D-P-3S-P-4H
-    3  1NT-P-2C-P-2D-P-3H-P-4S-P-4NT-P-5D-P-6S
-    3  1NT-P-2C-P-2D-P-3S-P-4H-P-4NT-P-5D-P-6H
-    3  1NT-P-2C-P-2D-P-3S-P-4H-P-4S-P-4NT-P-5C-P-5D-P-5H-P-6H
-    3  1NT-P-2C-X-2D-P-3S-P-3NT
-    2  1NT-P-2C-P-2D-P-3H-P-3S-P-4H-P-5C-P-6S
-    2  1NT-P-2C-P-2D-P-3H-P-4S-P-4NT-P-5D-P-5H-P-5S
-    2  1NT-P-2C-P-2D-P-3H-P-4S-P-4NT-P-5H-P-6S
-    2  1NT-P-2C-P-2D-P-3S-P-3NT-P-6NT
-    2  1NT-P-2C-P-2D-P-3S-P-4H-P-4NT-P-5H-P-6H
-    2  1NT-P-2C-P-2D-P-3S-P-4H-P-5C-P-5D-P-6H
-    2  1NT-P-2C-X-2D-P-3H-P-3S-P-4S
-    2  1NT-P-2C-X-P-P-3H-P-4H
-    1  1NT-P-2C-2D-P-3D-3NT
-    1  1NT-P-2C-2D-P-P-3H-P-4H
-    1  1NT-P-2C-2D-P-P-3NT
-    1  1NT-P-2C-2H-P-P-2S-P-3C-P-3NT
-    1  1NT-P-2C-2H-P-P-3S-P-4S
-    1  1NT-P-2C-2S-P-P-3NT
-    1  1NT-P-2C-2S-P-P-X
-    1  1NT-P-2C-3C-P-P-3NT
-    1  1NT-P-2C-3D-P-P-3NT
-    1  1NT-P-2C-3D-P-P-4H
-    1  1NT-P-2C-3D-P-P-4H-P-4NT-P-5D-P-5H
-    1  1NT-P-2C-3D-P-P-4S-P-4NT-P-6D-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-3NT-P-6NT
-    1  1NT-P-2C-P-2D-P-3H-P-3S-P-4C-P-4D-P-4H-P-4S-P-5C-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-3S-P-4C-P-4D-P-4NT-P-5C-P-5D-P-5S-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-3S-P-4C-P-4H-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-3S-P-4D-P-4S
-    1  1NT-P-2C-P-2D-P-3H-P-3S-P-4D-P-5C-P-5H-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-3S-P-4H-P-4S
-    1  1NT-P-2C-P-2D-P-3H-P-3S-P-4H-P-4S-P-4NT-P-5D-P-5H-P-6C-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-4S-P-4NT-P-5C-P-5D-P-5S-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-4S-P-4NT-P-5C-P-5NT-P-6H-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-4S-P-4NT-P-5D-P-5NT-P-6C-P-7S
-    1  1NT-P-2C-P-2D-P-3H-P-4S-P-4NT-P-5H-P-5NT-P-6C-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-4S-P-4NT-P-5H-P-5NT-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-4S-P-5C-P-5D-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-4S-P-5C-P-5H-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-4S-P-5H-P-5S-P-6S
-    1  1NT-P-2C-P-2D-P-3H-P-4S-P-6S
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-4NT-P-5C-P-5NT-P-6C-P-6H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-4NT-P-5C-P-6H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-4NT-P-5H-P-5NT-P-6C-P-6H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-4NT-P-5S-P-6H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-4S-P-4NT-P-5H-P-6H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-4S-P-4NT-P-5S-P-6H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-4S-P-4NT-P-6C-P-6H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-4S-P-5C-P-5H-P-6H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-4S-P-5C-P-6H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-4S-P-5H-P-6H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-5C-P-5D-P-5S-P-6H-P-7H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-5C-P-6H
-    1  1NT-P-2C-P-2D-P-3S-P-4H-P-5D-P-6H
-    1  1NT-P-2C-X-2D-P-3H-P-4S-P-4NT-P-5D-P-6S
-    1  1NT-P-2C-X-2D-P-3H-P-4S-P-4NT-P-5S-P-5NT-P-6H-P-6S
-    1  1NT-P-2C-X-P-P-3H-P-4H-P-4NT-P-5D-P-5H
-    1  1NT-P-2C-X-P-P-3H-P-4H-P-5C-P-5D-P-6H
-    1  1NT-P-2C-X-P-P-3S-P-3NT
-    1  1NT-P-2C-X-P-P-3S-P-3NT-P-4NT
-    1  1NT-P-2C-X-P-P-3S-P-4S-P-4NT-P-5C-P-5D-P-6D-P-6S
-    1  1NT-P-2C-X-P-P-3S-X-3NT
-    1  1NT-P-2C-X-XX-P-3H-P-4H
-    1  1NT-P-2C-X-XX-P-3H-P-4H-P-6H
-    1  1NT-P-2C-X-XX-P-3S-P-4S
-    1  1NT-P-2C-X-XX-P-3S-P-4S-P-4NT-P-5S-P-5NT-P-6C-P-6S
-    1  1NT-P-2C-X-XX-P-3S-P-4S-P-5D-P-5H-P-5S-P-6C-P-6S
+  122  1N-P-2C-P-2D-P-3S-P-4H
+  103  1N-P-2C-P-2D-P-3H-P-4S
+   85  1N-P-2C-P-2D-P-3S-P-3N
+   71  1N-P-2C-P-2D-P-3H-P-3N
+   15  1N-P-2C-P-2D-P-3H-P-3S-P-4S
+    7  1N-P-2C-P-2D-P-3H-P-4S-P-4N-P-5S-P-6S
+    6  1N-P-2C-X-2D-P-3H-P-4S
+    4  1N-P-2C-P-2D-P-3S-P-4H-P-4N-P-5C-P-5D-P-5H-P-6H
+    4  1N-P-2C-X-2D-P-3S-P-4H
+    3  1N-P-2C-P-2D-P-3H-P-4S-P-4N-P-5D-P-6S
+    3  1N-P-2C-P-2D-P-3S-P-4H-P-4N-P-5D-P-6H
+    3  1N-P-2C-P-2D-P-3S-P-4H-P-4S-P-4N-P-5C-P-5D-P-5H-P-6H
+    3  1N-P-2C-X-2D-P-3S-P-3N
+    2  1N-P-2C-P-2D-P-3H-P-3S-P-4H-P-5C-P-6S
+    2  1N-P-2C-P-2D-P-3H-P-4S-P-4N-P-5D-P-5H-P-5S
+    2  1N-P-2C-P-2D-P-3H-P-4S-P-4N-P-5H-P-6S
+    2  1N-P-2C-P-2D-P-3S-P-3N-P-6N
+    2  1N-P-2C-P-2D-P-3S-P-4H-P-4N-P-5H-P-6H
+    2  1N-P-2C-P-2D-P-3S-P-4H-P-5C-P-5D-P-6H
+    2  1N-P-2C-X-2D-P-3H-P-3S-P-4S
+    2  1N-P-2C-X-P-P-3H-P-4H
+    1  1N-P-2C-2D-P-3D-3N
+    1  1N-P-2C-2D-P-P-3H-P-4H
+    1  1N-P-2C-2D-P-P-3N
+    1  1N-P-2C-2H-P-P-2S-P-3C-P-3N
+    1  1N-P-2C-2H-P-P-3S-P-4S
+    1  1N-P-2C-2S-P-P-3N
+    1  1N-P-2C-2S-P-P-X
+    1  1N-P-2C-3C-P-P-3N
+    1  1N-P-2C-3D-P-P-3N
+    1  1N-P-2C-3D-P-P-4H
+    1  1N-P-2C-3D-P-P-4H-P-4N-P-5D-P-5H
+    1  1N-P-2C-3D-P-P-4S-P-4N-P-6D-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-3N-P-6N
+    1  1N-P-2C-P-2D-P-3H-P-3S-P-4C-P-4D-P-4H-P-4S-P-5C-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-3S-P-4C-P-4D-P-4N-P-5C-P-5D-P-5S-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-3S-P-4C-P-4H-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-3S-P-4D-P-4S
+    1  1N-P-2C-P-2D-P-3H-P-3S-P-4D-P-5C-P-5H-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-3S-P-4H-P-4S
+    1  1N-P-2C-P-2D-P-3H-P-3S-P-4H-P-4S-P-4N-P-5D-P-5H-P-6C-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-4S-P-4N-P-5C-P-5D-P-5S-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-4S-P-4N-P-5C-P-5N-P-6H-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-4S-P-4N-P-5D-P-5N-P-6C-P-7S
+    1  1N-P-2C-P-2D-P-3H-P-4S-P-4N-P-5H-P-5N-P-6C-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-4S-P-4N-P-5H-P-5N-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-4S-P-5C-P-5D-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-4S-P-5C-P-5H-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-4S-P-5H-P-5S-P-6S
+    1  1N-P-2C-P-2D-P-3H-P-4S-P-6S
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-4N-P-5C-P-5N-P-6C-P-6H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-4N-P-5C-P-6H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-4N-P-5H-P-5N-P-6C-P-6H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-4N-P-5S-P-6H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-4S-P-4N-P-5H-P-6H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-4S-P-4N-P-5S-P-6H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-4S-P-4N-P-6C-P-6H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-4S-P-5C-P-5H-P-6H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-4S-P-5C-P-6H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-4S-P-5H-P-6H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-5C-P-5D-P-5S-P-6H-P-7H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-5C-P-6H
+    1  1N-P-2C-P-2D-P-3S-P-4H-P-5D-P-6H
+    1  1N-P-2C-X-2D-P-3H-P-4S-P-4N-P-5D-P-6S
+    1  1N-P-2C-X-2D-P-3H-P-4S-P-4N-P-5S-P-5N-P-6H-P-6S
+    1  1N-P-2C-X-P-P-3H-P-4H-P-4N-P-5D-P-5H
+    1  1N-P-2C-X-P-P-3H-P-4H-P-5C-P-5D-P-6H
+    1  1N-P-2C-X-P-P-3S-P-3N
+    1  1N-P-2C-X-P-P-3S-P-3N-P-4N
+    1  1N-P-2C-X-P-P-3S-P-4S-P-4N-P-5C-P-5D-P-6D-P-6S
+    1  1N-P-2C-X-P-P-3S-X-3N
+    1  1N-P-2C-X-XX-P-3H-P-4H
+    1  1N-P-2C-X-XX-P-3H-P-4H-P-6H
+    1  1N-P-2C-X-XX-P-3S-P-4S
+    1  1N-P-2C-X-XX-P-3S-P-4S-P-4N-P-5S-P-5N-P-6C-P-6S
+    1  1N-P-2C-X-XX-P-3S-P-4S-P-5D-P-5H-P-5S-P-6C-P-6S
 ```
 
 ## Matched: 0 boards, by sequence
@@ -99,7 +99,7 @@ Match: 0/500 = 0.0%
 
 ## Not matched: example deals
 
-### 1NT-P-2C-P-2D-P-3S-P-4H (122)
+### 1N-P-2C-P-2D-P-3S-P-4H (122)
 
 ```
 [Event "autoCapture"]
@@ -118,7 +118,7 @@ Match: 0/500 = 0.0%
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -138,7 +138,7 @@ Match: 0/500 = 0.0%
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -158,12 +158,12 @@ Match: 0/500 = 0.0%
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 ```
 
-### 1NT-P-2C-P-2D-P-3H-P-4S (103)
+### 1N-P-2C-P-2D-P-3H-P-4S (103)
 
 ```
 [Event "autoCapture"]
@@ -182,7 +182,7 @@ Match: 0/500 = 0.0%
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -202,7 +202,7 @@ Match: 0/500 = 0.0%
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -222,12 +222,12 @@ Match: 0/500 = 0.0%
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 ```
 
-### 1NT-P-2C-P-2D-P-3S-P-3NT (85)
+### 1N-P-2C-P-2D-P-3S-P-3N (85)
 
 ```
 [Event "autoCapture"]
@@ -243,12 +243,12 @@ Match: 0/500 = 0.0%
 {HCP 11 5 16 8}
 {TP 12 5 16 9}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 [Event "autoCapture"]
 [Board "5"]
@@ -263,12 +263,12 @@ Match: 0/500 = 0.0%
 {HCP 14 7 16 3}
 {TP 16 7 16 4}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 [Event "autoCapture"]
 [Board "6"]
@@ -283,15 +283,15 @@ Match: 0/500 = 0.0%
 {HCP 10 8 15 7}
 {TP 12 9 16 7}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 ```
 
-### 1NT-P-2C-P-2D-P-3H-P-3NT (71)
+### 1N-P-2C-P-2D-P-3H-P-3N (71)
 
 ```
 [Event "autoCapture"]
@@ -307,12 +307,12 @@ Match: 0/500 = 0.0%
 {HCP 11 11 15 3}
 {TP 13 12 15 4}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 [Event "autoCapture"]
 [Board "26"]
@@ -327,12 +327,12 @@ Match: 0/500 = 0.0%
 {HCP 11 7 15 7}
 {TP 13 9 15 7}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 [Event "autoCapture"]
 [Board "52"]
@@ -347,15 +347,15 @@ Match: 0/500 = 0.0%
 {HCP 14 10 15 1}
 {TP 15 10 16 2}
 {Losers 6 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 ```
 
-### 1NT-P-2C-P-2D-P-3H-P-3S-P-4S (15)
+### 1N-P-2C-P-2D-P-3H-P-3S-P-4S (15)
 
 ```
 [Event "autoCapture"]
@@ -374,7 +374,7 @@ Match: 0/500 = 0.0%
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass
@@ -395,7 +395,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass
@@ -416,13 +416,13 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass
 ```
 
-### 1NT-P-2C-P-2D-P-3H-P-4S-P-4NT-P-5S-P-6S (7)
+### 1N-P-2C-P-2D-P-3H-P-4S-P-4N-P-5S-P-6S (7)
 
 ```
 [Event "autoCapture"]
@@ -441,9 +441,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass
 
@@ -463,9 +463,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass
 
@@ -485,14 +485,14 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass
 ```
 
-### 1NT-P-2C-X-2D-P-3H-P-4S (6)
+### 1N-P-2C-X-2D-P-3H-P-4S (6)
 
 ```
 [Event "autoCapture"]
@@ -511,7 +511,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -531,7 +531,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -551,12 +551,12 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 ```
 
-### 1NT-P-2C-P-2D-P-3S-P-4H-P-4NT-P-5C-P-5D-P-5H-P-6H (4)
+### 1N-P-2C-P-2D-P-3S-P-4H-P-4N-P-5C-P-5D-P-5H-P-6H (4)
 
 ```
 [Event "autoCapture"]
@@ -575,9 +575,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass
@@ -598,9 +598,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass
@@ -621,15 +621,15 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass
 ```
 
-### 1NT-P-2C-X-2D-P-3S-P-4H (4)
+### 1N-P-2C-X-2D-P-3S-P-4H (4)
 
 ```
 [Event "autoCapture"]
@@ -648,7 +648,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -668,7 +668,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -688,12 +688,12 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 ```
 
-### 1NT-P-2C-P-2D-P-3H-P-4S-P-4NT-P-5D-P-6S (3)
+### 1N-P-2C-P-2D-P-3H-P-4S-P-4N-P-5D-P-6S (3)
 
 ```
 [Event "autoCapture"]
@@ -712,9 +712,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass
 
@@ -734,9 +734,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass
 
@@ -756,9 +756,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass
 ```

--- a/GIB-report/Weak_2_Bids_Leveled.md
+++ b/GIB-report/Weak_2_Bids_Leveled.md
@@ -18,27 +18,27 @@ Match: 30/30 = 100.0%
     3  2H-P-4H
     3  2S-P-4S
     1  2D-P-2S-P-3S-P-4S
-    1  2D-P-3C-P-3D-P-3NT
+    1  2D-P-3C-P-3D-P-3N
     1  2D-P-3C-P-5C-P-5H-P-6C
     1  2D-P-4H
     1  2H
-    1  2H-2S-P-3NT
-    1  2H-P-2NT-P-3H
-    1  2H-P-3C-P-3D-P-3NT
+    1  2H-2S-P-3N
+    1  2H-P-2N-P-3H
+    1  2H-P-3C-P-3D-P-3N
     1  2H-P-3C-P-5C
     1  2H-P-3D-P-4C-P-5C
     1  2H-P-P-3D-P-3S-P-4S
-    1  2H-P-P-X-P-2NT-P-3C
+    1  2H-P-P-X-P-2N-P-3C
     1  2H-P-P-X-P-2S-3H-P-P-3S
     1  2H-X-3H-X-P-4S
-    1  2H-X-P-2NT-P-3C-P-3D
+    1  2H-X-P-2N-P-3C-P-3D
     1  2S
     1  2S-3C-3S-5C-P-6C
-    1  2S-P-2NT-P-3C-P-3S-P-4S
-    1  2S-P-2NT-P-3S-P-4S
+    1  2S-P-2N-P-3C-P-3S-P-4S
+    1  2S-P-2N-P-3S-P-4S
     1  2S-P-3D-P-4C
     1  2S-P-3S-X-P-4H
     1  2S-P-P-3D
-    1  2S-P-P-3NT
-    1  2S-X-3S-X-P-4H-P-4NT-P-5NT-P-6H
+    1  2S-P-P-3N
+    1  2S-X-3S-X-P-4H-P-4N-P-5N-P-6H
 ```

--- a/GIB/1-Spade
+++ b/GIB/1-Spade
@@ -54,11 +54,11 @@ Pass    Pass    Pass
 {HCP 13 7 13 7}
 {TP 13 7 13 7}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -79,7 +79,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -246,14 +246,14 @@ Pass    Pass    Pass
 {HCP 11 8 13 8}
 {TP 13 9 15 8}
 {Losers 7 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 3C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -315,7 +315,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1C      1D      1S      Pass
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -380,7 +380,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    3C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5S      Pass    6C      Pass
 Pass    Pass    
 
@@ -402,8 +402,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2S      Pass
-3C      Pass    3NT     Pass
+1N     Pass    2S      Pass
+3C      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -421,11 +421,11 @@ Pass    Pass
 {HCP 9 7 16 8}
 {TP 9 7 17 9}
 {Losers 9 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -442,11 +442,11 @@ Pass    Pass
 {HCP 4 10 14 12}
 {TP 6 11 15 12}
 {Losers 9 9 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -463,11 +463,11 @@ Pass    Pass
 {HCP 5 2 13 20}
 {TP 7 2 14 20}
 {Losers 8 11 8 5}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      X       1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -484,12 +484,12 @@ Pass    Pass
 {HCP 5 10 12 13}
 {TP 7 11 13 14}
 {Losers 8 7 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 1C      1D      1S      2C
-Pass    2NT     Pass    3C
-Pass    3NT     Pass    Pass
+Pass    2N     Pass    3C
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -506,12 +506,12 @@ Pass
 {HCP 14 3 12 11}
 {TP 14 4 14 13}
 {Losers 7 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      2D      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -555,7 +555,7 @@ Pass    Pass
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
 3C      Pass    3D      Pass
-3NT     Pass    6C      Pass
+3N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -640,7 +640,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -658,10 +658,10 @@ Pass
 {HCP 7 17 13 3}
 {TP 10 18 13 3}
 {Losers 7 6 7 11}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1H      1NT
+1C      Pass    1H      1N
 Pass    Pass    Pass    
 
 
@@ -682,7 +682,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2C      Pass    Pass    X
 Pass    2D      Pass    Pass
 Pass    
@@ -788,7 +788,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      1H
-Pass    1NT     2D      Pass
+Pass    1N     2D      Pass
 2S      Pass    Pass    Pass
 
 
@@ -810,7 +810,7 @@ Pass    1NT     2D      Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -828,12 +828,12 @@ Pass    1NT     2D      Pass
 {HCP 11 7 15 7}
 {TP 12 7 16 8}
 {Losers 7 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -850,12 +850,12 @@ Pass    1NT     2D      Pass
 {HCP 14 5 12 9}
 {TP 14 8 14 9}
 {Losers 8 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1017,12 +1017,12 @@ Pass    Pass
 {HCP 6 9 18 7}
 {TP 8 10 18 9}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      1S
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1039,11 +1039,11 @@ Pass    Pass
 {HCP 10 10 12 8}
 {TP 10 11 13 8}
 {Losers 8 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1144,12 +1144,12 @@ Pass    Pass
 {HCP 8 8 15 9}
 {TP 10 8 16 9}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1166,11 +1166,11 @@ Pass    Pass
 {HCP 11 4 13 12}
 {TP 11 5 14 13}
 {Losers 9 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      1S      2NT     Pass
-3NT     Pass    Pass    Pass
+1C      1S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1250,11 +1250,11 @@ Pass    Pass    Pass
 {HCP 3 12 12 13}
 {TP 4 12 12 13}
 {Losers 10 6 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-1C      X       Pass    2NT
-Pass    3NT     Pass    Pass
+1C      X       Pass    2N
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1297,7 +1297,7 @@ Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    3S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -1318,7 +1318,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      1S      1NT     2H
+1C      1S      1N     2H
 Pass    Pass    Pass    
 
 
@@ -1379,12 +1379,12 @@ Pass    Pass
 {HCP 11 8 13 8}
 {TP 12 8 14 9}
 {Losers 7 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1489,12 +1489,12 @@ Pass
 {HCP 9 4 16 11}
 {TP 10 5 17 12}
 {Losers 9 9 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      X       1H      Pass
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1514,7 +1514,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1C      1NT     Pass    2D
+1C      1N     Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -1557,7 +1557,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -1574,12 +1574,12 @@ Pass    Pass
 {HCP 4 16 12 8}
 {TP 4 17 12 9}
 {Losers 11 6 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 1C      Pass    Pass    X
-Pass    1NT     Pass    2NT
-Pass    3NT     Pass    Pass
+Pass    1N     Pass    2N
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1680,12 +1680,12 @@ Pass
 {HCP 7 9 17 7}
 {TP 8 10 18 9}
 {Losers 9 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2H      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1727,7 +1727,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1C      1D      X       1NT
+1C      1D      X       1N
 2S      Pass    Pass    Pass
 
 
@@ -1766,13 +1766,13 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 13 7 13 11}
 {Losers 7 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1789,12 +1789,12 @@ Pass    Pass
 {HCP 6 9 18 7}
 {TP 9 10 18 9}
 {Losers 7 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      1H
-2NT     Pass    3C      Pass
-3H      Pass    3NT     Pass
+2N     Pass    3C      Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1877,12 +1877,12 @@ Pass    Pass
 {HCP 13 5 16 6}
 {TP 15 5 18 8}
 {Losers 5 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1899,12 +1899,12 @@ Pass    Pass
 {HCP 13 9 12 6}
 {TP 14 10 14 7}
 {Losers 6 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1964,11 +1964,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 8 14 6}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2009,7 +2009,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1C      1NT     Pass    2D
+1C      1N     Pass    2D
 Pass    2H      Pass    Pass
 2S      Pass    Pass    Pass
 
@@ -2028,11 +2028,11 @@ Pass    2H      Pass    Pass
 {HCP 16 9 10 5}
 {TP 16 9 13 8}
 {Losers 6 8 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2H      2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2071,12 +2071,12 @@ Pass
 {HCP 9 3 17 11}
 {TP 12 4 19 11}
 {Losers 7 10 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 3C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2117,7 +2117,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1C      1NT     2H      2S
+1C      1N     2H      2S
 Pass    Pass    Pass    
 
 
@@ -2156,10 +2156,10 @@ Pass    3D      Pass    Pass
 {HCP 6 10 12 12}
 {TP 6 10 14 12}
 {Losers 10 8 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1S      X       1NT
+1D      1S      X       1N
 Pass    Pass    Pass    
 
 
@@ -2202,7 +2202,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    Pass    X
-Pass    1H      1S      1NT
+Pass    1H      1S      1N
 2C      Pass    Pass    Pass
 
 
@@ -2241,12 +2241,12 @@ Pass    Pass
 {HCP 12 11 13 4}
 {TP 12 11 14 5}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2284,10 +2284,10 @@ Pass    Pass    Pass
 {HCP 16 3 13 8}
 {TP 16 5 13 10}
 {Losers 8 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1S      3NT     Pass
+1D      1S      3N     Pass
 Pass    Pass    
 
 
@@ -2328,8 +2328,8 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      1H      1S      3D
-3S      4H      4NT     Pass
-5D      Pass    5NT     Pass
+3S      4H      4N     Pass
+5D      Pass    5N     Pass
 6C      Pass    6S      Pass
 Pass    Pass    
 
@@ -2351,7 +2351,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2H      X
+1N     Pass    2H      X
 Pass    Pass    Pass    
 
 
@@ -2372,7 +2372,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2394,8 +2394,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    3S      Pass
-4S      Pass    4NT     Pass
+2N     Pass    3S      Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -2413,11 +2413,11 @@ Pass    Pass
 {HCP 12 10 12 6}
 {TP 13 11 12 7}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2434,10 +2434,10 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 12 7 12 9}
 {Losers 9 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1H      2NT     Pass
+1D      1H      2N     Pass
 Pass    Pass    
 
 
@@ -2500,8 +2500,8 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-2S      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+2S      Pass    4N     Pass
+5H      Pass    5N     Pass
 6D      Pass    6S      Pass
 Pass    Pass    
 
@@ -2644,12 +2644,12 @@ Pass    Pass    Pass
 {HCP 4 11 13 12}
 {TP 5 12 15 12}
 {Losers 9 7 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 1D      Pass    Pass    X
 1H      2D      Pass    2H
-2S      3NT     Pass    Pass
+2S      3N     Pass    Pass
 Pass    
 
 
@@ -2708,12 +2708,12 @@ Pass    Pass
 {HCP 5 15 15 5}
 {TP 8 15 17 7}
 {Losers 7 7 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
 3D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2730,13 +2730,13 @@ Pass    Pass
 {HCP 14 3 12 11}
 {TP 14 4 12 11}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    3C      Pass
 3D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2753,11 +2753,11 @@ Pass    Pass
 {HCP 7 14 12 7}
 {TP 7 14 14 7}
 {Losers 9 7 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2774,12 +2774,12 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 10 8 16 10}
 {Losers 8 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2817,10 +2817,10 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 7 13 9}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2837,11 +2837,11 @@ Pass    Pass
 {HCP 2 10 13 15}
 {TP 2 11 13 15}
 {Losers 11 8 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
-1D      1NT     Pass    2C
-Pass    2D      Pass    3NT
+1D      1N     Pass    2C
+Pass    2D      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -2861,7 +2861,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1D      X       1NT     2S
+1D      X       1N     2S
 Pass    Pass    X       Pass
 3D      Pass    Pass    3S
 Pass    Pass    Pass    
@@ -2884,7 +2884,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -2902,11 +2902,11 @@ Pass    Pass
 {HCP 18 5 12 5}
 {TP 19 6 12 6}
 {Losers 5 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2945,11 +2945,11 @@ Pass
 {HCP 7 10 15 8}
 {TP 10 10 16 8}
 {Losers 7 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2986,11 +2986,11 @@ Pass    Pass    Pass
 {HCP 9 14 12 5}
 {TP 10 15 12 6}
 {Losers 8 7 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3011,7 +3011,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1D      Pass    1H      2S
-Pass    2NT     Pass    3S
+Pass    2N     Pass    3S
 Pass    Pass    Pass    
 
 
@@ -3028,11 +3028,11 @@ Pass    Pass    Pass
 {HCP 7 13 12 8}
 {TP 7 13 12 8}
 {Losers 10 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3070,11 +3070,11 @@ Pass    Pass
 {HCP 5 12 12 11}
 {TP 8 13 12 11}
 {Losers 7 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3117,7 +3117,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      3H      Pass
 4D      Pass    Pass    Pass
 
@@ -3140,7 +3140,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1D      1S      2S      Pass
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 3D      Pass    Pass    3S
 X       Pass    Pass    Pass
 
@@ -3159,12 +3159,12 @@ X       Pass    Pass    Pass
 {HCP 9 7 13 11}
 {TP 10 7 15 13}
 {Losers 9 9 5 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1S      1NT     Pass
+1D      1S      1N     Pass
 2D      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3185,7 +3185,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2NT     Pass    3D      Pass
+2N     Pass    3D      Pass
 Pass    Pass    
 
 
@@ -3205,7 +3205,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    3D      Pass
 Pass    Pass    
 
@@ -3227,7 +3227,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4H      Pass
 4S      Pass    Pass    Pass
 
@@ -3246,11 +3246,11 @@ Pass    Pass
 {HCP 10 8 12 10}
 {TP 12 9 12 10}
 {Losers 7 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3267,11 +3267,11 @@ Pass    Pass
 {HCP 7 9 13 11}
 {TP 8 9 14 11}
 {Losers 8 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3288,12 +3288,12 @@ Pass    Pass
 {HCP 10 7 18 5}
 {TP 11 8 18 8}
 {Losers 8 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3314,7 +3314,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1D      1S      3D      3S
-Pass    4NT     Pass    5D
+Pass    4N     Pass    5D
 Pass    5H      Pass    5S
 Pass    6S      Pass    Pass
 Pass    
@@ -3333,11 +3333,11 @@ Pass
 {HCP 9 12 13 6}
 {TP 9 13 13 8}
 {Losers 9 7 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3358,7 +3358,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     X       2H      3C
+1N     X       2H      3C
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -3376,11 +3376,11 @@ Pass    Pass
 {HCP 6 10 18 6}
 {TP 6 10 18 7}
 {Losers 9 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3446,7 +3446,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2S      Pass    3S      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -3463,11 +3463,11 @@ Pass    Pass
 {HCP 7 16 12 5}
 {TP 8 16 13 7}
 {Losers 9 7 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3505,11 +3505,11 @@ Pass    Pass    Pass
 {HCP 14 6 12 8}
 {TP 14 7 12 9}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3568,12 +3568,12 @@ Pass    Pass    Pass
 {HCP 10 7 13 10}
 {TP 10 9 13 10}
 {Losers 9 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3612,11 +3612,11 @@ Pass    Pass
 {HCP 9 4 14 13}
 {TP 13 6 14 13}
 {Losers 5 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3633,12 +3633,12 @@ Pass    Pass
 {HCP 10 6 16 8}
 {TP 11 6 18 8}
 {Losers 8 10 4 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3658,7 +3658,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      1H      1NT     2H
+1D      1H      1N     2H
 Pass    Pass    Pass    
 
 
@@ -3680,7 +3680,7 @@ Pass    Pass    Pass
 [Auction "S"]
 1D      Pass    2H      Pass
 3C      Pass    3H      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5H      Pass    6H      Pass
 Pass    Pass    
 
@@ -3746,7 +3746,7 @@ Pass
 [Auction "S"]
 1D      Pass    1S      2H
 X       Pass    2S      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -3790,7 +3790,7 @@ Pass    Pass
 1D      Pass    1S      Pass
 2D      Pass    3C      Pass
 3H      Pass    3S      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -3869,11 +3869,11 @@ Pass
 {HCP 15 10 12 3}
 {TP 15 10 13 4}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3953,10 +3953,10 @@ Pass    Pass
 {HCP 10 11 12 7}
 {TP 10 13 13 9}
 {Losers 8 6 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3999,7 +3999,7 @@ Pass    Pass
 [Auction "S"]
 1D      1H      1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3D      Pass
+2N     Pass    3D      Pass
 Pass    Pass    
 
 
@@ -4037,12 +4037,12 @@ Pass
 {HCP 3 10 13 14}
 {TP 4 11 15 15}
 {Losers 10 7 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 1D      2C      Pass    2D
-X       2NT     Pass    3C
-Pass    3NT     Pass    Pass
+X       2N     Pass    3C
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -4059,11 +4059,11 @@ Pass
 {HCP 12 7 13 8}
 {TP 12 7 14 8}
 {Losers 9 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4085,7 +4085,7 @@ Pass
 [Auction "S"]
 1D      Pass    1S      2C
 X       Pass    4S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 6S      Pass    Pass    Pass
 
 
@@ -4123,13 +4123,13 @@ Pass
 {HCP 16 3 18 3}
 {TP 18 5 18 3}
 {Losers 5 9 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2NT     Pass    4C      Pass
+2N     Pass    4C      Pass
 4S      Pass    5C      Pass
-5S      Pass    6NT     Pass
+5S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -4167,11 +4167,11 @@ Pass    Pass
 {HCP 4 7 11 18}
 {TP 6 7 13 18}
 {Losers 9 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
 1D      X       Pass    1S
-Pass    2C      Pass    3NT
+Pass    2C      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -4210,12 +4210,12 @@ Pass
 {HCP 18 8 13 1}
 {TP 19 8 15 2}
 {Losers 5 10 6 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2H      Pass
-3D      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+3D      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -4301,7 +4301,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4407,7 +4407,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2C      Pass    3D      Pass
 Pass    Pass    
 
@@ -4425,12 +4425,12 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 8 13 8}
 {Losers 7 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1H      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4447,11 +4447,11 @@ Pass    Pass
 {HCP 7 12 19 2}
 {TP 9 12 19 3}
 {Losers 7 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1H      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1H      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4471,8 +4471,8 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1H      Pass    Pass    1NT
-Pass    2NT     Pass    3C
+1H      Pass    Pass    1N
+Pass    2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -4621,7 +4621,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "E"]
 [Auction "S"]
-1H      X       Pass    1NT
+1H      X       Pass    1N
 2D      Pass    2H      3C
 X       4C      Pass    Pass
 Pass    
@@ -4643,7 +4643,7 @@ Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1H      Pass    1NT     3S
+1H      Pass    1N     3S
 Pass    Pass    Pass    
 
 
@@ -4704,7 +4704,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1H      Pass    1NT     2H
+1H      Pass    1N     2H
 Pass    4S      Pass    Pass
 Pass    
 
@@ -4722,12 +4722,12 @@ Pass
 {HCP 16 3 11 10}
 {TP 18 4 14 12}
 {Losers 5 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1H      Pass    2C      Pass
 2D      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4744,12 +4744,12 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 14 11 14 6}
 {Losers 6 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2H      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4769,7 +4769,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -4832,7 +4832,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -4854,7 +4854,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    3NT     Pass
+1H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -5022,7 +5022,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2C      Pass    2H      Pass
 Pass    Pass    
 
@@ -5067,7 +5067,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 1H      Pass    Pass    X
-2C      2H      Pass    2NT
+2C      2H      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -5168,13 +5168,13 @@ Pass    Pass
 {HCP 12 5 15 8}
 {TP 12 7 15 8}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2D      Pass    2S      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5216,7 +5216,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1H      Pass    1NT     2S
+1H      Pass    1N     2S
 Pass    Pass    Pass    
 
 
@@ -5278,7 +5278,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 3S      Pass    4H      Pass
 Pass    Pass    
 
@@ -5299,7 +5299,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -5362,7 +5362,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2C      Pass    2H      Pass
 Pass    Pass    
 
@@ -5383,10 +5383,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+1H      Pass    2N     Pass
+3C      Pass    3N     Pass
 4D      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -5408,7 +5408,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1H      X       2NT     Pass
+1H      X       2N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -5452,7 +5452,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    2C      Pass
-2H      Pass    2NT     Pass
+2H      Pass    2N     Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5512,11 +5512,11 @@ Pass    Pass
 {HCP 11 5 20 4}
 {TP 13 7 21 5}
 {Losers 7 9 4 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    2C      Pass
-6NT     Pass    Pass    Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -5602,7 +5602,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    6S      Pass
+3N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -5622,7 +5622,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2C      Pass    3C      Pass
 Pass    Pass    
 
@@ -5685,7 +5685,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2H      Pass    Pass    Pass
 
 
@@ -5770,8 +5770,8 @@ Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1H      Pass    1NT     2H
-Pass    2NT     3D      Pass
+1H      Pass    1N     2H
+Pass    2N     3D      Pass
 Pass    Pass    
 
 
@@ -5940,7 +5940,7 @@ Pass
 [Contract "3C"]
 [Declarer "W"]
 [Auction "S"]
-1H      Pass    1S      2NT
+1H      Pass    1S      2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -5962,7 +5962,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6H      Pass
 Pass    Pass    
 
@@ -5983,7 +5983,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1H      Pass    1NT     X
+1H      Pass    1N     X
 2H      2S      3H      3S
 4H      Pass    Pass    4S
 X       Pass    Pass    Pass
@@ -6047,7 +6047,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "W"]
 [Auction "S"]
-1H      1S      Pass    1NT
+1H      1S      Pass    1N
 2C      2S      3H      3S
 Pass    Pass    Pass    
 
@@ -6089,7 +6089,7 @@ Pass    Pass    Pass
 [Contract "4C"]
 [Declarer "E"]
 [Auction "S"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2H      X       3H      4C
 Pass    Pass    Pass    
 
@@ -6110,7 +6110,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1H      Pass    1NT     2S
+1H      Pass    1N     2S
 Pass    Pass    Pass    
 
 
@@ -6211,11 +6211,11 @@ Pass    Pass
 {HCP 3 6 17 14}
 {TP 6 7 17 14}
 {Losers 8 9 7 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    1S      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -6273,12 +6273,12 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 16 6 13 8}
 {Losers 6 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2H      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6295,12 +6295,12 @@ Pass    Pass
 {HCP 17 7 11 5}
 {TP 19 8 13 6}
 {Losers 5 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1H      Pass    2C      Pass
 2D      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6338,12 +6338,12 @@ Pass    Pass
 {HCP 6 6 16 12}
 {TP 8 6 18 14}
 {Losers 8 10 5 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1H      1S      Pass    2S
 3C      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6386,7 +6386,7 @@ Pass    Pass
 [Auction "S"]
 1H      X       Pass    1S
 Pass    2D      Pass    2H
-Pass    2NT     Pass    3S
+Pass    2N     Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -6472,7 +6472,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1S      Pass    1NT     2H
+1S      Pass    1N     2H
 Pass    Pass    2S      3H
 Pass    Pass    Pass    
 
@@ -6493,7 +6493,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 3D      Pass    4S      Pass
 Pass    Pass    
 
@@ -6537,8 +6537,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    2C      3D
-4D      Pass    4NT     Pass
-5NT     Pass    6C      Pass
+4D      Pass    4N     Pass
+5N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -6596,12 +6596,12 @@ Pass    Pass    Pass
 {HCP 11 0 12 17}
 {TP 13 2 12 17}
 {Losers 7 10 8 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1S      1NT     X       XX
+1S      1N     X       XX
 Pass    2C      3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6618,11 +6618,11 @@ Pass    Pass
 {HCP 17 7 11 5}
 {TP 18 8 13 5}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    2H      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6642,7 +6642,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     2C
+1S      Pass    1N     2C
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -6685,7 +6685,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2C      Pass    4S      Pass
 Pass    Pass    
 
@@ -6752,7 +6752,7 @@ Pass
 1S      Pass    2D      Pass
 2H      Pass    3H      Pass
 3S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -6770,12 +6770,12 @@ Pass
 {HCP 2 17 13 8}
 {TP 4 17 13 8}
 {Losers 9 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 1S      Pass    Pass    X
-Pass    1NT     Pass    2NT
-Pass    3NT     Pass    Pass
+Pass    1N     Pass    2N
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -6795,7 +6795,7 @@ Pass
 [Contract "6C"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 3C      Pass    4C      Pass
 5C      Pass    6C      Pass
 Pass    Pass    
@@ -6836,12 +6836,12 @@ Pass    Pass
 {HCP 8 13 16 3}
 {TP 8 13 17 3}
 {Losers 9 8 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2D      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6884,7 +6884,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2H      Pass    Pass    Pass
 
 
@@ -6905,7 +6905,7 @@ Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1S      Pass    1NT     2D
+1S      Pass    1N     2D
 Pass    Pass    2S      3D
 Pass    Pass    Pass    
 
@@ -6926,7 +6926,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1S      2NT     3D      Pass
+1S      2N     3D      Pass
 3H      Pass    Pass    X
 3S      Pass    Pass    Pass
 
@@ -6949,7 +6949,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1S      X       Pass    3H
-Pass    3NT     Pass    4H
+Pass    3N     Pass    4H
 Pass    Pass    Pass    
 
 
@@ -6966,14 +6966,14 @@ Pass    Pass    Pass
 {HCP 5 15 12 8}
 {TP 7 16 13 9}
 {Losers 8 6 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 1S      Pass    Pass    X
-Pass    1NT     Pass    2D
+Pass    1N     Pass    2D
 Pass    2S      Pass    3C
 Pass    3D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -7013,7 +7013,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     X
+1S      Pass    1N     X
 Pass    2H      Pass    Pass
 2S      Pass    Pass    Pass
 
@@ -7079,9 +7079,9 @@ Pass    Pass
 [Auction "S"]
 1S      Pass    3S      Pass
 4C      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -7098,11 +7098,11 @@ Pass    Pass
 {HCP 20 5 13 2}
 {TP 21 7 14 3}
 {Losers 4 9 6 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    2D      Pass
-2S      Pass    6NT     Pass
+2S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -7123,7 +7123,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 5S      Pass    Pass    Pass
 
 
@@ -7144,7 +7144,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -7188,7 +7188,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1S      2C      X       Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -7210,7 +7210,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    2C      Pass
-2S      Pass    2NT     Pass
+2S      Pass    2N     Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -7252,9 +7252,9 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2C      Pass    3S      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -7274,7 +7274,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2H      Pass    Pass    Pass
 
 
@@ -7295,7 +7295,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1S      Pass    1NT     2C
+1S      Pass    1N     2C
 Pass    Pass    2H      Pass
 4H      Pass    Pass    Pass
 
@@ -7317,7 +7317,7 @@ Pass    Pass    2H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      X       2NT     Pass
+1S      X       2N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -7420,10 +7420,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+1S      Pass    2N     Pass
+3D      Pass    3N     Pass
 4C      Pass    4D      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 6D      Pass    6S      Pass
 Pass    Pass    
 
@@ -7441,10 +7441,10 @@ Pass    Pass
 {HCP 3 6 16 15}
 {TP 5 6 17 15}
 {Losers 9 10 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "W"]
 [Auction "S"]
-1S      1NT     Pass    Pass
+1S      1N     Pass    Pass
 Pass    
 
 
@@ -7546,7 +7546,7 @@ Pass    Pass
 [Contract "6C"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 3C      Pass    4C      Pass
 5C      Pass    6C      Pass
 Pass    Pass    
@@ -7607,12 +7607,12 @@ Pass    Pass
 {HCP 3 7 12 18}
 {TP 4 8 12 21}
 {Losers 9 8 7 4}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-1S      X       Pass    1NT
+1S      X       Pass    1N
 Pass    2D      Pass    3C
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -7633,8 +7633,8 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3H      Pass
-4H      Pass    4NT     Pass
-5NT     Pass    6H      Pass
+4H      Pass    4N     Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -7656,7 +7656,7 @@ Pass    Pass
 [Auction "S"]
 1S      Pass    2D      Pass
 3C      Pass    4H      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -7678,7 +7678,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    2S      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -7695,11 +7695,11 @@ Pass    Pass
 {HCP 8 9 19 4}
 {TP 8 9 20 6}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1S      Pass    1NT     Pass
-3D      Pass    3NT     Pass
+1S      Pass    1N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7719,9 +7719,9 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 3C      Pass    3H      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -7741,7 +7741,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2C      Pass    3C      Pass
 4S      Pass    5C      Pass
 Pass    Pass    
@@ -7760,11 +7760,11 @@ Pass    Pass
 {HCP 4 11 13 12}
 {TP 5 13 14 12}
 {Losers 10 5 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 1S      2H      Pass    3D
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -7784,7 +7784,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2H      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -7806,8 +7806,8 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
-2S      Pass    2NT     Pass
+1S      Pass    1N     Pass
+2S      Pass    2N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -7825,11 +7825,11 @@ Pass
 {HCP 12 8 11 9}
 {TP 12 8 14 9}
 {Losers 8 8 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1S      Pass    1NT     Pass
-2H      Pass    2NT     Pass
+1S      Pass    1N     Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7849,7 +7849,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7955,7 +7955,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 3D      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -7997,7 +7997,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2C      Pass    2S      Pass
 Pass    Pass    
 
@@ -8122,7 +8122,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2H      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -8144,7 +8144,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 3D      Pass    4D      Pass
 5D      Pass    Pass    Pass
 
@@ -8166,7 +8166,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2C      Pass    3C      Pass
 Pass    Pass    
 
@@ -8253,7 +8253,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      X       Pass    Pass
 5S      Pass    Pass    Pass
 
@@ -8275,7 +8275,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -8296,10 +8296,10 @@ Pass
 [Contract "5S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      X       3H      Pass
 4D      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5S      Pass
 Pass    Pass    
 
@@ -8320,7 +8320,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2D      Pass    2H      Pass
 Pass    Pass    
 
@@ -8338,12 +8338,12 @@ Pass    Pass
 {HCP 12 3 17 8}
 {TP 14 4 19 10}
 {Losers 6 9 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    2D      Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8363,7 +8363,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    4C      Pass    4H
 Pass    Pass    Pass    
 
@@ -8385,7 +8385,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    2S      Pass
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 4S      Pass    Pass    Pass
 
 
@@ -8427,7 +8427,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2S      Pass    Pass    Pass
 
 
@@ -8445,12 +8445,12 @@ Pass    Pass    Pass
 {HCP 5 4 11 20}
 {TP 7 4 13 20}
 {Losers 8 11 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 1S      X       Pass    2C
 Pass    3D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -8491,8 +8491,8 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    1NT     Pass
-2D      Pass    2NT     Pass
+1S      Pass    1N     Pass
+2D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -8556,8 +8556,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      2S      3H      Pass
-4S      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5D      Pass    5N     Pass
 6C      Pass    6S      Pass
 Pass    Pass    
 

--- a/GIB/1m-1N_forced.pbn
+++ b/GIB/1m-1N_forced.pbn
@@ -12,11 +12,11 @@
 {HCP 9 10 18 3}
 {TP 9 12 18 3}
 {Losers 9 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1D      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -36,7 +36,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -54,11 +54,11 @@ Pass    Pass    Pass
 {HCP 9 5 19 7}
 {TP 9 5 19 8}
 {Losers 9 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -75,10 +75,10 @@ Pass    Pass    Pass
 {HCP 9 10 14 7}
 {TP 9 11 15 8}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -95,11 +95,11 @@ Pass    Pass
 {HCP 8 8 19 5}
 {TP 8 8 19 6}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -119,7 +119,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2S
+1D      Pass    1N     2S
 Pass    Pass    Pass    
 
 
@@ -139,7 +139,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -157,12 +157,12 @@ Pass    Pass    Pass
 {HCP 9 8 16 7}
 {TP 9 9 17 8}
 {Losers 9 9 5 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -179,10 +179,10 @@ Pass    Pass    Pass
 {HCP 9 8 12 11}
 {TP 9 8 12 12}
 {Losers 8 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -199,12 +199,12 @@ Pass    Pass
 {HCP 9 12 16 3}
 {TP 9 13 16 3}
 {Losers 9 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2S      3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -224,7 +224,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2S      Pass    Pass
 Pass    
 
@@ -242,10 +242,10 @@ Pass
 {HCP 9 12 12 7}
 {TP 9 13 13 8}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -262,10 +262,10 @@ Pass    Pass
 {HCP 8 9 13 10}
 {TP 8 11 13 11}
 {Losers 9 7 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -282,11 +282,11 @@ Pass    Pass
 {HCP 9 5 18 8}
 {TP 9 7 18 8}
 {Losers 9 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1D      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -303,10 +303,10 @@ Pass    Pass
 {HCP 9 10 13 8}
 {TP 9 10 13 8}
 {Losers 8 9 9 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -326,7 +326,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -347,7 +347,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2H
+1C      Pass    1N     2H
 Pass    Pass    Pass    
 
 
@@ -367,7 +367,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 2C      2H      Pass    Pass
 Pass    
 
@@ -388,7 +388,7 @@ Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    Pass    Pass    
 
 
@@ -408,7 +408,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      X       1NT     2S
+1D      X       1N     2S
 Pass    Pass    Pass    
 
 
@@ -425,11 +425,11 @@ Pass    Pass    Pass
 {HCP 9 11 15 5}
 {TP 9 12 17 6}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3C      Pass    3NT     Pass
+1C      Pass    1N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -446,11 +446,11 @@ Pass    Pass
 {HCP 9 8 18 5}
 {TP 9 8 18 6}
 {Losers 9 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -467,10 +467,10 @@ Pass    Pass
 {HCP 9 8 14 9}
 {TP 9 8 15 9}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -487,10 +487,10 @@ Pass    Pass
 {HCP 9 12 12 7}
 {TP 9 12 13 7}
 {Losers 9 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -510,7 +510,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 3D      Pass    Pass    Pass
 
 
@@ -528,11 +528,11 @@ Pass    Pass
 {HCP 9 6 19 6}
 {TP 9 6 19 6}
 {Losers 9 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -552,7 +552,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    2H
 Pass    3C      Pass    3H
 Pass    4H      Pass    Pass
@@ -575,7 +575,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2S      Pass    Pass    Pass
 
 
@@ -596,7 +596,7 @@ Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    3D      Pass    Pass
 Pass    
 
@@ -614,11 +614,11 @@ Pass
 {HCP 8 10 17 5}
 {TP 8 11 17 6}
 {Losers 9 8 5 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -635,11 +635,11 @@ Pass
 {HCP 9 7 18 6}
 {TP 9 8 19 6}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -656,10 +656,10 @@ Pass    Pass
 {HCP 9 9 13 9}
 {TP 9 11 13 10}
 {Losers 9 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -676,11 +676,11 @@ Pass    Pass
 {HCP 9 9 18 4}
 {TP 9 10 18 4}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1D      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -697,10 +697,10 @@ Pass    Pass
 {HCP 9 11 13 7}
 {TP 9 12 13 7}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -720,7 +720,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -741,7 +741,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 Pass    2S      Pass    Pass
 Pass    
 
@@ -762,7 +762,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    2H
 Pass    Pass    Pass    
 
@@ -780,10 +780,10 @@ Pass    Pass    Pass
 {HCP 9 10 13 8}
 {TP 9 10 14 8}
 {Losers 9 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -803,7 +803,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2S
+1C      Pass    1N     2S
 Pass    Pass    Pass    
 
 
@@ -823,7 +823,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -844,7 +844,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -865,7 +865,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
 Pass    X       Pass    3S
 Pass    4S      Pass    Pass
@@ -885,10 +885,10 @@ Pass
 {HCP 9 13 14 4}
 {TP 9 14 15 5}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -908,7 +908,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    Pass    Pass    
 
 
@@ -925,10 +925,10 @@ Pass    Pass    Pass
 {HCP 9 13 14 4}
 {TP 9 13 15 5}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -948,7 +948,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2S      Pass    3D      Pass
 4D      Pass    Pass    Pass
 
@@ -970,7 +970,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -988,11 +988,11 @@ Pass    Pass
 {HCP 7 9 18 6}
 {TP 7 11 18 6}
 {Losers 9 8 6 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -1009,12 +1009,12 @@ Pass    Pass
 {HCP 9 7 17 7}
 {TP 9 9 18 8}
 {Losers 9 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1031,10 +1031,10 @@ Pass    Pass
 {HCP 9 10 13 8}
 {TP 9 11 14 8}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -1054,7 +1054,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2H
 Pass    Pass    Pass    
 
@@ -1075,7 +1075,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    2D
 Pass    Pass    Pass    
 

--- a/GIB/1m-1N_freebid.pbn
+++ b/GIB/1m-1N_freebid.pbn
@@ -12,11 +12,11 @@
 {HCP 8 6 19 7}
 {TP 8 7 19 8}
 {Losers 9 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -57,7 +57,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    2D
 3C      Pass    Pass    Pass
 
@@ -76,11 +76,11 @@ Pass    Pass    Pass
 {HCP 9 7 14 10}
 {TP 9 7 14 10}
 {Losers 9 10 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -97,11 +97,11 @@ Pass    Pass
 {HCP 8 7 19 6}
 {TP 8 8 19 6}
 {Losers 9 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -118,11 +118,11 @@ Pass    Pass
 {HCP 8 11 13 8}
 {TP 8 11 14 8}
 {Losers 9 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -139,11 +139,11 @@ Pass    Pass
 {HCP 9 9 14 8}
 {TP 9 10 14 9}
 {Losers 9 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -160,11 +160,11 @@ Pass    Pass
 {HCP 9 14 12 5}
 {TP 9 14 13 5}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -184,7 +184,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -288,11 +288,11 @@ Pass
 {HCP 8 12 13 7}
 {TP 8 12 13 7}
 {Losers 8 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -312,7 +312,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2H
+1C      Pass    1N     2H
 Pass    Pass    Pass    
 
 
@@ -329,10 +329,10 @@ Pass    Pass    Pass
 {HCP 9 15 12 4}
 {TP 9 15 13 6}
 {Losers 8 6 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -349,11 +349,11 @@ Pass    Pass
 {HCP 9 11 18 2}
 {TP 9 12 18 3}
 {Losers 9 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -416,7 +416,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    Pass    Pass    
 
 
@@ -433,12 +433,12 @@ Pass    Pass    Pass
 {HCP 8 8 19 5}
 {TP 8 10 19 7}
 {Losers 9 8 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2D      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -476,10 +476,10 @@ Pass    Pass    Pass
 {HCP 8 12 12 8}
 {TP 8 12 12 8}
 {Losers 9 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -496,11 +496,11 @@ Pass    Pass
 {HCP 9 14 17 0}
 {TP 9 14 17 1}
 {Losers 9 7 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -521,7 +521,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -539,10 +539,10 @@ Pass    Pass
 {HCP 9 13 14 4}
 {TP 9 14 14 5}
 {Losers 9 7 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -580,12 +580,12 @@ Pass
 {HCP 8 10 19 3}
 {TP 8 12 21 3}
 {Losers 9 7 4 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -602,10 +602,10 @@ Pass
 {HCP 9 11 12 8}
 {TP 9 11 12 9}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -664,12 +664,12 @@ Pass    Pass
 {HCP 8 9 19 4}
 {TP 8 10 21 4}
 {Losers 9 8 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -690,7 +690,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    Pass    Pass    
 
 
@@ -707,10 +707,10 @@ Pass    Pass    Pass
 {HCP 8 10 13 9}
 {TP 8 10 13 9}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -730,7 +730,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -752,7 +752,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2C      Pass    2D      Pass
 2S      Pass    Pass    Pass
 
@@ -792,11 +792,11 @@ Pass    Pass    Pass
 {HCP 8 12 14 6}
 {TP 8 12 14 6}
 {Losers 9 8 7 11}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -816,7 +816,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    2D
 Pass    Pass    Pass    
 
@@ -855,11 +855,11 @@ Pass    Pass    Pass
 {HCP 7 9 13 11}
 {TP 7 11 15 11}
 {Losers 9 7 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -879,7 +879,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 Pass    
 
@@ -897,10 +897,10 @@ Pass
 {HCP 9 7 14 10}
 {TP 9 9 15 10}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -941,7 +941,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2S
+1D      Pass    1N     2S
 Pass    Pass    Pass    
 
 
@@ -961,7 +961,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 2C      2S      Pass    Pass
 Pass    
 
@@ -979,10 +979,10 @@ Pass
 {HCP 9 10 14 7}
 {TP 9 11 14 9}
 {Losers 9 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -999,11 +999,11 @@ Pass    Pass
 {HCP 9 7 14 10}
 {TP 9 8 15 10}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1023,7 +1023,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1S      1NT
+1C      Pass    1S      1N
 Pass    Pass    2C      Pass
 Pass    Pass    
 
@@ -1044,7 +1044,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 X       Pass    3D      Pass
 Pass    Pass    
@@ -1063,11 +1063,11 @@ Pass    Pass
 {HCP 8 10 12 10}
 {TP 8 10 12 10}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -1084,10 +1084,10 @@ Pass    Pass
 {HCP 8 18 13 1}
 {TP 8 18 13 3}
 {Losers 9 6 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -1107,7 +1107,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -1171,7 +1171,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2S
+1C      Pass    1N     2S
 Pass    3S      Pass    Pass
 Pass    
 
@@ -1189,11 +1189,11 @@ Pass
 {HCP 7 19 14 0}
 {TP 7 19 14 1}
 {Losers 9 6 8 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     X
-Pass    2C      Pass    2NT
+1D      Pass    1N     X
+Pass    2C      Pass    2N
 Pass    Pass    Pass    
 
 
@@ -1232,12 +1232,12 @@ Pass    Pass    Pass
 {HCP 7 9 19 5}
 {TP 7 10 20 6}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 3C      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1322,7 +1322,7 @@ Pass    Pass    X       Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2H
 Pass    Pass    Pass    
 
@@ -1340,11 +1340,11 @@ Pass    Pass    Pass
 {HCP 9 7 13 11}
 {TP 9 7 13 11}
 {Losers 9 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1364,7 +1364,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -1385,7 +1385,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -1406,7 +1406,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2H
+1D      Pass    1N     2H
 Pass    Pass    Pass    
 
 
@@ -1447,7 +1447,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2H
+1C      Pass    1N     2H
 Pass    Pass    Pass    
 
 
@@ -1506,12 +1506,12 @@ Pass    Pass
 {HCP 9 7 17 7}
 {TP 9 8 18 8}
 {Losers 9 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1553,7 +1553,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2H
 Pass    Pass    Pass    
 
@@ -1571,10 +1571,10 @@ Pass    Pass    Pass
 {HCP 8 12 14 6}
 {TP 8 12 14 6}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -1591,10 +1591,10 @@ Pass    Pass
 {HCP 9 11 12 8}
 {TP 9 11 12 9}
 {Losers 9 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -1614,7 +1614,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     2H
+1D      Pass    1N     2H
 3D      Pass    Pass    Pass
 
 
@@ -1653,10 +1653,10 @@ Pass    Pass
 {HCP 9 13 14 4}
 {TP 9 14 14 5}
 {Losers 9 7 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -1676,7 +1676,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -1694,10 +1694,10 @@ Pass    Pass
 {HCP 8 12 14 6}
 {TP 8 12 14 7}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -1735,11 +1735,11 @@ Pass    Pass
 {HCP 9 10 14 7}
 {TP 9 11 14 7}
 {Losers 9 9 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -1776,11 +1776,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 7 13 11}
 {TP 9 7 13 11}
 {Losers 9 10 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1800,7 +1800,7 @@ Pass    Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -1818,14 +1818,14 @@ Pass    Pass    Pass    Pass
 {HCP 9 10 18 3}
 {TP 9 12 19 3}
 {Losers 9 7 5 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      X
 XX      1S      Pass    Pass
 2D      Pass    2H      Pass
-2S      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2S      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1866,7 +1866,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -1907,7 +1907,7 @@ Pass    Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    Pass    Pass    
 
 
@@ -1924,11 +1924,11 @@ Pass    Pass    Pass
 {HCP 9 13 13 5}
 {TP 9 13 13 6}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1948,7 +1948,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
 2H      Pass    Pass    Pass
 
@@ -1970,7 +1970,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2H
 Pass    Pass    Pass    
 
@@ -2009,11 +2009,11 @@ Pass    Pass
 {HCP 8 11 20 1}
 {TP 8 11 20 3}
 {Losers 9 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3D      Pass    3NT     Pass
+1D      Pass    1N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2030,10 +2030,10 @@ Pass    Pass
 {HCP 9 9 13 9}
 {TP 9 10 13 9}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2113,12 +2113,12 @@ Pass    Pass
 {HCP 8 7 15 10}
 {TP 8 9 17 10}
 {Losers 9 7 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2135,11 +2135,11 @@ Pass    Pass
 {HCP 8 8 19 5}
 {TP 8 10 19 7}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2156,10 +2156,10 @@ Pass    Pass
 {HCP 7 10 12 11}
 {TP 7 11 12 11}
 {Losers 9 9 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2179,7 +2179,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
@@ -2198,10 +2198,10 @@ Pass    Pass
 {HCP 7 12 14 7}
 {TP 7 12 15 8}
 {Losers 9 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2218,10 +2218,10 @@ Pass    Pass
 {HCP 9 13 12 6}
 {TP 9 13 12 6}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2259,11 +2259,11 @@ Pass    Pass
 {HCP 8 6 19 7}
 {TP 8 8 19 7}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2304,7 +2304,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -2322,11 +2322,11 @@ Pass    Pass
 {HCP 8 6 19 7}
 {TP 8 6 19 7}
 {Losers 9 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2343,11 +2343,11 @@ Pass    Pass
 {HCP 8 12 14 6}
 {TP 8 12 15 7}
 {Losers 9 8 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2364,11 +2364,11 @@ Pass    Pass
 {HCP 9 12 14 5}
 {TP 9 12 14 5}
 {Losers 9 8 7 11}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2385,11 +2385,11 @@ Pass    Pass
 {HCP 9 5 18 8}
 {TP 9 5 19 8}
 {Losers 9 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2449,11 +2449,11 @@ X       3S      Pass    Pass
 {HCP 9 7 13 11}
 {TP 9 8 13 11}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2473,7 +2473,7 @@ X       3S      Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -2515,7 +2515,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 Pass    
 
@@ -2536,7 +2536,7 @@ Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2C
 Pass    Pass    2D      Pass
 3C      Pass    3D      Pass
@@ -2556,12 +2556,12 @@ Pass    Pass
 {HCP 9 12 18 1}
 {TP 9 12 19 2}
 {Losers 9 7 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2H      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2578,11 +2578,11 @@ Pass    Pass
 {HCP 8 13 13 6}
 {TP 8 13 13 6}
 {Losers 9 7 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2620,11 +2620,11 @@ Pass    Pass
 {HCP 8 12 12 8}
 {TP 8 12 13 9}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2641,10 +2641,10 @@ Pass    Pass
 {HCP 9 16 12 3}
 {TP 9 16 13 5}
 {Losers 9 7 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2661,11 +2661,11 @@ Pass    Pass
 {HCP 9 9 12 10}
 {TP 9 10 12 10}
 {Losers 9 7 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2682,11 +2682,11 @@ Pass    Pass
 {HCP 9 10 14 7}
 {TP 9 10 14 7}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2724,11 +2724,11 @@ Pass    Pass
 {HCP 9 7 18 6}
 {TP 9 9 18 6}
 {Losers 9 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1D      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2745,10 +2745,10 @@ Pass    Pass
 {HCP 9 8 12 11}
 {TP 9 9 12 11}
 {Losers 8 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2765,11 +2765,11 @@ Pass    Pass
 {HCP 9 8 12 11}
 {TP 9 8 12 11}
 {Losers 8 10 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2786,10 +2786,10 @@ Pass    Pass
 {HCP 6 16 11 7}
 {TP 6 16 12 7}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-Pass    Pass    Pass    1NT
+Pass    Pass    Pass    1N
 Pass    Pass    Pass    
 
 
@@ -2806,10 +2806,10 @@ Pass    Pass    Pass
 {HCP 9 11 14 6}
 {TP 9 11 14 6}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2847,11 +2847,11 @@ Pass
 {HCP 8 9 20 3}
 {TP 8 11 20 4}
 {Losers 9 8 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2868,10 +2868,10 @@ Pass
 {HCP 9 14 12 5}
 {TP 9 14 12 6}
 {Losers 9 7 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2888,10 +2888,10 @@ Pass    Pass
 {HCP 9 11 14 6}
 {TP 9 11 15 7}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2930,12 +2930,12 @@ Pass
 {HCP 9 9 19 3}
 {TP 9 10 21 5}
 {Losers 9 8 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2S      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2952,10 +2952,10 @@ Pass    Pass
 {HCP 9 8 12 11}
 {TP 9 8 12 12}
 {Losers 9 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2975,7 +2975,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 2C      2S      Pass    Pass
 Pass    
 
@@ -2997,7 +2997,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    Pass    Pass    
 
 
@@ -3056,11 +3056,11 @@ Pass    Pass    Pass
 {HCP 9 10 19 2}
 {TP 9 11 19 2}
 {Losers 9 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3080,7 +3080,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -3098,11 +3098,11 @@ Pass    Pass
 {HCP 8 8 17 7}
 {TP 8 8 17 9}
 {Losers 9 9 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3122,7 +3122,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 Pass    2S      Pass    Pass
 Pass    
 
@@ -3140,10 +3140,10 @@ Pass
 {HCP 9 16 12 3}
 {TP 9 16 12 5}
 {Losers 9 7 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3160,11 +3160,11 @@ Pass    Pass
 {HCP 9 14 16 1}
 {TP 9 14 19 2}
 {Losers 9 7 4 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     2S
-3C      Pass    3NT     Pass
+1C      Pass    1N     2S
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3184,7 +3184,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 Pass    2D      Pass    Pass
 Pass    
 
@@ -3202,10 +3202,10 @@ Pass
 {HCP 9 10 13 8}
 {TP 9 10 13 8}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3243,11 +3243,11 @@ Pass    Pass
 {HCP 9 14 13 4}
 {TP 9 15 14 4}
 {Losers 8 8 7 11}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3264,12 +3264,12 @@ Pass    Pass
 {HCP 8 12 18 2}
 {TP 8 13 19 3}
 {Losers 9 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 2H      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3289,7 +3289,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    Pass    Pass    
 
 
@@ -3309,7 +3309,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2D
 Pass    Pass    Pass    
 
@@ -3349,11 +3349,11 @@ Pass    Pass    Pass
 {HCP 7 8 18 7}
 {TP 7 9 18 8}
 {Losers 9 9 5 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -3370,13 +3370,13 @@ Pass    Pass    Pass
 {HCP 8 6 16 10}
 {TP 8 6 18 10}
 {Losers 9 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3396,7 +3396,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -3414,11 +3414,11 @@ Pass    Pass    Pass
 {HCP 9 9 14 8}
 {TP 9 11 16 9}
 {Losers 9 7 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3456,11 +3456,11 @@ Pass    Pass
 {HCP 9 12 14 5}
 {TP 9 12 14 5}
 {Losers 9 7 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3480,7 +3480,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    Pass    Pass    
 
 
@@ -3497,10 +3497,10 @@ Pass    Pass    Pass
 {HCP 7 10 13 10}
 {TP 7 10 14 10}
 {Losers 9 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3520,7 +3520,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2D
 Pass    Pass    Pass    
 
@@ -3538,10 +3538,10 @@ Pass    Pass    Pass
 {HCP 8 12 13 7}
 {TP 8 13 13 9}
 {Losers 9 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3558,10 +3558,10 @@ Pass    Pass
 {HCP 8 10 14 8}
 {TP 8 11 14 8}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3578,11 +3578,11 @@ Pass    Pass
 {HCP 9 6 19 6}
 {TP 9 6 19 6}
 {Losers 9 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3623,7 +3623,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     2D
+1D      Pass    1N     2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -3644,7 +3644,7 @@ Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2C
 Pass    Pass    2D      Pass
 Pass    Pass    
@@ -3666,7 +3666,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    Pass    Pass    
 
 
@@ -3683,10 +3683,10 @@ Pass    Pass    Pass
 {HCP 8 12 13 7}
 {TP 8 12 14 8}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3706,7 +3706,7 @@ Pass    Pass
 [Contract "2DX"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 2C      2D      Pass    Pass
 X       Pass    Pass    Pass
 
@@ -3746,10 +3746,10 @@ X       Pass    Pass    Pass
 {HCP 8 11 13 8}
 {TP 8 11 14 8}
 {Losers 9 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3766,10 +3766,10 @@ Pass    Pass
 {HCP 9 11 13 7}
 {TP 9 12 14 8}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3828,11 +3828,11 @@ Pass    Pass    Pass
 {HCP 8 6 19 7}
 {TP 8 7 19 8}
 {Losers 9 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3849,11 +3849,11 @@ Pass    Pass    Pass
 {HCP 9 11 13 7}
 {TP 9 12 13 7}
 {Losers 9 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3870,11 +3870,11 @@ Pass    Pass
 {HCP 8 14 18 0}
 {TP 8 15 18 2}
 {Losers 9 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     2H
-2NT     Pass    3NT     Pass
+1C      Pass    1N     2H
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3891,10 +3891,10 @@ Pass    Pass
 {HCP 7 11 14 8}
 {TP 7 11 15 9}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3911,11 +3911,11 @@ Pass    Pass
 {HCP 8 14 14 4}
 {TP 8 14 14 4}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3932,10 +3932,10 @@ Pass    Pass
 {HCP 8 12 13 7}
 {TP 8 13 13 7}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3997,7 +3997,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1H      1NT
+1D      Pass    1H      1N
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -4015,11 +4015,11 @@ Pass    Pass
 {HCP 7 17 12 4}
 {TP 7 18 12 5}
 {Losers 9 6 9 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4039,7 +4039,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2D
 Pass    Pass    Pass    
 
@@ -4102,7 +4102,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
 2H      Pass    3D      Pass
 Pass    Pass    
@@ -4124,7 +4124,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2H
+1C      Pass    1N     2H
 Pass    Pass    Pass    
 
 
@@ -4162,11 +4162,11 @@ Pass    Pass
 {HCP 8 17 14 1}
 {TP 8 17 16 2}
 {Losers 9 6 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1S      1NT
-3D      Pass    3NT     Pass
+1D      Pass    1S      1N
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4186,7 +4186,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 Pass    2H      Pass    3C
 Pass    3D      Pass    3H
 Pass    4H      Pass    Pass
@@ -4209,7 +4209,7 @@ Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -4227,11 +4227,11 @@ Pass
 {HCP 9 10 14 7}
 {TP 9 10 14 8}
 {Losers 9 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4251,7 +4251,7 @@ Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2C
+1D      Pass    1N     2C
 Pass    Pass    Pass    
 
 
@@ -4268,11 +4268,11 @@ Pass    Pass    Pass
 {HCP 8 9 13 10}
 {TP 8 10 13 11}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4292,7 +4292,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     2H
+1D      Pass    1N     2H
 3H      Pass    4D      Pass
 5D      Pass    Pass    Pass
 
@@ -4311,11 +4311,11 @@ Pass    Pass    Pass
 {HCP 9 11 13 7}
 {TP 9 11 13 9}
 {Losers 8 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4335,7 +4335,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    2H
 3D      Pass    Pass    Pass
 
@@ -4357,7 +4357,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -4396,11 +4396,11 @@ Pass    Pass
 {HCP 8 13 12 7}
 {TP 8 14 12 8}
 {Losers 9 7 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4438,12 +4438,12 @@ Pass    Pass
 {HCP 9 6 16 9}
 {TP 9 7 18 9}
 {Losers 9 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2H      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4482,11 +4482,11 @@ Pass    Pass    X       Pass
 {HCP 9 9 19 3}
 {TP 9 9 19 5}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4503,10 +4503,10 @@ Pass    Pass
 {HCP 9 17 12 2}
 {TP 9 17 12 3}
 {Losers 9 6 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4523,10 +4523,10 @@ Pass    Pass
 {HCP 9 14 12 5}
 {TP 9 14 12 5}
 {Losers 9 6 9 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4546,7 +4546,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -4585,10 +4585,10 @@ Pass    Pass    Pass
 {HCP 9 10 12 9}
 {TP 9 12 12 9}
 {Losers 9 7 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4605,11 +4605,11 @@ Pass    Pass
 {HCP 8 10 12 10}
 {TP 8 11 12 10}
 {Losers 9 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4629,7 +4629,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -4692,7 +4692,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 Pass    2S      Pass    Pass
 Pass    
 
@@ -4714,7 +4714,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -4752,11 +4752,11 @@ Pass    Pass    Pass
 {HCP 8 6 18 8}
 {TP 8 8 18 8}
 {Losers 9 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4776,7 +4776,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 Pass    
 
@@ -4815,10 +4815,10 @@ Pass    Pass
 {HCP 6 16 16 2}
 {TP 6 16 17 3}
 {Losers 9 6 6 11}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4859,7 +4859,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2C
+1D      Pass    1N     2C
 Pass    Pass    Pass    
 
 
@@ -4876,11 +4876,11 @@ Pass    Pass    Pass
 {HCP 9 12 13 6}
 {TP 9 12 14 6}
 {Losers 9 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4918,11 +4918,11 @@ Pass
 {HCP 9 9 14 8}
 {TP 9 9 14 9}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4986,7 +4986,7 @@ Pass
 [Contract "3S"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1H      2NT
+1C      Pass    1H      2N
 Pass    3S      Pass    Pass
 Pass    
 
@@ -5025,11 +5025,11 @@ Pass
 {HCP 8 7 19 6}
 {TP 8 10 19 7}
 {Losers 9 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5046,11 +5046,11 @@ Pass
 {HCP 9 10 18 3}
 {TP 9 10 18 3}
 {Losers 9 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5070,7 +5070,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -5135,7 +5135,7 @@ Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -5156,7 +5156,7 @@ Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2D
 Pass    Pass    Pass    
 
@@ -5174,11 +5174,11 @@ Pass    Pass    Pass
 {HCP 8 7 18 7}
 {TP 8 10 18 8}
 {Losers 9 7 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5198,7 +5198,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 Pass    2H      Pass    Pass
 Pass    
 
@@ -5261,7 +5261,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2S
+1D      Pass    1N     2S
 Pass    Pass    Pass    
 
 
@@ -5281,7 +5281,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2H
+1C      Pass    1N     2H
 Pass    Pass    Pass    
 
 
@@ -5319,10 +5319,10 @@ Pass    Pass
 {HCP 9 11 13 7}
 {TP 9 12 13 7}
 {Losers 8 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -5362,11 +5362,11 @@ X       Pass    Pass    Pass
 {HCP 8 7 14 11}
 {TP 8 8 14 11}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5383,10 +5383,10 @@ X       Pass    Pass    Pass
 {HCP 9 14 12 5}
 {TP 9 14 12 5}
 {Losers 8 7 8 11}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -5406,7 +5406,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    2H
 Pass    Pass    Pass    
 
@@ -5424,12 +5424,12 @@ Pass    Pass    Pass
 {HCP 9 9 17 5}
 {TP 9 9 19 6}
 {Losers 9 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2H      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5446,11 +5446,11 @@ Pass    Pass
 {HCP 9 2 18 11}
 {TP 9 5 20 11}
 {Losers 9 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3D      Pass    3NT     Pass
+1D      Pass    1N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5488,11 +5488,11 @@ Pass    Pass
 {HCP 8 11 17 4}
 {TP 8 13 18 5}
 {Losers 9 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     2S
-2NT     Pass    3NT     Pass
+1C      Pass    1N     2S
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5509,11 +5509,11 @@ Pass    Pass
 {HCP 9 11 14 6}
 {TP 9 11 14 6}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5551,11 +5551,11 @@ Pass    Pass    Pass
 {HCP 7 13 14 6}
 {TP 7 14 15 6}
 {Losers 9 6 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5614,10 +5614,10 @@ Pass
 {HCP 9 9 14 8}
 {TP 9 10 14 9}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -5634,11 +5634,11 @@ Pass    Pass
 {HCP 7 10 14 9}
 {TP 7 10 14 9}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5658,7 +5658,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2C      2H      Pass    Pass
 Pass    
 
@@ -5697,11 +5697,11 @@ Pass
 {HCP 8 9 14 9}
 {TP 8 9 14 10}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5741,7 +5741,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -5781,12 +5781,12 @@ Pass    Pass
 {HCP 7 8 18 7}
 {TP 7 9 18 7}
 {Losers 9 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5803,11 +5803,11 @@ Pass    Pass
 {HCP 9 8 12 11}
 {TP 9 8 12 12}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5845,11 +5845,11 @@ Pass    Pass
 {HCP 9 12 12 7}
 {TP 9 12 12 7}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5869,7 +5869,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2H
+1C      Pass    1N     2H
 Pass    Pass    Pass    
 
 
@@ -5886,11 +5886,11 @@ Pass    Pass    Pass
 {HCP 9 7 18 6}
 {TP 9 8 18 7}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1D      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5907,11 +5907,11 @@ Pass    Pass
 {HCP 7 8 18 7}
 {TP 7 8 18 7}
 {Losers 9 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -5949,11 +5949,11 @@ Pass    Pass
 {HCP 9 12 12 7}
 {TP 9 12 13 7}
 {Losers 9 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -5991,10 +5991,10 @@ Pass    Pass
 {HCP 7 16 14 3}
 {TP 7 16 14 3}
 {Losers 9 8 7 11}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6011,11 +6011,11 @@ Pass    Pass
 {HCP 7 7 18 8}
 {TP 7 7 18 8}
 {Losers 9 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6052,10 +6052,10 @@ Pass    Pass    Pass    Pass
 {HCP 9 9 12 10}
 {TP 9 9 12 10}
 {Losers 9 10 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6072,11 +6072,11 @@ Pass    Pass
 {HCP 8 9 18 5}
 {TP 8 9 18 6}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6115,11 +6115,11 @@ Pass    Pass    Pass    1C
 {HCP 9 7 19 5}
 {TP 9 8 19 6}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6136,11 +6136,11 @@ Pass    Pass    Pass    1C
 {HCP 7 9 18 6}
 {TP 7 9 18 7}
 {Losers 9 9 6 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -6157,11 +6157,11 @@ Pass    Pass    Pass    1C
 {HCP 9 13 14 4}
 {TP 9 14 14 5}
 {Losers 9 7 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6178,10 +6178,10 @@ Pass    Pass    Pass    1C
 {HCP 9 10 13 8}
 {TP 9 11 14 8}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6198,11 +6198,11 @@ Pass    Pass
 {HCP 9 8 13 10}
 {TP 9 9 13 10}
 {Losers 9 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6244,7 +6244,7 @@ Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 Pass    2D      Pass    Pass
 Pass    
 
@@ -6265,7 +6265,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -6283,10 +6283,10 @@ Pass    Pass    Pass
 {HCP 9 8 16 7}
 {TP 9 9 17 7}
 {Losers 8 8 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6303,11 +6303,11 @@ Pass    Pass
 {HCP 9 9 12 10}
 {TP 9 10 12 10}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6324,11 +6324,11 @@ Pass    Pass
 {HCP 9 5 20 6}
 {TP 9 6 21 7}
 {Losers 9 9 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6348,7 +6348,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2S
+1D      Pass    1N     2S
 Pass    Pass    Pass    
 
 
@@ -6365,10 +6365,10 @@ Pass    Pass    Pass
 {HCP 8 15 11 6}
 {TP 8 16 13 7}
 {Losers 9 7 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-Pass    Pass    Pass    1NT
+Pass    Pass    Pass    1N
 Pass    Pass    Pass    
 
 
@@ -6385,10 +6385,10 @@ Pass    Pass    Pass
 {HCP 9 7 13 11}
 {TP 9 8 13 11}
 {Losers 9 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6426,11 +6426,11 @@ Pass
 {HCP 9 10 14 7}
 {TP 9 11 15 8}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6447,10 +6447,10 @@ Pass
 {HCP 8 14 13 5}
 {TP 8 15 13 6}
 {Losers 8 7 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6488,11 +6488,11 @@ Pass    Pass
 {HCP 9 7 18 6}
 {TP 9 8 20 7}
 {Losers 9 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6509,11 +6509,11 @@ Pass    Pass
 {HCP 9 7 18 6}
 {TP 9 7 18 6}
 {Losers 9 10 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6530,11 +6530,11 @@ Pass    Pass
 {HCP 9 11 14 6}
 {TP 9 11 14 6}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6551,11 +6551,11 @@ Pass    Pass
 {HCP 8 9 19 4}
 {TP 8 10 19 5}
 {Losers 9 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6572,12 +6572,12 @@ Pass    Pass
 {HCP 9 10 17 4}
 {TP 9 12 18 5}
 {Losers 8 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      1S
 X       Pass    2H      2S
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6597,7 +6597,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1H      1NT
+1D      Pass    1H      1N
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -6618,7 +6618,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     2NT
+1D      Pass    1N     2N
 Pass    3H      Pass    Pass
 Pass    
 
@@ -6639,7 +6639,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 2C      2H      Pass    Pass
 Pass    
 
@@ -6702,7 +6702,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -6720,12 +6720,12 @@ Pass    Pass
 {HCP 9 8 18 5}
 {TP 9 10 19 7}
 {Losers 8 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2S      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6785,10 +6785,10 @@ Pass
 {HCP 9 10 12 9}
 {TP 9 10 12 10}
 {Losers 9 7 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6805,11 +6805,11 @@ Pass    Pass
 {HCP 9 5 19 7}
 {TP 9 5 19 7}
 {Losers 9 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6829,7 +6829,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     2D
+1D      Pass    1N     2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -6847,10 +6847,10 @@ Pass
 {HCP 9 12 14 5}
 {TP 9 12 14 6}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6888,10 +6888,10 @@ Pass    Pass
 {HCP 9 15 14 2}
 {TP 9 15 14 2}
 {Losers 9 6 7 12}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6911,7 +6911,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1S      1NT
+1C      Pass    1S      1N
 Pass    Pass    2C      Pass
 Pass    Pass    
 
@@ -6929,11 +6929,11 @@ Pass    Pass
 {HCP 9 9 12 10}
 {TP 9 9 12 10}
 {Losers 9 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6953,7 +6953,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -6971,10 +6971,10 @@ Pass    Pass
 {HCP 9 12 12 7}
 {TP 9 12 12 8}
 {Losers 9 7 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7015,7 +7015,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2D
 Pass    Pass    Pass    
 
@@ -7033,12 +7033,12 @@ Pass    Pass    Pass
 {HCP 9 5 19 7}
 {TP 9 5 21 8}
 {Losers 9 10 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7076,10 +7076,10 @@ Pass    Pass    Pass
 {HCP 7 12 14 7}
 {TP 7 12 14 7}
 {Losers 9 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7096,11 +7096,11 @@ Pass    Pass
 {HCP 7 8 18 7}
 {TP 7 10 19 7}
 {Losers 9 8 6 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -7117,11 +7117,11 @@ Pass    Pass
 {HCP 9 8 19 4}
 {TP 9 10 21 5}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7138,11 +7138,11 @@ Pass    Pass
 {HCP 9 8 18 5}
 {TP 9 8 18 5}
 {Losers 9 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7159,11 +7159,11 @@ Pass    Pass
 {HCP 8 9 19 4}
 {TP 8 10 19 5}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7183,7 +7183,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -7201,11 +7201,11 @@ Pass    Pass
 {HCP 9 7 19 5}
 {TP 9 8 21 6}
 {Losers 9 8 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7222,11 +7222,11 @@ Pass    Pass
 {HCP 7 12 18 3}
 {TP 7 12 18 4}
 {Losers 9 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7243,10 +7243,10 @@ Pass    Pass
 {HCP 9 11 13 7}
 {TP 9 12 15 7}
 {Losers 9 8 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7266,7 +7266,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -7284,11 +7284,11 @@ Pass    Pass    Pass
 {HCP 9 8 19 4}
 {TP 9 8 19 4}
 {Losers 9 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7305,11 +7305,11 @@ Pass    Pass
 {HCP 9 9 15 7}
 {TP 9 9 15 8}
 {Losers 9 10 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7326,11 +7326,11 @@ Pass    Pass
 {HCP 9 12 14 5}
 {TP 9 12 14 6}
 {Losers 9 7 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7350,7 +7350,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     2H
+1D      Pass    1N     2H
 3D      Pass    Pass    Pass
 
 
@@ -7368,11 +7368,11 @@ Pass    Pass
 {HCP 8 7 18 7}
 {TP 8 7 18 7}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7389,10 +7389,10 @@ Pass    Pass
 {HCP 9 12 14 5}
 {TP 9 12 14 6}
 {Losers 8 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7430,11 +7430,11 @@ Pass    Pass
 {HCP 9 11 13 7}
 {TP 9 13 13 8}
 {Losers 9 6 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7451,11 +7451,11 @@ Pass    Pass
 {HCP 8 8 15 9}
 {TP 8 10 17 10}
 {Losers 9 8 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7472,11 +7472,11 @@ Pass    Pass
 {HCP 9 8 14 9}
 {TP 9 9 14 10}
 {Losers 9 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7517,7 +7517,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2D
 Pass    Pass    Pass    
 
@@ -7556,11 +7556,11 @@ Pass    Pass    Pass
 {HCP 9 8 12 11}
 {TP 9 8 13 11}
 {Losers 8 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7577,12 +7577,12 @@ Pass    Pass    Pass
 {HCP 9 8 19 4}
 {TP 9 8 21 5}
 {Losers 9 10 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2S      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7602,7 +7602,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     2H
+1D      Pass    1N     2H
 3D      Pass    Pass    Pass
 
 
@@ -7683,10 +7683,10 @@ Pass    Pass
 {HCP 6 12 13 9}
 {TP 6 12 13 10}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7703,11 +7703,11 @@ Pass    Pass
 {HCP 9 6 21 4}
 {TP 9 7 21 4}
 {Losers 9 8 4 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7724,11 +7724,11 @@ Pass    Pass
 {HCP 9 4 18 9}
 {TP 9 4 18 9}
 {Losers 9 11 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7745,11 +7745,11 @@ Pass    Pass
 {HCP 9 10 12 9}
 {TP 9 11 13 9}
 {Losers 9 7 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7766,10 +7766,10 @@ Pass    Pass
 {HCP 8 8 13 11}
 {TP 8 8 13 11}
 {Losers 9 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7786,11 +7786,11 @@ Pass    Pass
 {HCP 9 5 19 7}
 {TP 9 5 19 7}
 {Losers 9 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7828,11 +7828,11 @@ Pass    Pass
 {HCP 9 6 19 6}
 {TP 9 6 19 6}
 {Losers 8 10 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7852,7 +7852,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2S      Pass    Pass
 Pass    
 
@@ -7873,7 +7873,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 Pass    
 
@@ -7916,7 +7916,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 Pass    
 
@@ -7937,7 +7937,7 @@ Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1C      X       1NT     3D
+1C      X       1N     3D
 Pass    Pass    Pass    
 
 
@@ -7954,10 +7954,10 @@ Pass    Pass    Pass
 {HCP 8 15 14 3}
 {TP 8 15 15 3}
 {Losers 9 8 6 12}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7978,7 +7978,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1D      Pass    1S      X
-XX      1NT     Pass    Pass
+XX      1N     Pass    Pass
 2D      2H      Pass    Pass
 Pass    
 
@@ -7999,7 +7999,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 Pass    2H      Pass    Pass
 Pass    
 
@@ -8017,12 +8017,12 @@ Pass
 {HCP 9 7 16 8}
 {TP 9 8 18 8}
 {Losers 9 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1S      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8039,10 +8039,10 @@ Pass    Pass
 {HCP 9 11 12 8}
 {TP 9 11 12 8}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8062,7 +8062,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -8080,11 +8080,11 @@ Pass    Pass
 {HCP 8 8 17 7}
 {TP 8 8 20 9}
 {Losers 9 10 4 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8101,10 +8101,10 @@ Pass    Pass
 {HCP 9 10 13 8}
 {TP 9 10 14 8}
 {Losers 9 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8121,11 +8121,11 @@ Pass    Pass
 {HCP 9 1 19 11}
 {TP 9 1 19 11}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8145,7 +8145,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 2C      2H      Pass    Pass
 Pass    
 
@@ -8163,11 +8163,11 @@ Pass
 {HCP 8 9 19 4}
 {TP 8 9 19 6}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8184,10 +8184,10 @@ Pass    Pass
 {HCP 7 10 13 10}
 {TP 7 10 14 10}
 {Losers 9 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8204,11 +8204,11 @@ Pass    Pass
 {HCP 9 6 14 11}
 {TP 9 7 14 11}
 {Losers 9 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8225,11 +8225,11 @@ Pass    Pass
 {HCP 9 6 14 11}
 {TP 9 7 14 11}
 {Losers 9 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8249,7 +8249,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2C
+1D      Pass    1N     2C
 2D      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -8270,7 +8270,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    3D      Pass    Pass
 Pass    
 
@@ -8288,10 +8288,10 @@ Pass
 {HCP 9 11 12 8}
 {TP 9 11 13 8}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8311,7 +8311,7 @@ Pass    Pass
 [Contract "2HX"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 Pass    2H      Pass    Pass
 X       Pass    Pass    Pass
 
@@ -8330,11 +8330,11 @@ X       Pass    Pass    Pass
 {HCP 9 10 13 8}
 {TP 9 10 13 9}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8351,10 +8351,10 @@ X       Pass    Pass    Pass
 {HCP 9 11 14 6}
 {TP 9 11 14 6}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8371,11 +8371,11 @@ Pass    Pass
 {HCP 7 9 18 6}
 {TP 7 12 18 8}
 {Losers 9 7 5 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -8414,11 +8414,11 @@ Pass    Pass    X       Pass
 {HCP 9 10 14 7}
 {TP 9 10 15 7}
 {Losers 9 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8435,11 +8435,11 @@ Pass    Pass
 {HCP 8 9 14 9}
 {TP 8 9 16 9}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8477,10 +8477,10 @@ Pass    Pass
 {HCP 7 17 13 3}
 {TP 7 17 13 4}
 {Losers 9 7 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8500,7 +8500,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -8521,7 +8521,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -8543,7 +8543,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    2S
+1N     Pass    Pass    2S
 Pass    3D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -8566,7 +8566,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2H      Pass    3D
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
@@ -8585,11 +8585,11 @@ Pass    Pass    Pass
 {HCP 9 8 14 9}
 {TP 9 9 14 10}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8606,11 +8606,11 @@ Pass    Pass    Pass
 {HCP 9 12 14 5}
 {TP 9 12 15 5}
 {Losers 9 9 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8627,11 +8627,11 @@ Pass    Pass    Pass
 {HCP 8 13 12 7}
 {TP 8 13 12 8}
 {Losers 9 7 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8648,11 +8648,11 @@ Pass    Pass    Pass
 {HCP 9 5 19 7}
 {TP 9 6 19 8}
 {Losers 9 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8736,7 +8736,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2C
+1D      Pass    1N     2C
 Pass    Pass    Pass    
 
 
@@ -8798,7 +8798,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1H      1NT
+1C      Pass    1H      1N
 Pass    Pass    2C      Pass
 Pass    Pass    
 
@@ -8840,7 +8840,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -8858,11 +8858,11 @@ Pass    Pass
 {HCP 9 5 18 8}
 {TP 9 6 18 9}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8879,11 +8879,11 @@ Pass    Pass
 {HCP 8 7 18 7}
 {TP 8 7 18 7}
 {Losers 9 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8903,7 +8903,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -8924,7 +8924,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -8967,7 +8967,7 @@ Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2D
 Pass    Pass    Pass    
 
@@ -8988,7 +8988,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2S
+1C      Pass    1N     2S
 Pass    Pass    Pass    
 
 
@@ -9029,7 +9029,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -9050,7 +9050,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -9068,10 +9068,10 @@ Pass    Pass    Pass
 {HCP 9 10 13 8}
 {TP 9 10 13 8}
 {Losers 9 10 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -9091,7 +9091,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2H
 Pass    Pass    Pass    
 
@@ -9154,7 +9154,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2S
+1C      Pass    1N     2S
 Pass    Pass    Pass    
 
 
@@ -9171,10 +9171,10 @@ Pass    Pass    Pass
 {HCP 9 10 13 8}
 {TP 9 10 14 8}
 {Losers 9 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -9212,11 +9212,11 @@ Pass    Pass
 {HCP 8 11 17 4}
 {TP 8 12 19 4}
 {Losers 9 7 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9254,11 +9254,11 @@ Pass    Pass
 {HCP 9 5 16 10}
 {TP 9 7 17 11}
 {Losers 8 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3C      Pass    3NT     Pass
+1C      Pass    1N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9275,11 +9275,11 @@ Pass    Pass
 {HCP 7 9 14 10}
 {TP 7 10 14 11}
 {Losers 9 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9299,7 +9299,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1S      2NT
+1C      Pass    1S      2N
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9317,10 +9317,10 @@ Pass    Pass
 {HCP 9 10 12 9}
 {TP 9 10 12 10}
 {Losers 8 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -9337,11 +9337,11 @@ Pass    Pass
 {HCP 9 14 12 5}
 {TP 9 14 12 5}
 {Losers 9 8 8 11}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9358,11 +9358,11 @@ Pass    Pass
 {HCP 8 9 16 7}
 {TP 8 11 17 8}
 {Losers 9 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9421,10 +9421,10 @@ Pass    Pass    Pass
 {HCP 9 10 12 9}
 {TP 9 10 12 10}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -9444,7 +9444,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 Pass    
 
@@ -9504,11 +9504,11 @@ Pass    Pass
 {HCP 8 13 12 7}
 {TP 8 13 12 8}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9550,7 +9550,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 2H      Pass    Pass    Pass
 
 
@@ -9592,7 +9592,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -9613,7 +9613,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -9652,11 +9652,11 @@ Pass    Pass
 {HCP 9 4 18 9}
 {TP 9 5 18 9}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9676,7 +9676,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1S      1NT
+1D      Pass    1S      1N
 Pass    2D      Pass    2H
 Pass    Pass    Pass    
 
@@ -9741,7 +9741,7 @@ Pass    Pass    X       Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    X
+1N     Pass    Pass    X
 Pass    Pass    2D      Pass
 Pass    Pass    
 
@@ -9762,7 +9762,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 Pass    2D      Pass    Pass
 Pass    
 
@@ -9780,11 +9780,11 @@ Pass
 {HCP 7 6 18 9}
 {TP 7 6 20 9}
 {Losers 9 11 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9801,11 +9801,11 @@ Pass
 {HCP 9 11 17 3}
 {TP 9 11 17 4}
 {Losers 9 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1D      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9843,11 +9843,11 @@ Pass
 {HCP 8 5 18 9}
 {TP 8 6 18 9}
 {Losers 9 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9867,7 +9867,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     3D
+1C      Pass    1N     3D
 Pass    Pass    Pass    
 
 
@@ -9884,11 +9884,11 @@ Pass    Pass    Pass
 {HCP 9 11 12 8}
 {TP 9 12 12 8}
 {Losers 9 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -9905,11 +9905,11 @@ Pass    Pass
 {HCP 9 5 19 7}
 {TP 9 6 20 7}
 {Losers 9 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9947,11 +9947,11 @@ Pass    Pass
 {HCP 7 16 13 4}
 {TP 7 16 13 4}
 {Losers 9 7 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -10010,11 +10010,11 @@ Pass    Pass    Pass
 {HCP 9 9 13 9}
 {TP 9 10 13 10}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -10115,11 +10115,11 @@ Pass    Pass
 {HCP 7 8 18 7}
 {TP 7 8 18 7}
 {Losers 9 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10136,11 +10136,11 @@ Pass    Pass
 {HCP 9 8 19 4}
 {TP 9 9 21 4}
 {Losers 9 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10157,11 +10157,11 @@ Pass    Pass
 {HCP 9 12 12 7}
 {TP 9 12 12 8}
 {Losers 9 7 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -10198,11 +10198,11 @@ Pass    Pass    Pass
 {HCP 9 9 17 5}
 {TP 9 11 17 6}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1D      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10219,11 +10219,11 @@ Pass    Pass
 {HCP 8 12 14 6}
 {TP 8 12 16 9}
 {Losers 9 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10240,12 +10240,12 @@ Pass    Pass
 {HCP 8 9 18 5}
 {TP 8 11 20 7}
 {Losers 9 7 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10284,11 +10284,11 @@ Pass    2H      Pass    Pass
 {HCP 9 7 18 6}
 {TP 9 7 18 6}
 {Losers 9 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10347,11 +10347,11 @@ Pass    Pass    Pass
 {HCP 9 7 18 6}
 {TP 9 8 18 7}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10389,12 +10389,12 @@ Pass    Pass
 {HCP 9 12 13 6}
 {TP 9 12 13 6}
 {Losers 9 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    2S
-Pass    3C      Pass    3NT
+1N     Pass    Pass    2S
+Pass    3C      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -10435,7 +10435,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -10453,11 +10453,11 @@ Pass    Pass    Pass
 {HCP 8 8 19 5}
 {TP 8 8 19 6}
 {Losers 9 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10474,10 +10474,10 @@ Pass    Pass    Pass
 {HCP 8 6 19 7}
 {TP 8 7 20 7}
 {Losers 9 10 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 

--- a/GIB/1m-1_2_or_3_NT.pbn
+++ b/GIB/1m-1_2_or_3_NT.pbn
@@ -12,12 +12,12 @@
 {HCP 8 9 19 4}
 {TP 8 10 21 4}
 {Losers 9 8 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -38,7 +38,7 @@
 [Declarer "E"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    Pass    Pass    
 
 
@@ -55,10 +55,10 @@ Pass    Pass    Pass
 {HCP 8 10 13 9}
 {TP 8 10 13 9}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -75,12 +75,12 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 7 13 7}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -100,7 +100,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -122,7 +122,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2C      Pass    2D      Pass
 2S      Pass    Pass    Pass
 
@@ -162,11 +162,11 @@ Pass    Pass    Pass
 {HCP 13 7 12 8}
 {TP 13 8 12 9}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -183,11 +183,11 @@ Pass    Pass
 {HCP 8 12 14 6}
 {TP 8 12 14 6}
 {Losers 9 8 7 11}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -207,7 +207,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    2D
 Pass    Pass    Pass    
 
@@ -225,13 +225,13 @@ Pass    Pass    Pass
 {HCP 15 11 10 4}
 {TP 15 11 13 5}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -248,12 +248,12 @@ Pass    Pass
 {HCP 14 6 14 6}
 {TP 14 6 15 8}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -270,11 +270,11 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 11 14 2}
 {Losers 7 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -334,12 +334,12 @@ Pass    Pass    1D      Pass
 {HCP 12 5 13 10}
 {TP 12 7 14 10}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -381,7 +381,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    Pass    1C      X
-2NT     Pass    3C      X
+2N     Pass    3C      X
 Pass    3S      Pass    Pass
 Pass    
 
@@ -399,11 +399,11 @@ Pass
 {HCP 7 9 13 11}
 {TP 7 11 15 11}
 {Losers 9 7 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -423,8 +423,8 @@ Pass    Pass
 [Contract "6C"]
 [Declarer "S"]
 [Auction "S"]
-2C      Pass    2NT     Pass
-3C      Pass    4NT     Pass
+2C      Pass    2N     Pass
+3C      Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -445,7 +445,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 Pass    
 
@@ -463,10 +463,10 @@ Pass
 {HCP 9 7 14 10}
 {TP 9 9 15 10}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -507,7 +507,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2S
+1D      Pass    1N     2S
 Pass    Pass    Pass    
 
 
@@ -527,7 +527,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 2C      2S      Pass    Pass
 Pass    
 
@@ -545,10 +545,10 @@ Pass
 {HCP 14 9 12 5}
 {TP 14 10 13 5}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -565,11 +565,11 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 11 13 4}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -586,10 +586,10 @@ Pass    Pass
 {HCP 9 10 14 7}
 {TP 9 11 14 9}
 {Losers 9 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -606,11 +606,11 @@ Pass    Pass
 {HCP 9 7 14 10}
 {TP 9 8 15 10}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -648,11 +648,11 @@ Pass    Pass
 {HCP 13 4 14 9}
 {TP 13 5 14 9}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -669,11 +669,11 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 7 14 6}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -693,7 +693,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1S      1NT
+1C      Pass    1S      1N
 Pass    Pass    2C      Pass
 Pass    Pass    
 
@@ -714,7 +714,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 X       Pass    3D      Pass
 Pass    Pass    
@@ -733,11 +733,11 @@ Pass    Pass
 {HCP 8 10 12 10}
 {TP 8 10 12 10}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -754,11 +754,11 @@ Pass    Pass
 {HCP 13 4 12 11}
 {TP 13 5 13 12}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      X       XX      1H
-Pass    2H      3NT     Pass
+Pass    2H      3N     Pass
 Pass    Pass    
 
 
@@ -775,10 +775,10 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 14 11 13 4}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -795,10 +795,10 @@ Pass    Pass
 {HCP 8 18 13 1}
 {TP 8 18 13 3}
 {Losers 9 6 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -815,10 +815,10 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 8 12 6}
 {Losers 7 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -838,7 +838,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -856,11 +856,11 @@ Pass    Pass
 {HCP 15 0 14 11}
 {TP 15 1 14 12}
 {Losers 7 11 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      1S      2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -965,7 +965,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2S
+1C      Pass    1N     2S
 Pass    3S      Pass    Pass
 Pass    
 
@@ -983,10 +983,10 @@ Pass
 {HCP 15 8 12 5}
 {TP 15 9 13 5}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1003,11 +1003,11 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 12 13 6}
 {Losers 8 6 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1024,11 +1024,11 @@ Pass    Pass
 {HCP 7 19 14 0}
 {TP 7 19 14 1}
 {Losers 9 6 8 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     X
-Pass    2C      Pass    2NT
+1D      Pass    1N     X
+Pass    2C      Pass    2N
 Pass    Pass    Pass    
 
 
@@ -1045,11 +1045,11 @@ Pass    Pass    Pass
 {HCP 13 13 13 1}
 {TP 13 13 13 2}
 {Losers 8 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1066,12 +1066,12 @@ Pass    Pass
 {HCP 12 6 17 5}
 {TP 12 7 18 5}
 {Losers 8 10 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2C      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1088,12 +1088,12 @@ Pass    Pass
 {HCP 15 7 11 7}
 {TP 15 7 12 7}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1132,11 +1132,11 @@ Pass    Pass    1NT     Pass
 {HCP 15 10 14 1}
 {TP 15 11 16 3}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1153,10 +1153,10 @@ Pass    Pass
 {HCP 15 10 11 4}
 {TP 15 11 12 6}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1173,12 +1173,12 @@ Pass    Pass
 {HCP 7 9 19 5}
 {TP 7 10 20 6}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 3C      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1281,12 +1281,12 @@ Pass    Pass    X       Pass
 {HCP 15 11 11 3}
 {TP 15 13 15 4}
 {Losers 7 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      2H
 Pass    Pass    X       Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1324,11 +1324,11 @@ Pass    Pass
 {HCP 13 6 14 7}
 {TP 13 6 14 8}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1345,10 +1345,10 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 6 16 6}
 {Losers 8 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1368,7 +1368,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2H
 Pass    Pass    Pass    
 
@@ -1386,11 +1386,11 @@ Pass    Pass    Pass
 {HCP 13 11 14 2}
 {TP 13 11 14 4}
 {Losers 7 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1407,11 +1407,11 @@ Pass    Pass
 {HCP 9 7 13 11}
 {TP 9 7 13 11}
 {Losers 9 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1431,7 +1431,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -1452,7 +1452,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -1470,11 +1470,11 @@ Pass    Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 7 12 7}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1494,7 +1494,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2H
+1D      Pass    1N     2H
 Pass    Pass    Pass    
 
 
@@ -1532,11 +1532,11 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 13 11 13 6}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      2C
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1574,11 +1574,11 @@ Pass
 {HCP 14 6 13 7}
 {TP 14 6 13 8}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1598,7 +1598,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2H
+1C      Pass    1N     2H
 Pass    Pass    Pass    
 
 
@@ -1615,12 +1615,12 @@ Pass    Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 8 13 4}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1659,10 +1659,10 @@ Pass    Pass
 {HCP 15 11 12 2}
 {TP 15 12 13 4}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1679,11 +1679,11 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 15 9 13 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1721,11 +1721,11 @@ Pass    Pass    1C      Pass
 {HCP 15 6 12 7}
 {TP 15 6 13 8}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1762,11 +1762,11 @@ Pass    Pass    Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 8 14 7}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1805,12 +1805,12 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 14 7 14 8}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1827,12 +1827,12 @@ Pass    Pass
 {HCP 9 7 17 7}
 {TP 9 8 18 8}
 {Losers 9 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1853,7 +1853,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1C      X
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 Pass    Pass    
 
 
@@ -1895,7 +1895,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2H
 Pass    Pass    Pass    
 
@@ -1913,10 +1913,10 @@ Pass    Pass    Pass
 {HCP 8 12 14 6}
 {TP 8 12 14 6}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -1933,10 +1933,10 @@ Pass    Pass
 {HCP 9 11 12 8}
 {TP 9 11 12 9}
 {Losers 9 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -1956,7 +1956,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     2H
+1D      Pass    1N     2H
 3D      Pass    Pass    Pass
 
 
@@ -1974,11 +1974,11 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 13 9 14 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2037,11 +2037,11 @@ Pass    Pass
 {HCP 13 7 14 6}
 {TP 13 10 14 7}
 {Losers 8 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2058,11 +2058,11 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 15 9 13 5}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2083,7 +2083,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-3D      Pass    4NT     Pass
+3D      Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -2101,10 +2101,10 @@ Pass    Pass
 {HCP 9 13 14 4}
 {TP 9 14 14 5}
 {Losers 9 7 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2144,13 +2144,13 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 7 14 9}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2167,10 +2167,10 @@ Pass    Pass
 {HCP 14 9 14 3}
 {TP 14 9 15 3}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2187,10 +2187,10 @@ Pass    Pass
 {HCP 8 12 14 6}
 {TP 8 12 14 7}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2228,11 +2228,11 @@ Pass    Pass
 {HCP 9 10 14 7}
 {TP 9 11 14 7}
 {Losers 9 9 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2269,12 +2269,12 @@ Pass    Pass    Pass    Pass
 {HCP 13 6 11 10}
 {TP 13 8 12 11}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1D      Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2291,11 +2291,11 @@ Pass    Pass    1D      Pass
 {HCP 13 3 13 11}
 {TP 13 4 13 11}
 {Losers 8 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2312,11 +2312,11 @@ Pass    Pass
 {HCP 9 7 13 11}
 {TP 9 7 13 11}
 {Losers 9 10 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2333,10 +2333,10 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 7 14 7}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2374,11 +2374,11 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 8 12 7}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2400,7 +2400,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2H      Pass    3D      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -2418,11 +2418,11 @@ Pass    Pass
 {HCP 13 15 11 1}
 {TP 13 16 14 2}
 {Losers 8 5 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      2D
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2442,7 +2442,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -2460,11 +2460,11 @@ Pass    Pass
 {HCP 15 5 12 8}
 {TP 15 6 12 8}
 {Losers 7 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2481,14 +2481,14 @@ Pass    Pass
 {HCP 9 10 18 3}
 {TP 9 12 19 3}
 {Losers 9 7 5 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      X
 XX      1S      Pass    Pass
 2D      Pass    2H      Pass
-2S      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2S      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2547,10 +2547,10 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 10 12 4}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2567,12 +2567,12 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 14 6 14 9}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2589,10 +2589,10 @@ Pass    Pass
 {HCP 15 4 14 7}
 {TP 15 5 15 8}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2633,7 +2633,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -2674,7 +2674,7 @@ Pass    Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    Pass    Pass    
 
 
@@ -2691,10 +2691,10 @@ Pass    Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 8 14 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2711,10 +2711,10 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 8 14 6}
 {Losers 7 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2731,11 +2731,11 @@ Pass    Pass
 {HCP 9 13 13 5}
 {TP 9 13 13 6}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2755,7 +2755,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
 2H      Pass    Pass    Pass
 
@@ -2777,7 +2777,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2H
 Pass    Pass    Pass    
 
@@ -2795,11 +2795,11 @@ Pass    Pass    Pass
 {HCP 13 6 12 9}
 {TP 13 7 13 9}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2816,11 +2816,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 13 9 15 6}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2837,11 +2837,11 @@ Pass    Pass
 {HCP 13 13 11 3}
 {TP 13 16 12 3}
 {Losers 8 5 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      2C
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2861,7 +2861,7 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -2900,11 +2900,11 @@ Pass    Pass
 {HCP 14 4 18 4}
 {TP 14 5 18 6}
 {Losers 8 10 6 9}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -2921,11 +2921,11 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 14 5 15 7}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2942,11 +2942,11 @@ Pass    Pass
 {HCP 8 11 20 1}
 {TP 8 11 20 3}
 {Losers 9 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-3D      Pass    3NT     Pass
+1D      Pass    1N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2963,10 +2963,10 @@ Pass    Pass
 {HCP 9 9 13 9}
 {TP 9 10 13 9}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3004,11 +3004,11 @@ Pass    Pass
 {HCP 12 11 12 5}
 {TP 12 12 12 6}
 {Losers 8 8 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3025,10 +3025,10 @@ Pass    Pass
 {HCP 15 10 12 3}
 {TP 15 12 12 5}
 {Losers 7 7 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3045,10 +3045,10 @@ Pass    Pass
 {HCP 13 8 13 6}
 {TP 13 9 14 6}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3107,12 +3107,12 @@ Pass    Pass
 {HCP 14 11 11 4}
 {TP 14 11 11 4}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1C      Pass
-1H      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1H      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3129,12 +3129,12 @@ Pass    Pass
 {HCP 8 7 15 10}
 {TP 8 9 17 10}
 {Losers 9 7 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3151,11 +3151,11 @@ Pass    Pass
 {HCP 8 8 19 5}
 {TP 8 10 19 7}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3172,10 +3172,10 @@ Pass    Pass
 {HCP 14 12 12 2}
 {TP 14 14 14 3}
 {Losers 8 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3192,10 +3192,10 @@ Pass    Pass
 {HCP 7 10 12 11}
 {TP 7 11 12 11}
 {Losers 9 9 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3215,7 +3215,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
@@ -3234,10 +3234,10 @@ Pass    Pass
 {HCP 15 12 11 2}
 {TP 15 14 13 4}
 {Losers 8 6 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3254,10 +3254,10 @@ Pass    Pass
 {HCP 7 12 14 7}
 {TP 7 12 15 8}
 {Losers 9 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3274,10 +3274,10 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 10 13 2}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3294,12 +3294,12 @@ Pass    Pass
 {HCP 14 9 11 6}
 {TP 14 11 12 8}
 {Losers 8 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1C      Pass
 1H      Pass    1S      3C
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3316,10 +3316,10 @@ Pass    Pass
 {HCP 9 13 12 6}
 {TP 9 13 12 6}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3357,11 +3357,11 @@ Pass    Pass
 {HCP 8 6 19 7}
 {TP 8 8 19 7}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3378,10 +3378,10 @@ Pass    Pass
 {HCP 15 3 12 10}
 {TP 15 4 14 11}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3398,11 +3398,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 8 13 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3481,11 +3481,11 @@ Pass    Pass
 {HCP 15 8 10 7}
 {TP 15 8 11 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+Pass    Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3505,7 +3505,7 @@ Pass    Pass    1NT     Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -3527,7 +3527,7 @@ Pass    Pass    1NT     Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -3545,11 +3545,11 @@ Pass    Pass    1NT     Pass
 {HCP 8 6 19 7}
 {TP 8 6 19 7}
 {Losers 9 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3566,12 +3566,12 @@ Pass    Pass    1NT     Pass
 {HCP 14 3 12 11}
 {TP 14 5 14 11}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3588,10 +3588,10 @@ Pass    Pass
 {HCP 14 12 12 2}
 {TP 14 12 12 2}
 {Losers 8 7 9 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3608,11 +3608,11 @@ Pass    Pass
 {HCP 8 12 14 6}
 {TP 8 12 15 7}
 {Losers 9 8 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3629,11 +3629,11 @@ Pass    Pass
 {HCP 9 12 14 5}
 {TP 9 12 14 5}
 {Losers 9 8 7 11}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3650,11 +3650,11 @@ Pass    Pass
 {HCP 9 5 18 8}
 {TP 9 5 19 8}
 {Losers 9 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3671,10 +3671,10 @@ Pass    Pass
 {HCP 13 3 16 8}
 {TP 13 5 18 8}
 {Losers 8 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3734,11 +3734,11 @@ X       3S      Pass    Pass
 {HCP 9 7 13 11}
 {TP 9 8 13 11}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3755,12 +3755,12 @@ X       3S      Pass    Pass
 {HCP 12 9 14 5}
 {TP 12 10 15 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3780,7 +3780,7 @@ X       3S      Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -3822,7 +3822,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 Pass    
 
@@ -3840,13 +3840,13 @@ Pass
 {HCP 14 7 12 7}
 {TP 14 7 12 8}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3863,10 +3863,10 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 11 13 4}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3883,12 +3883,12 @@ Pass    Pass
 {HCP 15 13 11 1}
 {TP 15 13 12 2}
 {Losers 8 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3908,7 +3908,7 @@ Pass    Pass    1NT     Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2C
 Pass    Pass    2D      Pass
 3C      Pass    3D      Pass
@@ -3928,12 +3928,12 @@ Pass    Pass
 {HCP 9 12 18 1}
 {TP 9 12 19 2}
 {Losers 9 7 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2H      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3950,10 +3950,10 @@ Pass    Pass
 {HCP 13 6 11 10}
 {TP 13 7 13 10}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3970,11 +3970,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 7 13 6}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3991,11 +3991,11 @@ Pass    Pass
 {HCP 8 13 13 6}
 {TP 8 13 13 6}
 {Losers 9 7 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4054,13 +4054,13 @@ Pass    Pass    Pass
 {HCP 13 7 13 7}
 {TP 13 8 15 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4098,11 +4098,11 @@ Pass    Pass    Pass
 {HCP 8 12 12 8}
 {TP 8 12 13 9}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4119,11 +4119,11 @@ Pass    Pass    Pass
 {HCP 12 6 18 4}
 {TP 12 6 18 5}
 {Losers 8 11 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4140,10 +4140,10 @@ Pass    Pass
 {HCP 9 16 12 3}
 {TP 9 16 13 5}
 {Losers 9 7 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4160,11 +4160,11 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 15 9 12 6}
 {Losers 7 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4181,10 +4181,10 @@ Pass    Pass
 {HCP 14 2 14 10}
 {TP 14 3 14 10}
 {Losers 7 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4201,11 +4201,11 @@ Pass    Pass
 {HCP 9 9 12 10}
 {TP 9 10 12 10}
 {Losers 9 7 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4222,13 +4222,13 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 7 13 6}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4245,11 +4245,11 @@ Pass    Pass
 {HCP 9 10 14 7}
 {TP 9 10 14 7}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4270,7 +4270,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1C      1D
-1H      Pass    1NT     2S
+1H      Pass    1N     2S
 3C      Pass    Pass    Pass
 
 
@@ -4288,10 +4288,10 @@ Pass    Pass    1C      1D
 {HCP 14 13 12 1}
 {TP 14 13 14 2}
 {Losers 8 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4352,11 +4352,11 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 6 13 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4378,7 +4378,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1C      Pass
 1H      Pass    1S      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -4438,11 +4438,11 @@ Pass    Pass    X       Pass
 {HCP 9 7 18 6}
 {TP 9 9 18 6}
 {Losers 9 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1D      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4459,10 +4459,10 @@ Pass    Pass
 {HCP 9 8 12 11}
 {TP 9 9 12 11}
 {Losers 8 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4479,13 +4479,13 @@ Pass    Pass
 {HCP 15 9 14 2}
 {TP 15 11 15 3}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4502,12 +4502,12 @@ Pass    Pass
 {HCP 14 10 11 5}
 {TP 14 11 14 6}
 {Losers 8 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4524,10 +4524,10 @@ Pass    Pass
 {HCP 14 8 16 2}
 {TP 14 9 18 2}
 {Losers 7 8 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4544,11 +4544,11 @@ Pass    Pass
 {HCP 9 8 12 11}
 {TP 9 8 12 11}
 {Losers 8 10 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4565,12 +4565,12 @@ Pass    Pass
 {HCP 14 11 12 3}
 {TP 14 11 13 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4587,10 +4587,10 @@ Pass    Pass
 {HCP 14 5 15 6}
 {TP 14 7 17 6}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4607,12 +4607,12 @@ Pass    Pass
 {HCP 13 9 11 7}
 {TP 13 10 12 7}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4629,11 +4629,11 @@ Pass    Pass
 {HCP 15 5 14 6}
 {TP 15 5 14 6}
 {Losers 7 11 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4650,10 +4650,10 @@ Pass    Pass
 {HCP 6 16 11 7}
 {TP 6 16 12 7}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-Pass    Pass    Pass    1NT
+Pass    Pass    Pass    1N
 Pass    Pass    Pass    
 
 
@@ -4670,10 +4670,10 @@ Pass    Pass    Pass
 {HCP 9 11 14 6}
 {TP 9 11 14 6}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4711,11 +4711,11 @@ Pass
 {HCP 15 0 14 11}
 {TP 15 2 15 12}
 {Losers 8 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      X       XX      1H
-Pass    2H      3NT     Pass
+Pass    2H      3N     Pass
 Pass    Pass    
 
 
@@ -4753,12 +4753,12 @@ Pass    Pass
 {HCP 14 9 11 6}
 {TP 14 9 11 6}
 {Losers 8 8 9 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1C      Pass
 1D      Pass    1H      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -4775,11 +4775,11 @@ Pass    Pass    1C      Pass
 {HCP 14 6 12 8}
 {TP 14 6 12 8}
 {Losers 8 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4796,11 +4796,11 @@ Pass    Pass
 {HCP 8 9 20 3}
 {TP 8 11 20 4}
 {Losers 9 8 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4817,11 +4817,11 @@ Pass    Pass
 {HCP 15 7 13 5}
 {TP 15 8 13 6}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4859,10 +4859,10 @@ Pass    Pass
 {HCP 9 14 12 5}
 {TP 9 14 12 6}
 {Losers 9 7 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4882,7 +4882,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -4900,10 +4900,10 @@ Pass    Pass
 {HCP 9 11 14 6}
 {TP 9 11 15 7}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4942,12 +4942,12 @@ Pass
 {HCP 9 9 19 3}
 {TP 9 10 21 5}
 {Losers 9 8 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2S      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4968,7 +4968,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -4986,10 +4986,10 @@ Pass    Pass
 {HCP 14 12 12 2}
 {TP 14 14 14 4}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5006,11 +5006,11 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 8 14 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5027,11 +5027,11 @@ Pass    Pass
 {HCP 13 7 13 7}
 {TP 13 8 13 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5048,10 +5048,10 @@ Pass    Pass
 {HCP 9 8 12 11}
 {TP 9 8 12 12}
 {Losers 9 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -5071,7 +5071,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 2C      2S      Pass    Pass
 Pass    
 
@@ -5110,11 +5110,11 @@ Pass    Pass
 {HCP 12 13 13 2}
 {TP 12 13 13 2}
 {Losers 8 7 8 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5131,11 +5131,11 @@ Pass    Pass
 {HCP 13 9 12 6}
 {TP 13 9 12 6}
 {Losers 8 9 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5152,12 +5152,12 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 14 11 13 5}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5174,10 +5174,10 @@ Pass    Pass
 {HCP 12 8 12 8}
 {TP 12 9 13 8}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5198,7 +5198,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    Pass    Pass    
 
 
@@ -5215,11 +5215,11 @@ Pass    Pass    Pass
 {HCP 12 8 12 8}
 {TP 12 8 12 9}
 {Losers 8 10 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5236,10 +5236,10 @@ Pass    Pass
 {HCP 11 13 12 4}
 {TP 11 13 12 6}
 {Losers 8 8 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5277,11 +5277,11 @@ Pass
 {HCP 14 3 13 10}
 {TP 14 3 14 11}
 {Losers 8 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5319,10 +5319,10 @@ Pass    Pass    Pass
 {HCP 15 8 14 3}
 {TP 15 10 14 5}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5339,11 +5339,11 @@ Pass    Pass
 {HCP 9 10 19 2}
 {TP 9 11 19 2}
 {Losers 9 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5360,10 +5360,10 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 9 13 7}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5404,7 +5404,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -5422,11 +5422,11 @@ Pass    Pass
 {HCP 15 8 11 6}
 {TP 15 8 11 6}
 {Losers 7 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+Pass    Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5443,11 +5443,11 @@ Pass    Pass    1NT     Pass
 {HCP 8 8 17 7}
 {TP 8 8 17 9}
 {Losers 9 9 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5464,11 +5464,11 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 14 10 13 5}
 {Losers 8 8 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5509,7 +5509,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 Pass    2S      Pass    Pass
 Pass    
 
@@ -5527,10 +5527,10 @@ Pass
 {HCP 9 16 12 3}
 {TP 9 16 12 5}
 {Losers 9 7 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -5547,11 +5547,11 @@ Pass    Pass
 {HCP 9 14 16 1}
 {TP 9 14 19 2}
 {Losers 9 7 4 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     2S
-3C      Pass    3NT     Pass
+1C      Pass    1N     2S
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5571,7 +5571,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 Pass    2D      Pass    Pass
 Pass    
 
@@ -5589,10 +5589,10 @@ Pass
 {HCP 9 10 13 8}
 {TP 9 10 13 8}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -5609,11 +5609,11 @@ Pass    Pass
 {HCP 14 5 12 9}
 {TP 14 5 13 9}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5651,11 +5651,11 @@ Pass    Pass
 {HCP 9 14 13 4}
 {TP 9 15 14 4}
 {Losers 8 8 7 11}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5672,10 +5672,10 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 7 12 9}
 {Losers 7 9 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5713,12 +5713,12 @@ Pass    Pass    1C      Pass
 {HCP 15 6 14 5}
 {TP 15 6 15 5}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5735,11 +5735,11 @@ Pass    Pass
 {HCP 12 1 18 9}
 {TP 12 2 18 9}
 {Losers 8 11 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5799,12 +5799,12 @@ Pass    Pass
 {HCP 8 12 18 2}
 {TP 8 13 19 3}
 {Losers 9 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 2H      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5824,7 +5824,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    Pass    Pass    
 
 
@@ -5844,7 +5844,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2D
 Pass    Pass    Pass    
 
@@ -5884,11 +5884,11 @@ Pass    Pass    Pass
 {HCP 7 8 18 7}
 {TP 7 9 18 8}
 {Losers 9 9 5 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -5947,13 +5947,13 @@ Pass    Pass
 {HCP 8 6 16 10}
 {TP 8 6 18 10}
 {Losers 9 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5970,10 +5970,10 @@ Pass    Pass
 {HCP 14 11 14 1}
 {TP 14 13 14 3}
 {Losers 7 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5990,11 +5990,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 9 13 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6014,7 +6014,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -6032,11 +6032,11 @@ Pass    Pass
 {HCP 15 9 13 3}
 {TP 15 11 13 3}
 {Losers 8 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6073,11 +6073,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 9 14 8}
 {TP 9 11 16 9}
 {Losers 9 7 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6094,11 +6094,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 11 13 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6136,11 +6136,11 @@ Pass    Pass
 {HCP 9 12 14 5}
 {TP 9 12 14 5}
 {Losers 9 7 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6157,11 +6157,11 @@ Pass    Pass
 {HCP 15 0 19 6}
 {TP 15 2 19 7}
 {Losers 8 10 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1D      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -6181,7 +6181,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    Pass    Pass    
 
 
@@ -6198,11 +6198,11 @@ Pass    Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 8 12 7}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6219,11 +6219,11 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 14 7 16 7}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6240,11 +6240,11 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 8 12 6}
 {Losers 7 9 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6282,10 +6282,10 @@ Pass
 {HCP 7 10 13 10}
 {TP 7 10 14 10}
 {Losers 9 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6305,7 +6305,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2D
 Pass    Pass    Pass    
 
@@ -6323,10 +6323,10 @@ Pass    Pass    Pass
 {HCP 8 12 13 7}
 {TP 8 13 13 9}
 {Losers 9 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6365,10 +6365,10 @@ Pass    Pass
 {HCP 8 10 14 8}
 {TP 8 11 14 8}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6385,11 +6385,11 @@ Pass    Pass
 {HCP 9 6 19 6}
 {TP 9 6 19 6}
 {Losers 9 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6451,7 +6451,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     2D
+1D      Pass    1N     2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -6469,11 +6469,11 @@ Pass
 {HCP 14 4 18 4}
 {TP 14 4 18 5}
 {Losers 8 11 5 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -6490,10 +6490,10 @@ Pass
 {HCP 15 7 13 5}
 {TP 15 8 13 5}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6513,7 +6513,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    X       Pass    2C
 Pass    Pass    2D      Pass
 Pass    Pass    
@@ -6535,7 +6535,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2D
+1C      Pass    1N     2D
 Pass    Pass    Pass    
 
 
@@ -6552,10 +6552,10 @@ Pass    Pass    Pass
 {HCP 8 12 13 7}
 {TP 8 12 14 8}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6572,10 +6572,10 @@ Pass    Pass
 {HCP 14 10 13 3}
 {TP 14 11 13 4}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6592,12 +6592,12 @@ Pass    Pass
 {HCP 15 12 11 2}
 {TP 15 14 12 3}
 {Losers 8 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6617,7 +6617,7 @@ Pass    Pass    1NT     Pass
 [Contract "2DX"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 2C      2D      Pass    Pass
 X       Pass    Pass    Pass
 
@@ -6657,10 +6657,10 @@ X       Pass    Pass    Pass
 {HCP 8 11 13 8}
 {TP 8 11 14 8}
 {Losers 9 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6677,12 +6677,12 @@ Pass    Pass
 {HCP 15 2 19 4}
 {TP 15 3 19 6}
 {Losers 7 10 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    4C      Pass
-4S      Pass    6NT     Pass
+2N     Pass    4C      Pass
+4S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -6699,10 +6699,10 @@ Pass    Pass
 {HCP 9 11 13 7}
 {TP 9 12 14 8}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6740,10 +6740,10 @@ Pass    Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 8 13 8}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6760,10 +6760,10 @@ Pass    Pass
 {HCP 15 3 14 8}
 {TP 15 3 14 8}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6826,7 +6826,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 5C      Pass    6C      Pass
 Pass    Pass    
 
@@ -6844,11 +6844,11 @@ Pass    Pass
 {HCP 8 6 19 7}
 {TP 8 7 19 8}
 {Losers 9 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6865,12 +6865,12 @@ Pass    Pass
 {HCP 13 1 16 10}
 {TP 13 2 17 10}
 {Losers 8 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6887,12 +6887,12 @@ Pass    Pass
 {HCP 9 6 20 5}
 {TP 9 6 22 6}
 {Losers 9 10 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 3C      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6909,11 +6909,11 @@ Pass    Pass
 {HCP 9 11 13 7}
 {TP 9 12 13 7}
 {Losers 9 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6930,11 +6930,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 9 15 6}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6951,10 +6951,10 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 12 8 13 9}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6971,11 +6971,11 @@ Pass    Pass
 {HCP 8 14 18 0}
 {TP 8 15 18 2}
 {Losers 9 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     2H
-2NT     Pass    3NT     Pass
+1C      Pass    1N     2H
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6992,10 +6992,10 @@ Pass    Pass
 {HCP 7 11 14 8}
 {TP 7 11 15 9}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7034,11 +7034,11 @@ Pass    Pass
 {HCP 8 14 14 4}
 {TP 8 14 14 4}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7055,10 +7055,10 @@ Pass    Pass
 {HCP 8 12 13 7}
 {TP 8 13 13 7}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -7138,11 +7138,11 @@ Pass    Pass
 {HCP 13 8 16 3}
 {TP 13 9 18 4}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7159,11 +7159,11 @@ Pass    Pass
 {HCP 12 4 14 10}
 {TP 12 5 14 10}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7180,11 +7180,11 @@ Pass    Pass
 {HCP 15 7 14 4}
 {TP 15 8 14 5}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7225,7 +7225,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1H      1NT
+1D      Pass    1H      1N
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -7243,11 +7243,11 @@ Pass    Pass
 {HCP 7 17 12 4}
 {TP 7 18 12 5}
 {Losers 9 6 9 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7267,7 +7267,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2D
 Pass    Pass    Pass    
 
@@ -7285,11 +7285,11 @@ Pass    Pass    Pass
 {HCP 12 4 17 7}
 {TP 12 6 19 7}
 {Losers 8 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7327,11 +7327,11 @@ Pass    Pass
 {HCP 13 6 14 7}
 {TP 13 7 16 7}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7348,11 +7348,11 @@ Pass    Pass
 {HCP 13 10 13 4}
 {TP 13 10 13 5}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7369,10 +7369,10 @@ Pass    Pass
 {HCP 14 4 13 9}
 {TP 14 4 13 9}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7389,13 +7389,13 @@ Pass    Pass
 {HCP 14 10 13 3}
 {TP 14 10 14 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7412,11 +7412,11 @@ Pass    Pass
 {HCP 14 12 12 2}
 {TP 14 12 12 4}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7433,11 +7433,11 @@ Pass    Pass
 {HCP 15 5 14 6}
 {TP 15 6 14 6}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7454,11 +7454,11 @@ Pass    Pass
 {HCP 13 12 11 4}
 {TP 13 12 13 5}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      2H
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7475,11 +7475,11 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 9 12 6}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7560,11 +7560,11 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 6 13 7}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7581,10 +7581,10 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 13 7 12 8}
 {Losers 8 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7601,10 +7601,10 @@ Pass    Pass
 {HCP 13 8 13 6}
 {TP 13 8 13 7}
 {Losers 8 8 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7621,13 +7621,13 @@ Pass    Pass
 {HCP 13 8 11 8}
 {TP 13 10 13 9}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
 2S      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7644,11 +7644,11 @@ Pass    Pass
 {HCP 14 3 13 10}
 {TP 14 4 13 10}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7668,7 +7668,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
 2H      Pass    3D      Pass
 Pass    Pass    
@@ -7687,11 +7687,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 8 13 5}
 {Losers 7 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7708,12 +7708,12 @@ Pass    Pass
 {HCP 14 3 14 9}
 {TP 14 4 14 10}
 {Losers 7 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7730,11 +7730,11 @@ Pass    Pass
 {HCP 15 3 12 10}
 {TP 15 3 13 10}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7751,11 +7751,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 9 13 7}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7772,10 +7772,10 @@ Pass    Pass
 {HCP 15 10 12 3}
 {TP 15 12 12 3}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7795,7 +7795,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     2H
+1C      Pass    1N     2H
 Pass    Pass    Pass    
 
 
@@ -7812,10 +7812,10 @@ Pass    Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 10 13 6}
 {Losers 8 7 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7853,10 +7853,10 @@ Pass    Pass
 {HCP 14 8 14 4}
 {TP 14 10 14 6}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7873,11 +7873,11 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 9 14 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7894,11 +7894,11 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 11 13 6}
 {Losers 8 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      1S
-X       2S      3NT     Pass
+X       2S      3N     Pass
 Pass    Pass    
 
 
@@ -7915,11 +7915,11 @@ Pass    Pass
 {HCP 8 17 14 1}
 {TP 8 17 16 2}
 {Losers 9 6 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1S      1NT
-3D      Pass    3NT     Pass
+1D      Pass    1S      1N
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7936,10 +7936,10 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 8 15 8}
 {Losers 7 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7956,11 +7956,11 @@ Pass    Pass
 {HCP 14 10 14 2}
 {TP 14 11 14 2}
 {Losers 7 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7980,7 +7980,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 Pass    2H      Pass    3C
 Pass    3D      Pass    3H
 Pass    4H      Pass    Pass
@@ -8003,7 +8003,7 @@ Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -8021,11 +8021,11 @@ Pass
 {HCP 9 10 14 7}
 {TP 9 10 14 8}
 {Losers 9 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8045,7 +8045,7 @@ Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    1NT     2C
+1D      Pass    1N     2C
 Pass    Pass    Pass    
 
 
@@ -8062,11 +8062,11 @@ Pass    Pass    Pass
 {HCP 8 9 13 10}
 {TP 8 10 13 11}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8083,11 +8083,11 @@ Pass    Pass    Pass
 {HCP 12 10 11 7}
 {TP 12 11 12 7}
 {Losers 8 8 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -8107,7 +8107,7 @@ Pass    Pass    1D      Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     2H
+1D      Pass    1N     2H
 3H      Pass    4D      Pass
 5D      Pass    Pass    Pass
 
@@ -8126,13 +8126,13 @@ Pass    Pass    1D      Pass
 {HCP 15 6 13 6}
 {TP 15 8 14 9}
 {Losers 8 8 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
 2S      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8149,11 +8149,11 @@ Pass    Pass
 {HCP 9 11 13 7}
 {TP 9 11 13 9}
 {Losers 8 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8170,11 +8170,11 @@ Pass    Pass
 {HCP 15 12 10 3}
 {TP 15 12 12 3}
 {Losers 8 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      X
-Pass    2D      3NT     Pass
+Pass    2D      3N     Pass
 Pass    Pass    
 
 
@@ -8191,12 +8191,12 @@ Pass    Pass
 {HCP 15 4 19 2}
 {TP 15 5 19 3}
 {Losers 8 9 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    4C      Pass
-4H      Pass    6NT     Pass
+2N     Pass    4C      Pass
+4H      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -8213,11 +8213,11 @@ Pass    Pass
 {HCP 14 11 12 3}
 {TP 14 14 12 5}
 {Losers 7 6 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8237,7 +8237,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    2H
 3D      Pass    Pass    Pass
 
@@ -8259,7 +8259,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -8277,11 +8277,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 13 9 15 6}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8298,12 +8298,12 @@ Pass    Pass
 {HCP 15 4 15 6}
 {TP 15 5 16 7}
 {Losers 8 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8320,11 +8320,11 @@ Pass    Pass
 {HCP 9 13 11 7}
 {TP 9 13 11 9}
 {Losers 9 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -8341,10 +8341,10 @@ Pass    Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 7 13 6}
 {Losers 8 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8382,10 +8382,10 @@ Pass    Pass
 {HCP 14 15 10 1}
 {TP 14 15 11 2}
 {Losers 8 6 8 11}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "S"]
-Pass    Pass    1D      1NT
+Pass    Pass    1D      1N
 X       Pass    Pass    Pass
 
 
@@ -8403,11 +8403,11 @@ X       Pass    Pass    Pass
 {HCP 14 10 11 5}
 {TP 14 11 12 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8445,11 +8445,11 @@ Pass    Pass
 {HCP 8 13 12 7}
 {TP 8 14 12 8}
 {Losers 9 7 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8487,12 +8487,12 @@ Pass    Pass
 {HCP 9 6 16 9}
 {TP 9 7 18 9}
 {Losers 9 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2H      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8574,11 +8574,11 @@ Pass    Pass    X       Pass
 {HCP 9 9 19 3}
 {TP 9 9 19 5}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8595,10 +8595,10 @@ Pass    Pass
 {HCP 9 17 12 2}
 {TP 9 17 12 3}
 {Losers 9 6 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8615,10 +8615,10 @@ Pass    Pass
 {HCP 9 14 12 5}
 {TP 9 14 12 5}
 {Losers 9 6 9 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8638,7 +8638,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    X       Pass    2S
 Pass    Pass    Pass    
 
@@ -8656,13 +8656,13 @@ Pass    Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 8 13 4}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8679,11 +8679,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 10 12 4}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8741,10 +8741,10 @@ Pass    Pass    Pass
 {HCP 9 10 12 9}
 {TP 9 12 12 9}
 {Losers 9 7 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8761,11 +8761,11 @@ Pass    Pass
 {HCP 8 10 12 10}
 {TP 8 11 12 10}
 {Losers 9 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8803,10 +8803,10 @@ Pass    Pass
 {HCP 15 7 15 3}
 {TP 15 8 16 4}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8826,7 +8826,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -8844,12 +8844,12 @@ Pass    Pass
 {HCP 13 1 19 7}
 {TP 13 2 19 8}
 {Losers 8 11 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+2N     Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -8866,10 +8866,10 @@ Pass    Pass
 {HCP 13 11 14 2}
 {TP 13 11 14 3}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8886,11 +8886,11 @@ Pass    Pass
 {HCP 15 5 19 1}
 {TP 15 5 19 2}
 {Losers 7 10 6 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -8931,7 +8931,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-Pass    Pass    Pass    1NT
+Pass    Pass    Pass    1N
 2C      Pass    2D      Pass
 3C      Pass    Pass    Pass
 
@@ -8971,12 +8971,12 @@ Pass    Pass    Pass    1NT
 {HCP 15 9 11 5}
 {TP 15 9 11 7}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+Pass    Pass    1N     Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8993,10 +8993,10 @@ Pass    Pass    1NT     Pass
 {HCP 13 8 14 5}
 {TP 13 9 14 5}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9037,7 +9037,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 Pass    2S      Pass    Pass
 Pass    
 
@@ -9055,10 +9055,10 @@ Pass
 {HCP 14 6 13 7}
 {TP 14 7 13 8}
 {Losers 7 8 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9079,7 +9079,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -9097,11 +9097,11 @@ Pass    Pass
 {HCP 13 4 14 9}
 {TP 13 4 14 9}
 {Losers 8 11 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9118,10 +9118,10 @@ Pass    Pass
 {HCP 15 9 13 3}
 {TP 15 9 13 3}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9138,11 +9138,11 @@ Pass    Pass
 {HCP 12 13 12 3}
 {TP 12 14 13 4}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      2C
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9179,12 +9179,12 @@ Pass    Pass    Pass
 {HCP 14 9 11 6}
 {TP 14 9 13 6}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-1H      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1H      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9201,10 +9201,10 @@ Pass    Pass
 {HCP 13 9 12 6}
 {TP 13 9 12 6}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9221,11 +9221,11 @@ Pass    Pass
 {HCP 14 4 14 8}
 {TP 14 5 14 8}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9242,11 +9242,11 @@ Pass    Pass
 {HCP 8 6 18 8}
 {TP 8 8 18 8}
 {Losers 9 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9263,12 +9263,12 @@ Pass    Pass
 {HCP 13 6 17 4}
 {TP 13 6 19 5}
 {Losers 8 10 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9288,7 +9288,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 Pass    
 
@@ -9306,12 +9306,12 @@ Pass
 {HCP 14 10 11 5}
 {TP 14 12 13 6}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9328,11 +9328,11 @@ Pass    Pass
 {HCP 14 3 14 9}
 {TP 14 4 14 10}
 {Losers 8 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9349,12 +9349,12 @@ Pass    Pass
 {HCP 15 10 11 4}
 {TP 15 11 12 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 2C      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9371,10 +9371,10 @@ Pass    Pass    1NT     Pass
 {HCP 15 8 12 5}
 {TP 15 10 14 5}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9391,10 +9391,10 @@ Pass    Pass
 {HCP 14 4 14 8}
 {TP 14 4 14 8}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9415,7 +9415,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    Pass    1C      1S
-2S      X       2NT     Pass
+2S      X       2N     Pass
 3D      Pass    Pass    3S
 Pass    Pass    Pass    
 
@@ -9456,7 +9456,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -9517,11 +9517,11 @@ Pass    Pass
 {HCP 13 14 13 0}
 {TP 13 15 13 0}
 {Losers 8 6 8 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9541,7 +9541,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1NT     X
+1C      Pass    1N     X
 2C      2S      Pass    Pass
 Pass    
 
@@ -9559,12 +9559,12 @@ Pass
 {HCP 14 9 11 6}
 {TP 14 11 12 6}
 {Losers 8 6 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1D      1H
 X       3H      Pass    Pass
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9581,12 +9581,12 @@ Pass    Pass
 {HCP 15 7 14 4}
 {TP 15 8 16 5}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9606,7 +9606,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1H      1NT
+1C      Pass    1H      1N
 Pass    Pass    2C      Pass
 Pass    Pass    
 
@@ -9645,10 +9645,10 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 12 15 5}
 {Losers 8 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9665,11 +9665,11 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 10 12 8}
 {Losers 8 8 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      3C
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9686,11 +9686,11 @@ Pass    Pass
 {HCP 8 9 18 5}
 {TP 8 10 18 6}
 {Losers 9 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9731,7 +9731,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 4D      Pass    5D      Pass
 Pass    Pass    
 
@@ -9753,7 +9753,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-3D      Pass    4NT     Pass
+3D      Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -9771,13 +9771,13 @@ Pass    Pass
 {HCP 13 10 12 5}
 {TP 13 10 12 6}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9797,7 +9797,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -9818,7 +9818,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      Pass    1NT     X
+1D      Pass    1N     X
 2D      2H      Pass    Pass
 Pass    
 
@@ -9857,10 +9857,10 @@ Pass
 {HCP 15 7 13 5}
 {TP 15 7 13 5}
 {Losers 8 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9919,13 +9919,13 @@ Pass
 {HCP 13 5 13 9}
 {TP 13 7 13 10}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3C      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3C      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9942,11 +9942,11 @@ Pass
 {HCP 14 7 12 7}
 {TP 14 10 13 8}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      3C
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9963,11 +9963,11 @@ Pass    Pass
 {HCP 15 1 14 10}
 {TP 15 3 14 10}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9984,11 +9984,11 @@ Pass    Pass
 {HCP 9 9 18 4}
 {TP 9 11 19 5}
 {Losers 9 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      3D
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10009,8 +10009,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-3C      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+3C      Pass    4N     Pass
+5D      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -10028,10 +10028,10 @@ Pass    Pass
 {HCP 9 11 13 7}
 {TP 9 12 13 7}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -10090,11 +10090,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 9 13 4}
 {Losers 7 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10111,10 +10111,10 @@ Pass    Pass
 {HCP 9 9 12 10}
 {TP 9 9 12 11}
 {Losers 9 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -10131,12 +10131,12 @@ Pass    Pass
 {HCP 13 11 12 4}
 {TP 13 13 13 5}
 {Losers 8 5 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      2D
 Pass    Pass    X       3D
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10156,7 +10156,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    1NT     Pass
+1D      Pass    1N     Pass
 2D      Pass    Pass    Pass
 
 
@@ -10174,11 +10174,11 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 10 13 5}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10195,11 +10195,11 @@ Pass    Pass
 {HCP 9 11 12 8}
 {TP 9 11 13 8}
 {Losers 8 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -10237,12 +10237,12 @@ Pass    Pass
 {HCP 9 11 15 5}
 {TP 9 12 17 5}
 {Losers 9 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10259,10 +10259,10 @@ Pass    Pass
 {HCP 9 10 16 5}
 {TP 9 11 17 6}
 {Losers 9 8 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -10279,11 +10279,11 @@ Pass    Pass
 {HCP 8 10 13 9}
 {TP 8 10 13 10}
 {Losers 9 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -10300,10 +10300,10 @@ Pass    Pass
 {HCP 15 6 15 4}
 {TP 15 7 16 6}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10320,11 +10320,11 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 11 13 6}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10341,11 +10341,11 @@ Pass    Pass
 {HCP 15 2 12 11}
 {TP 15 2 13 11}
 {Losers 8 12 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10362,11 +10362,11 @@ Pass    Pass
 {HCP 13 6 13 8}
 {TP 13 7 13 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10383,11 +10383,11 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 9 14 6}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10430,7 +10430,7 @@ Pass    Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-2NT     Pass    3D      Pass
+2N     Pass    3D      Pass
 4D      Pass    5D      Pass
 Pass    Pass    
 
@@ -10448,13 +10448,13 @@ Pass    Pass
 {HCP 14 8 14 4}
 {TP 14 10 14 5}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10471,11 +10471,11 @@ Pass    Pass
 {HCP 15 7 14 4}
 {TP 15 7 14 5}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10492,11 +10492,11 @@ Pass    Pass
 {HCP 9 9 18 4}
 {TP 9 10 18 6}
 {Losers 9 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10513,9 +10513,9 @@ Pass    Pass
 {HCP 14 6 12 8}
 {TP 14 6 13 8}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 

--- a/GIB/1m-2N_forced.pbn
+++ b/GIB/1m-2N_forced.pbn
@@ -12,11 +12,11 @@
 {HCP 12 2 18 8}
 {TP 12 2 18 8}
 {Losers 8 11 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -33,10 +33,10 @@ Pass    Pass
 {HCP 11 11 12 6}
 {TP 11 13 14 8}
 {Losers 8 7 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -53,11 +53,11 @@ Pass    Pass
 {HCP 11 9 15 5}
 {TP 11 12 17 6}
 {Losers 8 6 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -74,11 +74,11 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 10 15 9}
 {Losers 8 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -95,11 +95,11 @@ Pass    Pass
 {HCP 12 5 12 11}
 {TP 12 6 12 11}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -116,11 +116,11 @@ Pass    Pass
 {HCP 12 13 14 1}
 {TP 12 13 15 2}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -137,11 +137,11 @@ Pass    Pass
 {HCP 11 7 14 8}
 {TP 11 8 15 9}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -158,10 +158,10 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 9 12 8}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -178,11 +178,11 @@ Pass    Pass
 {HCP 12 9 14 5}
 {TP 12 9 14 6}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -199,10 +199,10 @@ Pass    Pass
 {HCP 12 12 12 4}
 {TP 12 12 13 5}
 {Losers 8 8 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -222,7 +222,7 @@ Pass    Pass
 [Contract "3CX"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    2NT     3C
+1D      Pass    2N     3C
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -240,10 +240,10 @@ Pass    Pass
 {HCP 12 14 12 2}
 {TP 12 15 12 2}
 {Losers 8 7 8 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -263,7 +263,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    2NT     3H
+1C      Pass    2N     3H
 Pass    Pass    Pass    
 
 
@@ -280,11 +280,11 @@ Pass    Pass    Pass
 {HCP 12 5 19 4}
 {TP 12 5 19 4}
 {Losers 8 11 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -301,10 +301,10 @@ Pass    Pass    Pass
 {HCP 12 11 12 5}
 {TP 12 11 12 6}
 {Losers 8 8 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -321,10 +321,10 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 12 7 12 9}
 {Losers 8 10 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -344,7 +344,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    2NT     3H
+1C      Pass    2N     3H
 Pass    Pass    Pass    
 
 
@@ -364,7 +364,7 @@ Pass    Pass    Pass
 [Contract "4C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    2NT     3S
+1C      Pass    2N     3S
 4C      Pass    Pass    Pass
 
 
@@ -382,11 +382,11 @@ Pass    Pass    Pass
 {HCP 12 10 14 4}
 {TP 12 11 14 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -403,11 +403,11 @@ Pass    Pass    Pass
 {HCP 12 5 18 5}
 {TP 12 5 19 5}
 {Losers 8 10 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3S      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -424,10 +424,10 @@ Pass    Pass
 {HCP 12 8 12 8}
 {TP 12 9 13 9}
 {Losers 8 8 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -444,10 +444,10 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 12 8 12 9}
 {Losers 8 10 9 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -467,7 +467,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    2NT     3S
+1C      Pass    2N     3S
 4C      Pass    Pass    Pass
 
 
@@ -485,11 +485,11 @@ Pass    Pass
 {HCP 12 10 14 4}
 {TP 12 12 16 4}
 {Losers 8 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3S      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -509,7 +509,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    2NT     3H
+1C      Pass    2N     3H
 4C      Pass    Pass    Pass
 
 
@@ -527,11 +527,11 @@ Pass    Pass
 {HCP 11 11 17 1}
 {TP 11 11 18 3}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -548,11 +548,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 9 13 7}
 {Losers 8 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -572,7 +572,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     3H
+1D      Pass    2N     3H
 4D      Pass    Pass    Pass
 
 
@@ -590,10 +590,10 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 10 12 7}
 {Losers 8 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -610,11 +610,11 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 8 14 7}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -631,11 +631,11 @@ Pass    Pass
 {HCP 12 9 18 1}
 {TP 12 9 18 2}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -652,10 +652,10 @@ Pass    Pass
 {HCP 12 11 12 5}
 {TP 12 11 12 6}
 {Losers 8 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -672,10 +672,10 @@ Pass    Pass
 {HCP 12 16 12 0}
 {TP 12 17 13 1}
 {Losers 8 6 8 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -692,11 +692,11 @@ Pass    Pass
 {HCP 12 12 13 3}
 {TP 12 12 14 5}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -713,10 +713,10 @@ Pass    Pass
 {HCP 12 12 12 4}
 {TP 12 12 12 4}
 {Losers 8 9 7 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -733,11 +733,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 8 13 7}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -754,11 +754,11 @@ Pass    Pass
 {HCP 12 5 14 9}
 {TP 12 6 14 9}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -775,10 +775,10 @@ Pass    Pass
 {HCP 12 10 12 6}
 {TP 12 10 13 8}
 {Losers 8 8 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -798,7 +798,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    2NT     3C
+1D      Pass    2N     3C
 Pass    Pass    Pass    
 
 
@@ -815,11 +815,11 @@ Pass    Pass    Pass
 {HCP 12 4 13 11}
 {TP 12 5 14 11}
 {Losers 8 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -836,11 +836,11 @@ Pass    Pass    Pass
 {HCP 12 4 17 7}
 {TP 12 5 17 7}
 {Losers 8 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -857,10 +857,10 @@ Pass    Pass
 {HCP 11 8 12 9}
 {TP 11 8 12 9}
 {Losers 8 9 9 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -877,11 +877,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 9 13 8}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -898,11 +898,11 @@ Pass    Pass
 {HCP 11 12 13 4}
 {TP 11 15 13 6}
 {Losers 8 5 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     3H
-3NT     Pass    Pass    Pass
+1D      Pass    2N     3H
+3N     Pass    Pass    Pass
 
 
 
@@ -919,11 +919,11 @@ Pass    Pass
 {HCP 12 5 19 4}
 {TP 12 5 19 4}
 {Losers 8 10 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -940,11 +940,11 @@ Pass    Pass
 {HCP 12 6 19 3}
 {TP 12 7 19 3}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -961,11 +961,11 @@ Pass    Pass
 {HCP 12 10 14 4}
 {TP 12 11 14 6}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -982,11 +982,11 @@ Pass    Pass
 {HCP 12 11 14 3}
 {TP 12 12 14 4}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1006,7 +1006,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -1024,10 +1024,10 @@ Pass    Pass
 {HCP 12 5 13 10}
 {TP 12 6 14 10}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 

--- a/GIB/1m-2N_freebid.pbn
+++ b/GIB/1m-2N_freebid.pbn
@@ -12,11 +12,11 @@
 {HCP 12 3 18 7}
 {TP 12 4 19 7}
 {Losers 8 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -33,11 +33,11 @@ Pass    Pass
 {HCP 12 11 13 4}
 {TP 12 11 13 5}
 {Losers 8 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -54,12 +54,12 @@ Pass    Pass
 {HCP 12 5 13 10}
 {TP 12 7 14 10}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -76,11 +76,11 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 12 13 6}
 {Losers 8 6 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -97,12 +97,12 @@ Pass    Pass
 {HCP 12 6 17 5}
 {TP 12 7 18 5}
 {Losers 8 10 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2C      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -119,11 +119,11 @@ Pass    Pass
 {HCP 12 11 12 5}
 {TP 12 12 12 6}
 {Losers 8 8 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -140,12 +140,12 @@ Pass    Pass
 {HCP 12 9 14 5}
 {TP 12 10 15 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -162,11 +162,11 @@ Pass    Pass
 {HCP 12 6 18 4}
 {TP 12 6 18 5}
 {Losers 8 11 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -205,11 +205,11 @@ Pass    Pass    X       Pass
 {HCP 12 7 14 7}
 {TP 12 8 14 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -226,11 +226,11 @@ Pass    Pass    X       Pass
 {HCP 12 13 13 2}
 {TP 12 13 13 2}
 {Losers 8 7 8 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -247,10 +247,10 @@ Pass    Pass    X       Pass
 {HCP 12 8 12 8}
 {TP 12 9 13 8}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -267,11 +267,11 @@ Pass    Pass
 {HCP 12 8 12 8}
 {TP 12 8 12 9}
 {Losers 8 10 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -288,10 +288,10 @@ Pass    Pass
 {HCP 11 13 12 4}
 {TP 11 13 12 6}
 {Losers 8 8 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -308,11 +308,11 @@ Pass    Pass
 {HCP 12 1 18 9}
 {TP 12 2 18 9}
 {Losers 8 11 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -372,10 +372,10 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 12 8 13 9}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -392,11 +392,11 @@ Pass    Pass
 {HCP 12 4 14 10}
 {TP 12 5 14 10}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -413,11 +413,11 @@ Pass    Pass
 {HCP 12 4 17 7}
 {TP 12 6 19 7}
 {Losers 8 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -434,11 +434,11 @@ Pass    Pass
 {HCP 12 10 11 7}
 {TP 12 11 12 7}
 {Losers 8 8 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -455,11 +455,11 @@ Pass    Pass    1D      Pass
 {HCP 12 13 12 3}
 {TP 12 14 13 4}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      2C
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -476,11 +476,11 @@ Pass    Pass
 {HCP 12 13 12 3}
 {TP 12 13 12 5}
 {Losers 8 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -497,11 +497,11 @@ Pass    Pass
 {HCP 11 6 18 5}
 {TP 11 6 18 5}
 {Losers 8 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -518,11 +518,11 @@ Pass    Pass
 {HCP 11 8 14 7}
 {TP 11 11 15 9}
 {Losers 8 6 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -539,11 +539,11 @@ Pass    Pass
 {HCP 12 6 13 9}
 {TP 12 6 13 10}
 {Losers 8 11 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -560,11 +560,11 @@ Pass    Pass
 {HCP 11 7 12 10}
 {TP 11 8 12 11}
 {Losers 8 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -581,11 +581,11 @@ Pass    Pass
 {HCP 12 11 14 3}
 {TP 12 11 14 4}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -647,11 +647,11 @@ Pass    Pass
 {HCP 11 6 13 10}
 {TP 11 7 13 11}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -689,11 +689,11 @@ Pass    Pass    1C      Pass
 {HCP 12 10 14 4}
 {TP 12 11 14 6}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -710,11 +710,11 @@ Pass    Pass    1C      Pass
 {HCP 12 6 13 9}
 {TP 12 7 13 9}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -756,7 +756,7 @@ Pass    Pass    1C      Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     3S
+1D      Pass    2N     3S
 4D      Pass    5D      Pass
 Pass    Pass    
 
@@ -796,11 +796,11 @@ Pass    Pass
 {HCP 12 9 18 1}
 {TP 12 9 18 2}
 {Losers 8 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -817,11 +817,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 8 13 7}
 {Losers 8 10 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -859,11 +859,11 @@ Pass    Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 8 13 7}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -901,11 +901,11 @@ Pass    Pass
 {HCP 12 5 14 9}
 {TP 12 6 14 10}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -922,11 +922,11 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 11 13 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -943,11 +943,11 @@ Pass    Pass
 {HCP 11 11 14 4}
 {TP 11 11 14 4}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -964,11 +964,11 @@ Pass    Pass
 {HCP 12 7 19 2}
 {TP 12 10 21 3}
 {Losers 8 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -985,11 +985,11 @@ Pass    Pass
 {HCP 12 9 16 3}
 {TP 12 10 17 4}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1006,11 +1006,11 @@ Pass    Pass
 {HCP 12 10 17 1}
 {TP 12 11 19 3}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1027,10 +1027,10 @@ Pass    Pass
 {HCP 12 11 12 5}
 {TP 12 12 12 5}
 {Losers 8 8 8 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1047,10 +1047,10 @@ Pass    Pass
 {HCP 11 12 12 5}
 {TP 11 14 12 5}
 {Losers 8 6 8 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1093,7 +1093,7 @@ Pass    Pass    X       Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -1111,11 +1111,11 @@ Pass    Pass    X       Pass
 {HCP 12 6 17 5}
 {TP 12 7 17 7}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1154,10 +1154,10 @@ Pass    Pass
 {HCP 11 10 12 7}
 {TP 11 10 12 7}
 {Losers 8 9 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1174,11 +1174,11 @@ Pass    Pass
 {HCP 11 8 12 9}
 {TP 11 9 13 10}
 {Losers 8 8 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1195,11 +1195,11 @@ Pass    Pass
 {HCP 12 5 18 5}
 {TP 12 5 20 7}
 {Losers 8 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1238,11 +1238,11 @@ Pass    Pass
 {HCP 12 7 19 2}
 {TP 12 7 19 3}
 {Losers 8 10 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1259,11 +1259,11 @@ Pass    Pass
 {HCP 12 6 13 9}
 {TP 12 7 13 9}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1280,11 +1280,11 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 7 15 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1305,7 +1305,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      1S
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -1323,11 +1323,11 @@ Pass    Pass
 {HCP 12 9 13 6}
 {TP 12 12 15 7}
 {Losers 8 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1344,11 +1344,11 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 12 7 12 9}
 {Losers 8 10 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1365,11 +1365,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 8 14 7}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1407,10 +1407,10 @@ Pass    Pass
 {HCP 12 13 12 3}
 {TP 12 13 12 4}
 {Losers 8 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1427,11 +1427,11 @@ Pass    Pass
 {HCP 12 7 13 8}
 {TP 12 7 13 8}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1448,11 +1448,11 @@ Pass    Pass
 {HCP 11 13 12 4}
 {TP 11 13 12 6}
 {Losers 8 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1469,12 +1469,12 @@ Pass    Pass
 {HCP 12 13 11 4}
 {TP 12 13 12 4}
 {Losers 8 7 7 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1C      X
-1S      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1S      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -1491,12 +1491,12 @@ Pass    Pass    1C      X
 {HCP 12 8 14 6}
 {TP 12 9 16 7}
 {Losers 8 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1513,10 +1513,10 @@ Pass    Pass
 {HCP 12 5 12 11}
 {TP 12 7 13 11}
 {Losers 8 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1557,7 +1557,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     3S
+1D      Pass    2N     3S
 4D      Pass    5D      Pass
 Pass    Pass    
 
@@ -1575,11 +1575,11 @@ Pass    Pass
 {HCP 11 9 13 7}
 {TP 11 11 15 8}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1596,11 +1596,11 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 10 12 8}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1617,12 +1617,12 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 10 14 6}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1639,11 +1639,11 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 12 7 12 10}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1664,7 +1664,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -1682,11 +1682,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 8 13 7}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1703,10 +1703,10 @@ Pass    Pass
 {HCP 11 6 12 11}
 {TP 11 7 12 11}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1723,12 +1723,12 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 11 14 6}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1748,7 +1748,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    2NT     3H
+1D      Pass    2N     3H
 Pass    Pass    Pass    
 
 
@@ -1765,11 +1765,11 @@ Pass    Pass    Pass
 {HCP 12 5 12 11}
 {TP 12 6 12 11}
 {Losers 8 10 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1808,10 +1808,10 @@ Pass    Pass
 {HCP 11 8 12 9}
 {TP 11 9 12 9}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1832,7 +1832,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -1872,11 +1872,11 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 12 7 13 11}
 {Losers 8 9 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1916,11 +1916,11 @@ Pass    Pass    2S      Pass
 {HCP 12 12 14 2}
 {TP 12 12 14 3}
 {Losers 8 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1937,11 +1937,11 @@ Pass    Pass    2S      Pass
 {HCP 12 13 12 3}
 {TP 12 15 12 4}
 {Losers 8 6 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      X
-XX      2D      3NT     Pass
+XX      2D      3N     Pass
 Pass    Pass    
 
 
@@ -1958,12 +1958,12 @@ Pass    Pass
 {HCP 11 8 18 3}
 {TP 11 10 18 3}
 {Losers 8 7 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1980,11 +1980,11 @@ Pass    Pass
 {HCP 12 11 13 4}
 {TP 12 11 13 4}
 {Losers 8 9 8 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2001,12 +2001,12 @@ Pass    Pass
 {HCP 12 10 11 7}
 {TP 12 11 12 8}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1C      Pass
-1D      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2023,11 +2023,11 @@ Pass    Pass    1C      Pass
 {HCP 12 6 12 10}
 {TP 12 7 13 10}
 {Losers 8 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2044,12 +2044,12 @@ Pass    Pass
 {HCP 11 10 14 5}
 {TP 11 12 14 6}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      1S
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2066,11 +2066,11 @@ Pass    Pass
 {HCP 12 11 12 5}
 {TP 12 11 12 5}
 {Losers 8 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2087,12 +2087,12 @@ Pass    Pass
 {HCP 12 11 13 4}
 {TP 12 14 15 6}
 {Losers 8 5 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      2C
-X       Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+X       Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2109,11 +2109,11 @@ X       Pass    2NT     Pass
 {HCP 12 11 13 4}
 {TP 12 11 13 5}
 {Losers 8 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2130,11 +2130,11 @@ Pass    Pass
 {HCP 12 8 11 9}
 {TP 12 9 12 9}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -2151,11 +2151,11 @@ Pass    Pass    1D      Pass
 {HCP 12 11 13 4}
 {TP 12 11 13 5}
 {Losers 8 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2172,12 +2172,12 @@ Pass    Pass
 {HCP 12 4 17 7}
 {TP 12 4 17 8}
 {Losers 8 11 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2194,11 +2194,11 @@ Pass    Pass
 {HCP 11 5 14 10}
 {TP 11 7 14 10}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2237,10 +2237,10 @@ Pass    Pass
 {HCP 12 12 12 4}
 {TP 12 12 12 5}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2260,7 +2260,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -2278,11 +2278,11 @@ Pass    Pass
 {HCP 12 6 18 4}
 {TP 12 6 18 6}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2326,7 +2326,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2344,12 +2344,12 @@ Pass    Pass
 {HCP 11 10 14 5}
 {TP 11 10 15 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2366,11 +2366,11 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 11 12 8}
 {Losers 8 8 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2387,11 +2387,11 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 8 14 7}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2412,7 +2412,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    Pass    1C      1D
-2D      Pass    2NT     3D
+2D      Pass    2N     3D
 Pass    Pass    Pass    
 
 
@@ -2429,11 +2429,11 @@ Pass    Pass    Pass
 {HCP 11 10 14 5}
 {TP 11 10 14 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2453,8 +2453,8 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-Pass    Pass    1C      1NT
-2NT     Pass    3C      Pass
+Pass    Pass    1C      1N
+2N     Pass    3C      Pass
 3H      Pass    Pass    Pass
 
 
@@ -2472,12 +2472,12 @@ Pass    Pass    1C      1NT
 {HCP 11 6 14 9}
 {TP 11 7 14 9}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2494,11 +2494,11 @@ Pass    Pass    1C      1NT
 {HCP 12 9 13 6}
 {TP 12 10 13 6}
 {Losers 8 8 8 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2537,11 +2537,11 @@ Pass    Pass
 {HCP 12 6 11 11}
 {TP 12 7 13 11}
 {Losers 8 9 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2558,11 +2558,11 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 8 14 9}
 {Losers 8 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2579,11 +2579,11 @@ Pass    Pass
 {HCP 12 7 18 3}
 {TP 12 8 18 3}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2600,11 +2600,11 @@ Pass    Pass
 {HCP 12 5 12 11}
 {TP 12 5 13 11}
 {Losers 8 11 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2621,12 +2621,12 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 7 15 7}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2643,12 +2643,12 @@ Pass    Pass
 {HCP 11 9 14 6}
 {TP 11 11 16 8}
 {Losers 8 7 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      2H
 X       3H      Pass    Pass
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2669,7 +2669,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -2709,11 +2709,11 @@ Pass    Pass
 {HCP 12 5 12 11}
 {TP 12 6 13 12}
 {Losers 8 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      X       XX      1H
-Pass    2H      3NT     Pass
+Pass    2H      3N     Pass
 Pass    Pass    
 
 
@@ -2730,11 +2730,11 @@ Pass    Pass
 {HCP 12 12 13 3}
 {TP 12 14 14 3}
 {Losers 8 6 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      X
-Pass    2H      3NT     Pass
+Pass    2H      3N     Pass
 Pass    Pass    
 
 
@@ -2751,11 +2751,11 @@ Pass    Pass
 {HCP 12 6 13 9}
 {TP 12 7 13 9}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2794,10 +2794,10 @@ Pass    Pass
 {HCP 12 10 12 6}
 {TP 12 10 14 7}
 {Losers 8 8 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2814,11 +2814,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 8 13 7}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2835,12 +2835,12 @@ Pass    Pass
 {HCP 12 8 14 6}
 {TP 12 9 14 6}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2857,11 +2857,11 @@ Pass    Pass
 {HCP 12 5 12 11}
 {TP 12 5 13 11}
 {Losers 8 11 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2878,11 +2878,11 @@ Pass    Pass
 {HCP 12 9 13 6}
 {TP 12 12 13 6}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      X
-XX      2H      3NT     Pass
+XX      2H      3N     Pass
 Pass    Pass    
 
 
@@ -2899,12 +2899,12 @@ Pass    Pass
 {HCP 12 7 11 10}
 {TP 12 8 12 10}
 {Losers 8 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1C      Pass
 1H      Pass    1S      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -2943,11 +2943,11 @@ Pass    Pass    1C      Pass
 {HCP 12 9 14 5}
 {TP 12 9 15 7}
 {Losers 8 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2964,12 +2964,12 @@ Pass    Pass    1C      Pass
 {HCP 12 7 14 7}
 {TP 12 7 16 9}
 {Losers 8 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2989,7 +2989,7 @@ Pass    Pass    1C      Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -3007,11 +3007,11 @@ Pass    Pass    1C      Pass
 {HCP 12 9 13 6}
 {TP 12 10 13 8}
 {Losers 8 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3028,12 +3028,12 @@ Pass    Pass    1C      Pass
 {HCP 12 8 14 6}
 {TP 12 8 15 7}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3050,12 +3050,12 @@ Pass    Pass    1C      Pass
 {HCP 12 6 14 8}
 {TP 12 8 16 8}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3072,11 +3072,11 @@ Pass    Pass
 {HCP 12 12 13 3}
 {TP 12 12 13 4}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3093,11 +3093,11 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 10 14 9}
 {Losers 8 9 6 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3120,7 +3120,7 @@ Pass    Pass
 1D      Pass    1H      1S
 3C      Pass    3D      3S
 4D      Pass    4S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -3140,7 +3140,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    2NT     3S
+1C      Pass    2N     3S
 Pass    Pass    Pass    
 
 
@@ -3157,11 +3157,11 @@ Pass    Pass    Pass
 {HCP 12 8 14 6}
 {TP 12 11 16 7}
 {Losers 8 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3178,11 +3178,11 @@ Pass    Pass
 {HCP 12 7 13 8}
 {TP 12 8 13 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3199,11 +3199,11 @@ Pass    Pass
 {HCP 12 10 12 6}
 {TP 12 10 13 6}
 {Losers 8 8 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3220,12 +3220,12 @@ Pass    Pass
 {HCP 11 5 17 7}
 {TP 11 7 18 8}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3246,7 +3246,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -3264,11 +3264,11 @@ Pass    Pass
 {HCP 11 6 15 8}
 {TP 11 8 16 8}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3S      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3285,11 +3285,11 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 12 8 13 10}
 {Losers 8 8 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3306,11 +3306,11 @@ Pass    Pass
 {HCP 11 10 19 0}
 {TP 11 10 19 2}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3327,11 +3327,11 @@ Pass    Pass
 {HCP 12 12 12 4}
 {TP 12 13 13 4}
 {Losers 8 6 6 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3348,11 +3348,11 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 12 7 13 11}
 {Losers 8 10 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3391,11 +3391,11 @@ Pass    Pass
 {HCP 12 12 12 4}
 {TP 12 13 14 4}
 {Losers 8 6 6 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3433,11 +3433,11 @@ Pass    Pass
 {HCP 12 9 17 2}
 {TP 12 10 17 3}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3458,7 +3458,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -3476,10 +3476,10 @@ Pass    Pass
 {HCP 12 5 12 11}
 {TP 12 6 12 11}
 {Losers 8 9 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3496,11 +3496,11 @@ Pass    Pass
 {HCP 12 11 12 5}
 {TP 12 13 14 5}
 {Losers 8 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      X
-Pass    2C      3NT     Pass
+Pass    2C      3N     Pass
 Pass    Pass    
 
 
@@ -3517,11 +3517,11 @@ Pass    Pass
 {HCP 11 10 14 5}
 {TP 11 10 14 5}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3538,11 +3538,11 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 12 7 12 9}
 {Losers 8 10 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3559,10 +3559,10 @@ Pass    Pass
 {HCP 12 11 12 5}
 {TP 12 12 12 5}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3579,12 +3579,12 @@ Pass    Pass
 {HCP 11 4 14 11}
 {TP 11 5 14 11}
 {Losers 8 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3601,11 +3601,11 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 7 16 8}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3S      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3622,11 +3622,11 @@ Pass    Pass
 {HCP 12 12 13 3}
 {TP 12 13 13 4}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3669,7 +3669,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 4D      Pass    5D      Pass
 Pass    Pass    
 
@@ -3687,11 +3687,11 @@ Pass    Pass
 {HCP 12 12 13 3}
 {TP 12 12 14 3}
 {Losers 8 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3708,12 +3708,12 @@ Pass    Pass
 {HCP 12 8 14 6}
 {TP 12 10 17 7}
 {Losers 8 7 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3750,11 +3750,11 @@ Pass    Pass    Pass
 {HCP 11 9 13 7}
 {TP 11 11 14 7}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3771,12 +3771,12 @@ Pass    Pass    Pass
 {HCP 11 7 16 6}
 {TP 11 10 19 6}
 {Losers 8 7 4 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3793,11 +3793,11 @@ Pass    Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 9 14 8}
 {Losers 8 9 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3814,11 +3814,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 8 13 7}
 {Losers 8 9 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3835,11 +3835,11 @@ Pass    Pass
 {HCP 12 13 13 2}
 {TP 12 14 13 2}
 {Losers 8 6 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      X
-XX      1S      3NT     Pass
+XX      1S      3N     Pass
 Pass    Pass    
 
 
@@ -3856,12 +3856,12 @@ Pass    Pass
 {HCP 12 10 14 4}
 {TP 12 10 14 4}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3878,10 +3878,10 @@ Pass    Pass
 {HCP 12 11 12 5}
 {TP 12 12 12 5}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3898,11 +3898,11 @@ Pass    Pass
 {HCP 12 8 14 6}
 {TP 12 9 14 8}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3919,11 +3919,11 @@ Pass    Pass
 {HCP 12 12 13 3}
 {TP 12 13 14 3}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3940,11 +3940,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 10 14 9}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3961,11 +3961,11 @@ Pass    Pass
 {HCP 11 4 19 6}
 {TP 11 5 19 6}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3982,10 +3982,10 @@ Pass    Pass
 {HCP 11 9 11 9}
 {TP 11 12 14 10}
 {Losers 8 6 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4002,11 +4002,11 @@ Pass    Pass
 {HCP 11 8 14 7}
 {TP 11 8 14 8}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4067,12 +4067,12 @@ Pass    Pass
 {HCP 12 9 13 6}
 {TP 12 9 14 6}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4089,11 +4089,11 @@ Pass    Pass
 {HCP 12 10 14 4}
 {TP 12 10 14 4}
 {Losers 8 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4110,11 +4110,11 @@ Pass    Pass
 {HCP 12 4 18 6}
 {TP 12 4 18 6}
 {Losers 8 11 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4131,11 +4131,11 @@ Pass    Pass
 {HCP 12 8 11 9}
 {TP 12 9 13 10}
 {Losers 8 9 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4174,10 +4174,10 @@ Pass    Pass
 {HCP 12 5 12 11}
 {TP 12 6 13 11}
 {Losers 8 10 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4194,12 +4194,12 @@ Pass    Pass
 {HCP 11 5 14 10}
 {TP 11 6 14 11}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4238,12 +4238,12 @@ Pass    Pass
 {HCP 12 9 17 2}
 {TP 12 9 18 2}
 {Losers 8 9 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4282,11 +4282,11 @@ Pass    Pass
 {HCP 12 6 16 6}
 {TP 12 7 16 7}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3S      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4303,11 +4303,11 @@ Pass    Pass
 {HCP 12 10 14 4}
 {TP 12 11 14 5}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4324,10 +4324,10 @@ Pass    Pass
 {HCP 11 16 12 1}
 {TP 11 16 12 1}
 {Losers 8 6 9 12}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4344,11 +4344,11 @@ Pass    Pass
 {HCP 11 6 14 9}
 {TP 11 6 14 9}
 {Losers 8 11 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4368,7 +4368,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -4408,11 +4408,11 @@ Pass    Pass
 {HCP 12 12 13 3}
 {TP 12 14 13 5}
 {Losers 8 6 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      1S
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4451,11 +4451,11 @@ Pass    Pass
 {HCP 12 14 13 1}
 {TP 12 15 13 2}
 {Losers 8 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4472,11 +4472,11 @@ Pass    Pass
 {HCP 12 13 12 3}
 {TP 12 14 12 4}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      X
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4515,12 +4515,12 @@ Pass    Pass
 {HCP 12 11 14 3}
 {TP 12 11 15 5}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4537,11 +4537,11 @@ Pass    Pass
 {HCP 12 11 14 3}
 {TP 12 11 14 4}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4579,11 +4579,11 @@ Pass    Pass
 {HCP 12 6 14 8}
 {TP 12 6 15 8}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4621,11 +4621,11 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 12 6 12 10}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4642,11 +4642,11 @@ Pass    Pass
 {HCP 12 12 12 4}
 {TP 12 14 14 4}
 {Losers 8 6 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4663,12 +4663,12 @@ Pass    Pass
 {HCP 12 11 13 4}
 {TP 12 13 14 6}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4688,7 +4688,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    2NT     3S
+1D      Pass    2N     3S
 Pass    Pass    Pass    
 
 
@@ -4705,11 +4705,11 @@ Pass    Pass    Pass
 {HCP 11 7 13 9}
 {TP 11 9 14 10}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4751,7 +4751,7 @@ Pass    Pass    Pass
 [Contract "4HX"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    2NT     4H
+1C      Pass    2N     4H
 X       Pass    Pass    Pass
 
 
@@ -4790,11 +4790,11 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 10 13 6}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      1S
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4811,11 +4811,11 @@ Pass    Pass
 {HCP 11 8 12 9}
 {TP 11 8 12 10}
 {Losers 8 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4832,11 +4832,11 @@ Pass    Pass
 {HCP 11 8 13 8}
 {TP 11 8 14 9}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4853,11 +4853,11 @@ Pass    Pass
 {HCP 12 5 12 11}
 {TP 12 7 14 11}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4874,11 +4874,11 @@ Pass    Pass
 {HCP 12 5 12 11}
 {TP 12 5 12 11}
 {Losers 8 10 9 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4895,11 +4895,11 @@ Pass    Pass
 {HCP 12 5 19 4}
 {TP 12 6 19 5}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4916,12 +4916,12 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 8 14 7}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4938,12 +4938,12 @@ Pass    Pass
 {HCP 12 6 14 8}
 {TP 12 7 14 9}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4960,11 +4960,11 @@ Pass    Pass
 {HCP 12 6 13 9}
 {TP 12 7 13 10}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4981,12 +4981,12 @@ Pass    Pass
 {HCP 12 8 11 9}
 {TP 12 8 12 9}
 {Losers 8 10 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1C      Pass
 1D      Pass    1S      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -5003,11 +5003,11 @@ Pass    Pass    1C      Pass
 {HCP 12 10 11 7}
 {TP 12 13 12 7}
 {Losers 8 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      X
-XX      1S      3NT     Pass
+XX      1S      3N     Pass
 Pass    Pass    
 
 
@@ -5046,10 +5046,10 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 12 7 12 10}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5091,7 +5091,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -5109,12 +5109,12 @@ Pass    Pass
 {HCP 12 9 14 5}
 {TP 12 11 17 5}
 {Losers 8 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5131,11 +5131,11 @@ Pass    Pass
 {HCP 12 10 12 6}
 {TP 12 10 12 7}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5152,10 +5152,10 @@ Pass    Pass
 {HCP 12 10 12 6}
 {TP 12 12 13 7}
 {Losers 8 7 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5172,10 +5172,10 @@ Pass    Pass
 {HCP 12 15 11 2}
 {TP 12 16 13 3}
 {Losers 8 7 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5196,7 +5196,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    2H      Pass    Pass
 Pass    
 
@@ -5217,7 +5217,7 @@ Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    2NT     3D
+1C      Pass    2N     3D
 Pass    Pass    Pass    
 
 
@@ -5234,11 +5234,11 @@ Pass    Pass    Pass
 {HCP 12 6 15 7}
 {TP 12 7 16 8}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5255,11 +5255,11 @@ Pass    Pass    Pass
 {HCP 12 2 15 11}
 {TP 12 5 17 11}
 {Losers 8 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3S      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5301,7 +5301,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    2NT     3D
+1C      Pass    2N     3D
 Pass    Pass    Pass    
 
 
@@ -5318,11 +5318,11 @@ Pass    Pass    Pass
 {HCP 12 12 14 2}
 {TP 12 14 16 2}
 {Losers 8 6 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      2D
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5342,7 +5342,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -5381,11 +5381,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 8 13 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5402,11 +5402,11 @@ Pass    Pass
 {HCP 12 10 15 3}
 {TP 12 11 16 3}
 {Losers 8 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5426,7 +5426,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    2NT     3S
+1D      Pass    2N     3S
 Pass    Pass    Pass    
 
 
@@ -5465,12 +5465,12 @@ Pass    Pass    Pass
 {HCP 12 6 16 6}
 {TP 12 6 17 7}
 {Losers 8 10 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5491,7 +5491,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -5509,11 +5509,11 @@ Pass    Pass    Pass
 {HCP 12 8 12 8}
 {TP 12 8 12 8}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5530,12 +5530,12 @@ Pass    Pass
 {HCP 12 8 17 3}
 {TP 12 9 19 4}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5552,12 +5552,12 @@ Pass    Pass
 {HCP 12 11 14 3}
 {TP 12 13 16 3}
 {Losers 8 6 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5596,11 +5596,11 @@ Pass    Pass
 {HCP 12 9 13 6}
 {TP 12 9 14 7}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5617,11 +5617,11 @@ Pass    Pass
 {HCP 12 9 14 5}
 {TP 12 9 14 5}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5638,10 +5638,10 @@ Pass    Pass
 {HCP 11 9 12 8}
 {TP 11 9 12 8}
 {Losers 8 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5661,9 +5661,9 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3C      Pass    3D      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -5681,11 +5681,11 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 11 13 6}
 {Losers 8 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5702,11 +5702,11 @@ Pass    Pass
 {HCP 12 5 13 10}
 {TP 12 5 13 10}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5723,10 +5723,10 @@ Pass    Pass
 {HCP 11 12 12 5}
 {TP 11 12 12 6}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5743,10 +5743,10 @@ Pass    Pass
 {HCP 12 7 11 10}
 {TP 12 9 13 10}
 {Losers 8 8 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5766,7 +5766,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    2NT     3C
+1D      Pass    2N     3C
 Pass    Pass    Pass    
 
 
@@ -5783,12 +5783,12 @@ Pass    Pass    Pass
 {HCP 12 12 16 0}
 {TP 12 13 17 1}
 {Losers 8 7 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5805,10 +5805,10 @@ Pass    Pass    Pass
 {HCP 12 8 12 8}
 {TP 12 8 12 8}
 {Losers 8 9 9 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5829,7 +5829,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -5869,12 +5869,12 @@ Pass    Pass    1C      Pass
 {HCP 12 14 13 1}
 {TP 12 14 14 1}
 {Losers 8 8 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5895,7 +5895,7 @@ Pass    Pass    1C      Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5913,11 +5913,11 @@ Pass    Pass    1C      Pass
 {HCP 12 11 13 4}
 {TP 12 11 13 5}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5934,11 +5934,11 @@ Pass    Pass    1C      Pass
 {HCP 12 9 13 6}
 {TP 12 9 15 9}
 {Losers 8 9 6 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5955,11 +5955,11 @@ Pass    Pass
 {HCP 12 10 12 6}
 {TP 12 11 12 7}
 {Losers 8 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5976,11 +5976,11 @@ Pass    Pass
 {HCP 12 14 13 1}
 {TP 12 16 13 3}
 {Losers 8 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     3C
-3NT     Pass    Pass    Pass
+1C      Pass    2N     3C
+3N     Pass    Pass    Pass
 
 
 
@@ -5997,11 +5997,11 @@ Pass    Pass
 {HCP 12 12 14 2}
 {TP 12 12 14 3}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6018,12 +6018,12 @@ Pass    Pass
 {HCP 12 10 14 4}
 {TP 12 10 14 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6040,11 +6040,11 @@ Pass    Pass
 {HCP 12 3 19 6}
 {TP 12 3 19 6}
 {Losers 8 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6061,11 +6061,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 9 13 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6082,11 +6082,11 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 10 13 5}
 {Losers 8 8 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6103,11 +6103,11 @@ Pass    Pass
 {HCP 11 11 13 5}
 {TP 11 11 13 5}
 {Losers 8 7 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6124,11 +6124,11 @@ Pass    Pass
 {HCP 12 3 15 10}
 {TP 12 5 16 10}
 {Losers 8 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3S      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6148,7 +6148,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6166,11 +6166,11 @@ Pass    Pass
 {HCP 12 12 13 3}
 {TP 12 12 13 3}
 {Losers 8 9 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6209,11 +6209,11 @@ Pass    Pass
 {HCP 12 9 15 4}
 {TP 12 10 16 6}
 {Losers 8 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6230,12 +6230,12 @@ Pass    Pass
 {HCP 12 5 17 6}
 {TP 12 6 18 6}
 {Losers 8 10 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6252,11 +6252,11 @@ Pass    Pass
 {HCP 12 8 18 2}
 {TP 12 10 18 4}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6295,11 +6295,11 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 9 12 7}
 {Losers 8 9 9 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6316,11 +6316,11 @@ Pass    Pass
 {HCP 12 13 13 2}
 {TP 12 13 14 3}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6337,11 +6337,11 @@ Pass    Pass
 {HCP 11 15 12 2}
 {TP 11 15 12 3}
 {Losers 8 6 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      2D
-X       Pass    2NT     Pass
+X       Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6358,11 +6358,11 @@ Pass    Pass
 {HCP 12 6 14 8}
 {TP 12 6 14 9}
 {Losers 8 10 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6379,11 +6379,11 @@ Pass    Pass
 {HCP 12 12 13 3}
 {TP 12 12 15 4}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6400,11 +6400,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 9 15 7}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6421,10 +6421,10 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 9 13 7}
 {Losers 8 8 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6462,12 +6462,12 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 8 14 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6484,11 +6484,11 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 9 13 7}
 {Losers 8 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6527,10 +6527,10 @@ Pass    Pass
 {HCP 12 13 12 3}
 {TP 12 13 12 3}
 {Losers 8 7 9 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6547,11 +6547,11 @@ Pass    Pass
 {HCP 12 11 15 2}
 {TP 12 12 17 3}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6568,11 +6568,11 @@ Pass    Pass
 {HCP 12 8 15 5}
 {TP 12 9 16 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3S      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6611,11 +6611,11 @@ Pass    Pass
 {HCP 11 7 18 4}
 {TP 11 9 19 4}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6658,7 +6658,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1C      1S
-2S      Pass    2NT     Pass
+2S      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -6720,10 +6720,10 @@ Pass    Pass    1C      1S
 {HCP 12 5 12 11}
 {TP 12 6 12 11}
 {Losers 8 10 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6740,11 +6740,11 @@ Pass    Pass
 {HCP 12 12 14 2}
 {TP 12 12 14 2}
 {Losers 8 9 7 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6761,12 +6761,12 @@ Pass    Pass
 {HCP 11 10 13 6}
 {TP 11 10 14 6}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6786,7 +6786,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    2NT     3S
+1D      Pass    2N     3S
 Pass    Pass    Pass    
 
 
@@ -6803,10 +6803,10 @@ Pass    Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 10 13 7}
 {Losers 8 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6823,11 +6823,11 @@ Pass    Pass
 {HCP 12 10 18 0}
 {TP 12 10 18 1}
 {Losers 8 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6844,11 +6844,11 @@ Pass    Pass
 {HCP 12 9 14 5}
 {TP 12 9 15 5}
 {Losers 8 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6865,11 +6865,11 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 9 14 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6890,7 +6890,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6908,11 +6908,11 @@ Pass    Pass
 {HCP 12 7 13 8}
 {TP 12 7 13 9}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6929,10 +6929,10 @@ Pass    Pass
 {HCP 11 9 12 8}
 {TP 11 9 12 8}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6949,11 +6949,11 @@ Pass    Pass
 {HCP 11 4 18 7}
 {TP 11 4 19 7}
 {Losers 8 10 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6970,11 +6970,11 @@ Pass    Pass
 {HCP 12 6 18 4}
 {TP 12 8 18 4}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6991,12 +6991,12 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 7 14 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7013,10 +7013,10 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 9 13 8}
 {Losers 8 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7033,11 +7033,11 @@ Pass    Pass
 {HCP 12 4 13 11}
 {TP 12 5 13 11}
 {Losers 8 10 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7120,12 +7120,12 @@ Pass    Pass
 {HCP 12 8 14 6}
 {TP 12 10 14 7}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7142,11 +7142,11 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 11 9 16 6}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7163,11 +7163,11 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 12 13 6}
 {Losers 8 6 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      X
-XX      2H      3NT     Pass
+XX      2H      3N     Pass
 Pass    Pass    
 
 
@@ -7184,10 +7184,10 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 12 8 12 9}
 {Losers 8 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7247,10 +7247,10 @@ Pass    Pass    1C      Pass
 {HCP 12 7 12 9}
 {TP 12 8 12 10}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7267,11 +7267,11 @@ Pass    Pass
 {HCP 12 7 13 8}
 {TP 12 7 13 9}
 {Losers 8 10 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7288,11 +7288,11 @@ Pass    Pass
 {HCP 12 4 13 11}
 {TP 12 5 14 11}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7309,12 +7309,12 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 7 14 7}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7331,11 +7331,11 @@ Pass    Pass
 {HCP 12 6 13 9}
 {TP 12 6 13 9}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7352,11 +7352,11 @@ Pass    Pass
 {HCP 12 12 14 2}
 {TP 12 13 14 4}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7394,11 +7394,11 @@ Pass    Pass
 {HCP 11 5 14 10}
 {TP 11 5 15 10}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7419,7 +7419,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7437,11 +7437,11 @@ Pass    Pass
 {HCP 12 5 13 10}
 {TP 12 5 13 10}
 {Losers 8 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7458,11 +7458,11 @@ Pass    Pass
 {HCP 11 6 12 11}
 {TP 11 6 12 11}
 {Losers 8 10 9 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7523,11 +7523,11 @@ Pass    Pass    X       Pass
 {HCP 11 11 16 2}
 {TP 11 12 17 4}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7544,12 +7544,12 @@ Pass    Pass    X       Pass
 {HCP 12 11 14 3}
 {TP 12 12 14 3}
 {Losers 8 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7566,11 +7566,11 @@ Pass    Pass    X       Pass
 {HCP 12 8 13 7}
 {TP 12 10 13 8}
 {Losers 8 7 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7587,11 +7587,11 @@ Pass    Pass    X       Pass
 {HCP 12 8 14 6}
 {TP 12 11 15 7}
 {Losers 8 7 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7608,12 +7608,12 @@ Pass    Pass
 {HCP 11 9 14 6}
 {TP 11 10 15 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7652,11 +7652,11 @@ Pass    Pass
 {HCP 12 9 13 6}
 {TP 12 11 13 8}
 {Losers 8 7 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7673,11 +7673,11 @@ Pass    Pass
 {HCP 12 3 14 11}
 {TP 12 4 15 11}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7694,11 +7694,11 @@ Pass    Pass
 {HCP 11 6 19 4}
 {TP 11 8 19 6}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7737,11 +7737,11 @@ Pass    Pass
 {HCP 12 7 16 5}
 {TP 12 8 18 5}
 {Losers 8 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      1S
-X       3S      3NT     Pass
+X       3S      3N     Pass
 Pass    Pass    
 
 
@@ -7779,11 +7779,11 @@ Pass    Pass
 {HCP 12 12 14 2}
 {TP 12 12 14 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7800,11 +7800,11 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 10 12 7}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7825,7 +7825,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7843,11 +7843,11 @@ Pass    Pass
 {HCP 11 10 18 1}
 {TP 11 10 18 1}
 {Losers 8 8 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7886,11 +7886,11 @@ Pass    Pass
 {HCP 12 7 19 2}
 {TP 12 7 19 3}
 {Losers 8 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7907,12 +7907,12 @@ Pass    Pass
 {HCP 12 14 11 3}
 {TP 12 14 12 4}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1C      Pass
 1H      Pass    1S      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -7929,12 +7929,12 @@ Pass    Pass    1C      Pass
 {HCP 12 8 17 3}
 {TP 12 8 18 4}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7955,7 +7955,7 @@ Pass    Pass    1C      Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7973,12 +7973,12 @@ Pass    Pass    1C      Pass
 {HCP 11 11 15 3}
 {TP 11 12 15 5}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      X
-1S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7995,11 +7995,11 @@ Pass    Pass    1C      Pass
 {HCP 12 8 14 6}
 {TP 12 8 14 6}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8016,12 +8016,12 @@ Pass    Pass    1C      Pass
 {HCP 12 12 14 2}
 {TP 12 12 15 3}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8038,12 +8038,12 @@ Pass    Pass    1C      Pass
 {HCP 12 6 14 8}
 {TP 12 7 14 9}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8060,11 +8060,11 @@ Pass    Pass    1C      Pass
 {HCP 12 12 13 3}
 {TP 12 12 13 4}
 {Losers 8 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8081,12 +8081,12 @@ Pass    Pass
 {HCP 12 3 20 5}
 {TP 12 4 21 6}
 {Losers 8 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 3C      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8103,12 +8103,12 @@ Pass    Pass
 {HCP 11 11 14 4}
 {TP 11 11 14 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8147,11 +8147,11 @@ Pass    Pass
 {HCP 12 5 14 9}
 {TP 12 6 14 9}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8168,12 +8168,12 @@ Pass    Pass
 {HCP 12 3 14 11}
 {TP 12 5 14 11}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8190,11 +8190,11 @@ Pass    Pass
 {HCP 11 6 18 5}
 {TP 11 7 19 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8211,10 +8211,10 @@ Pass    Pass
 {HCP 12 8 12 8}
 {TP 12 9 13 8}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8231,11 +8231,11 @@ Pass    Pass
 {HCP 12 4 14 10}
 {TP 12 6 15 10}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8252,11 +8252,11 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 9 13 8}
 {Losers 8 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8273,12 +8273,12 @@ Pass    Pass
 {HCP 12 7 19 2}
 {TP 12 9 20 2}
 {Losers 8 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8317,12 +8317,12 @@ Pass    Pass
 {HCP 12 13 13 2}
 {TP 12 14 14 4}
 {Losers 8 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8339,11 +8339,11 @@ Pass    Pass
 {HCP 12 11 14 3}
 {TP 12 12 14 3}
 {Losers 8 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8360,11 +8360,11 @@ Pass    Pass
 {HCP 12 7 13 8}
 {TP 12 8 14 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8381,11 +8381,11 @@ Pass    Pass
 {HCP 12 6 14 8}
 {TP 12 8 15 8}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8402,11 +8402,11 @@ Pass    Pass
 {HCP 12 8 18 2}
 {TP 12 8 18 3}
 {Losers 8 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8427,7 +8427,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    Pass    1C      1S
-2S      X       2NT     Pass
+2S      X       2N     Pass
 3C      3S      Pass    Pass
 Pass    
 
@@ -8445,11 +8445,11 @@ Pass
 {HCP 12 3 14 11}
 {TP 12 5 14 12}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8491,7 +8491,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8531,11 +8531,11 @@ Pass    Pass
 {HCP 12 11 16 1}
 {TP 12 12 17 3}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8552,11 +8552,11 @@ Pass    Pass
 {HCP 12 12 11 5}
 {TP 12 12 13 6}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8573,11 +8573,11 @@ Pass    Pass
 {HCP 12 5 18 5}
 {TP 12 7 18 6}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8637,11 +8637,11 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 9 12 8}
 {Losers 8 8 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8658,11 +8658,11 @@ Pass    Pass
 {HCP 12 8 16 4}
 {TP 12 9 18 5}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8679,11 +8679,11 @@ Pass    Pass
 {HCP 12 3 18 7}
 {TP 12 4 18 10}
 {Losers 8 10 5 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8704,7 +8704,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -8722,10 +8722,10 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 9 12 7}
 {Losers 8 9 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8767,7 +8767,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -8785,11 +8785,11 @@ Pass    Pass
 {HCP 12 11 12 5}
 {TP 12 11 13 6}
 {Losers 8 8 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8806,11 +8806,11 @@ Pass    Pass
 {HCP 12 8 14 6}
 {TP 12 9 14 7}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8827,11 +8827,11 @@ Pass    Pass
 {HCP 12 9 13 6}
 {TP 12 10 13 6}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8869,12 +8869,12 @@ Pass
 {HCP 12 5 13 10}
 {TP 12 5 14 10}
 {Losers 8 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8891,11 +8891,11 @@ Pass
 {HCP 12 4 18 6}
 {TP 12 4 18 6}
 {Losers 8 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8912,11 +8912,11 @@ Pass    Pass
 {HCP 11 9 14 6}
 {TP 11 10 14 7}
 {Losers 8 8 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      1S
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8933,11 +8933,11 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 12 7 13 11}
 {Losers 8 8 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8976,11 +8976,11 @@ Pass    Pass
 {HCP 12 9 13 6}
 {TP 12 9 13 7}
 {Losers 8 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8997,10 +8997,10 @@ Pass    Pass
 {HCP 11 7 12 10}
 {TP 11 7 13 10}
 {Losers 8 10 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -9017,10 +9017,10 @@ Pass    Pass
 {HCP 11 12 12 5}
 {TP 11 12 12 6}
 {Losers 8 8 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -9058,12 +9058,12 @@ Pass
 {HCP 12 6 13 9}
 {TP 12 7 14 9}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9080,11 +9080,11 @@ Pass
 {HCP 12 12 14 2}
 {TP 12 13 14 4}
 {Losers 8 6 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     3H
-3NT     Pass    Pass    Pass
+1D      Pass    2N     3H
+3N     Pass    Pass    Pass
 
 
 
@@ -9101,11 +9101,11 @@ Pass
 {HCP 12 8 13 7}
 {TP 12 9 13 8}
 {Losers 8 8 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -9122,11 +9122,11 @@ Pass    Pass
 {HCP 12 8 14 6}
 {TP 12 8 14 7}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9143,11 +9143,11 @@ Pass    Pass
 {HCP 11 11 13 5}
 {TP 11 11 13 5}
 {Losers 8 8 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9164,10 +9164,10 @@ Pass    Pass
 {HCP 11 11 12 6}
 {TP 11 11 12 6}
 {Losers 8 8 9 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -9187,7 +9187,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -9205,12 +9205,12 @@ Pass    Pass
 {HCP 12 5 19 4}
 {TP 12 6 21 5}
 {Losers 8 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9227,12 +9227,12 @@ Pass    Pass
 {HCP 11 4 14 11}
 {TP 11 5 15 11}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9249,11 +9249,11 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 7 15 7}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9270,12 +9270,12 @@ Pass    Pass
 {HCP 12 9 13 6}
 {TP 12 12 14 7}
 {Losers 8 6 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      2H
 X       3H      X       Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9292,11 +9292,11 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 8 15 7}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9317,7 +9317,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1C      1S
-2S      Pass    2NT     Pass
+2S      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9335,11 +9335,11 @@ Pass    Pass    1C      1S
 {HCP 11 9 13 7}
 {TP 11 9 13 7}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9356,11 +9356,11 @@ Pass    Pass    1C      1S
 {HCP 12 7 13 8}
 {TP 12 7 13 8}
 {Losers 8 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9377,12 +9377,12 @@ Pass    Pass    1C      1S
 {HCP 12 6 16 6}
 {TP 12 8 17 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9421,11 +9421,11 @@ Pass    Pass    1C      1S
 {HCP 12 8 13 7}
 {TP 12 8 14 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9442,11 +9442,11 @@ Pass    Pass    1C      1S
 {HCP 12 10 13 5}
 {TP 12 10 13 5}
 {Losers 8 8 8 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -9507,12 +9507,12 @@ Pass    Pass
 {HCP 12 6 13 9}
 {TP 12 8 15 9}
 {Losers 8 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2C      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9532,7 +9532,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9571,11 +9571,11 @@ Pass    Pass    1C      Pass
 {HCP 12 14 14 0}
 {TP 12 15 15 2}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9592,11 +9592,11 @@ Pass    Pass    1C      Pass
 {HCP 12 7 12 9}
 {TP 12 7 13 9}
 {Losers 8 10 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -9613,12 +9613,12 @@ Pass    Pass
 {HCP 12 3 19 6}
 {TP 12 4 19 7}
 {Losers 8 10 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9635,11 +9635,11 @@ Pass    Pass
 {HCP 12 8 14 6}
 {TP 12 10 15 7}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9659,7 +9659,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    2NT     3C
+1D      Pass    2N     3C
 Pass    Pass    Pass    
 
 
@@ -9676,11 +9676,11 @@ Pass    Pass    Pass
 {HCP 11 7 18 4}
 {TP 11 7 19 5}
 {Losers 8 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9697,11 +9697,11 @@ Pass    Pass
 {HCP 12 5 13 10}
 {TP 12 7 13 10}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -9718,11 +9718,11 @@ Pass    Pass
 {HCP 12 9 14 5}
 {TP 12 9 14 5}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9739,12 +9739,12 @@ Pass    Pass
 {HCP 12 9 14 5}
 {TP 12 9 14 6}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9761,10 +9761,10 @@ Pass    Pass
 {HCP 11 10 12 7}
 {TP 11 10 12 7}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -9781,11 +9781,11 @@ Pass    Pass
 {HCP 12 7 18 3}
 {TP 12 8 19 4}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9802,11 +9802,11 @@ Pass    Pass
 {HCP 12 5 13 10}
 {TP 12 8 14 10}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9823,12 +9823,12 @@ Pass    Pass
 {HCP 12 5 14 9}
 {TP 12 6 14 10}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9848,8 +9848,8 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3S      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3S      Pass    3N     Pass
 4C      Pass    5C      Pass
 Pass    Pass    
 
@@ -9867,11 +9867,11 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 7 15 8}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9908,12 +9908,12 @@ Pass    Pass    Pass    Pass
 {HCP 11 7 14 8}
 {TP 11 7 14 9}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9930,11 +9930,11 @@ Pass    Pass    Pass    Pass
 {HCP 12 13 14 1}
 {TP 12 15 15 2}
 {Losers 8 6 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9951,11 +9951,11 @@ Pass    Pass    Pass    Pass
 {HCP 12 3 15 10}
 {TP 12 5 16 10}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9972,11 +9972,11 @@ Pass    Pass    Pass    Pass
 {HCP 12 9 13 6}
 {TP 12 11 13 8}
 {Losers 8 7 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -9993,11 +9993,11 @@ Pass    Pass
 {HCP 12 4 15 9}
 {TP 12 6 16 9}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10014,12 +10014,12 @@ Pass    Pass
 {HCP 11 8 14 7}
 {TP 11 8 14 7}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10036,12 +10036,12 @@ Pass    Pass
 {HCP 12 11 11 6}
 {TP 12 14 12 6}
 {Losers 8 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      X
 2C      2D      2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10058,12 +10058,12 @@ Pass    Pass
 {HCP 12 6 13 9}
 {TP 12 6 14 10}
 {Losers 8 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10101,11 +10101,11 @@ Pass    Pass
 {HCP 12 6 18 4}
 {TP 12 8 18 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10144,11 +10144,11 @@ Pass    Pass
 {HCP 12 5 13 10}
 {TP 12 7 13 10}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10165,11 +10165,11 @@ Pass    Pass
 {HCP 12 9 16 3}
 {TP 12 11 18 4}
 {Losers 8 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10186,12 +10186,12 @@ Pass    Pass
 {HCP 11 5 14 10}
 {TP 11 5 14 10}
 {Losers 8 10 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10208,11 +10208,11 @@ Pass    Pass
 {HCP 12 3 19 6}
 {TP 12 4 19 7}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10229,11 +10229,11 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 11 13 7}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     3S
-3NT     Pass    Pass    Pass
+1C      Pass    2N     3S
+3N     Pass    Pass    Pass
 
 
 
@@ -10254,7 +10254,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      2C
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -10272,11 +10272,11 @@ Pass    Pass
 {HCP 12 13 13 2}
 {TP 12 13 13 3}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10293,10 +10293,10 @@ Pass    Pass
 {HCP 12 12 12 4}
 {TP 12 12 14 6}
 {Losers 8 9 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -10313,10 +10313,10 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 12 7 12 10}
 {Losers 8 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -10353,11 +10353,11 @@ Pass    Pass    Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 11 13 5}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10374,11 +10374,11 @@ Pass    Pass    Pass    Pass
 {HCP 11 10 13 6}
 {TP 11 12 13 6}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10395,11 +10395,11 @@ Pass    Pass    Pass    Pass
 {HCP 12 13 12 3}
 {TP 12 13 12 3}
 {Losers 8 8 8 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -10438,11 +10438,11 @@ Pass    Pass
 {HCP 12 10 13 5}
 {TP 12 11 13 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10459,12 +10459,12 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 9 15 8}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+1S      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10481,12 +10481,12 @@ Pass    Pass
 {HCP 11 10 14 5}
 {TP 11 10 15 7}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10503,11 +10503,11 @@ Pass    Pass
 {HCP 12 5 14 9}
 {TP 12 5 15 10}
 {Losers 8 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10589,11 +10589,11 @@ Pass    Pass    1C      Pass
 {HCP 12 6 13 9}
 {TP 12 6 13 10}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -10610,12 +10610,12 @@ Pass    Pass
 {HCP 11 13 13 3}
 {TP 11 13 15 4}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 

--- a/GIB/1m-2m-..-3N.pbn
+++ b/GIB/1m-2m-..-3N.pbn
@@ -12,11 +12,11 @@
 {HCP 15 6 12 7}
 {TP 15 8 12 7}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -33,11 +33,11 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 10 12 7}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      3S
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -76,11 +76,11 @@ Pass    Pass
 {HCP 13 6 14 7}
 {TP 13 8 14 8}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -97,11 +97,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 8 13 5}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -118,11 +118,11 @@ Pass    Pass
 {HCP 14 11 12 3}
 {TP 14 13 12 4}
 {Losers 8 6 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      X
-Pass    2H      3NT     Pass
+Pass    2H      3N     Pass
 Pass    Pass    
 
 
@@ -139,11 +139,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 10 12 4}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -160,11 +160,11 @@ Pass    Pass
 {HCP 15 10 12 3}
 {TP 15 10 13 4}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -181,11 +181,11 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 8 13 6}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -202,11 +202,11 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 8 12 8}
 {Losers 8 9 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -245,11 +245,11 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 8 14 6}
 {Losers 7 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -270,7 +270,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -288,11 +288,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 7 12 7}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -309,11 +309,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 8 13 7}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -330,11 +330,11 @@ Pass    Pass
 {HCP 13 0 19 8}
 {TP 13 2 19 9}
 {Losers 8 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -351,11 +351,11 @@ Pass    Pass
 {HCP 13 6 12 9}
 {TP 13 6 12 9}
 {Losers 8 11 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -372,11 +372,11 @@ Pass    Pass
 {HCP 14 3 14 9}
 {TP 14 5 14 10}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -393,11 +393,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 9 15 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -414,11 +414,11 @@ Pass    Pass
 {HCP 14 8 13 5}
 {TP 14 8 15 7}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -456,11 +456,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 12 12 5}
 {Losers 8 7 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -477,12 +477,12 @@ Pass    Pass
 {HCP 13 6 17 4}
 {TP 13 7 19 5}
 {Losers 8 9 5 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+2S      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -499,11 +499,11 @@ Pass    Pass
 {HCP 14 12 14 0}
 {TP 14 12 14 2}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -520,11 +520,11 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 7 14 5}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -541,11 +541,11 @@ Pass    Pass
 {HCP 13 13 12 2}
 {TP 13 13 14 4}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -562,11 +562,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 7 12 7}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -583,11 +583,11 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 15 9 14 5}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -608,7 +608,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -626,11 +626,11 @@ Pass    Pass
 {HCP 13 4 18 5}
 {TP 13 6 18 5}
 {Losers 8 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -647,11 +647,11 @@ Pass    Pass
 {HCP 13 6 17 4}
 {TP 13 8 18 5}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -668,11 +668,11 @@ Pass    Pass
 {HCP 13 10 12 5}
 {TP 13 10 14 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -689,11 +689,11 @@ Pass    Pass
 {HCP 14 3 18 5}
 {TP 14 3 18 5}
 {Losers 8 11 7 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -710,11 +710,11 @@ Pass    Pass
 {HCP 15 11 12 2}
 {TP 15 11 12 2}
 {Losers 8 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -731,11 +731,11 @@ Pass    Pass
 {HCP 15 10 12 3}
 {TP 15 10 12 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -773,12 +773,12 @@ Pass    Pass
 {HCP 14 8 11 7}
 {TP 14 11 12 8}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-1H      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1H      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -799,7 +799,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -817,11 +817,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 7 12 8}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -838,11 +838,11 @@ Pass    Pass
 {HCP 14 5 12 9}
 {TP 14 7 13 10}
 {Losers 7 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -859,11 +859,11 @@ Pass    Pass
 {HCP 13 8 13 6}
 {TP 13 9 13 7}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      3C
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -880,11 +880,11 @@ Pass    Pass
 {HCP 13 9 14 4}
 {TP 13 11 15 5}
 {Losers 8 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -901,11 +901,11 @@ Pass    Pass
 {HCP 15 2 14 9}
 {TP 15 4 14 9}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -922,11 +922,11 @@ Pass    Pass
 {HCP 14 9 12 5}
 {TP 14 12 13 6}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -943,11 +943,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 8 12 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -964,11 +964,11 @@ Pass    Pass
 {HCP 13 5 12 10}
 {TP 13 7 13 10}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      3D
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -985,11 +985,11 @@ Pass    Pass
 {HCP 15 9 14 2}
 {TP 15 11 14 3}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1010,7 +1010,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      2H
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 4H      Pass    5C      Pass
 Pass    Pass    
 
@@ -1053,7 +1053,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1D      1H
-X       Pass    1NT     Pass
+X       Pass    1N     Pass
 2H      Pass    3D      Pass
 Pass    Pass    
 
@@ -1071,11 +1071,11 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 9 12 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1092,11 +1092,11 @@ Pass    Pass
 {HCP 14 9 12 5}
 {TP 14 11 12 6}
 {Losers 8 7 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1113,11 +1113,11 @@ Pass    Pass
 {HCP 14 3 18 5}
 {TP 14 5 18 5}
 {Losers 8 9 6 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -1134,11 +1134,11 @@ Pass    Pass
 {HCP 14 5 15 6}
 {TP 14 8 16 7}
 {Losers 8 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      3C
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1155,11 +1155,11 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 9 13 7}
 {Losers 6 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1176,11 +1176,11 @@ Pass    Pass
 {HCP 14 6 12 8}
 {TP 14 9 14 9}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1197,11 +1197,11 @@ Pass    Pass
 {HCP 14 10 13 3}
 {TP 14 11 14 5}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1218,11 +1218,11 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 10 13 2}
 {Losers 7 9 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1239,11 +1239,11 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 14 10 13 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1260,11 +1260,11 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 14 6 15 7}
 {Losers 7 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1281,11 +1281,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 7 13 7}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1302,11 +1302,11 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 6 13 7}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1323,11 +1323,11 @@ Pass    Pass
 {HCP 14 4 14 8}
 {TP 14 6 14 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1344,11 +1344,11 @@ Pass    Pass
 {HCP 15 8 14 3}
 {TP 15 10 16 3}
 {Losers 8 7 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1369,7 +1369,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      2S
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -1387,11 +1387,11 @@ Pass    Pass
 {HCP 13 11 12 4}
 {TP 13 11 12 4}
 {Losers 8 7 9 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1408,12 +1408,12 @@ Pass    Pass
 {HCP 14 8 11 7}
 {TP 14 8 12 8}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-1H      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1H      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1430,11 +1430,11 @@ Pass    Pass
 {HCP 13 8 13 6}
 {TP 13 8 14 7}
 {Losers 8 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1451,11 +1451,11 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 15 6 13 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1472,11 +1472,11 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 15 7 13 8}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1514,11 +1514,11 @@ Pass    Pass
 {HCP 15 7 13 5}
 {TP 15 7 13 6}
 {Losers 7 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1535,11 +1535,11 @@ Pass    Pass
 {HCP 13 10 14 3}
 {TP 13 11 15 5}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1556,11 +1556,11 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 9 12 6}
 {Losers 7 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1577,11 +1577,11 @@ Pass    Pass
 {HCP 13 5 19 3}
 {TP 13 7 19 4}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1619,11 +1619,11 @@ Pass    Pass
 {HCP 13 6 12 9}
 {TP 13 7 12 9}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1640,11 +1640,11 @@ Pass    Pass
 {HCP 13 11 12 4}
 {TP 13 13 13 4}
 {Losers 8 6 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      X
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1661,11 +1661,11 @@ Pass    Pass
 {HCP 15 10 14 1}
 {TP 15 11 16 1}
 {Losers 8 7 5 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      2H
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1682,11 +1682,11 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 8 14 6}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1703,11 +1703,11 @@ Pass    Pass
 {HCP 15 10 14 1}
 {TP 15 10 14 2}
 {Losers 7 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1746,11 +1746,11 @@ Pass    Pass    1C      2S
 {HCP 14 12 14 0}
 {TP 14 13 14 1}
 {Losers 7 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1767,11 +1767,11 @@ Pass    Pass    1C      2S
 {HCP 14 7 13 6}
 {TP 14 8 14 7}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1788,11 +1788,11 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 9 12 7}
 {Losers 7 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1809,11 +1809,11 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 8 13 9}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1830,11 +1830,11 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 9 12 7}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1851,11 +1851,11 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 8 12 7}
 {Losers 7 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1872,11 +1872,11 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 7 13 6}
 {Losers 7 9 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1893,11 +1893,11 @@ Pass    Pass
 {HCP 13 5 13 9}
 {TP 13 6 14 9}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1914,11 +1914,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 7 13 8}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1935,11 +1935,11 @@ Pass    Pass
 {HCP 13 7 13 7}
 {TP 13 8 14 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1956,11 +1956,11 @@ Pass    Pass
 {HCP 13 13 12 2}
 {TP 13 13 13 3}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      2H
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1977,11 +1977,11 @@ Pass    Pass
 {HCP 15 7 18 0}
 {TP 15 8 18 2}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      3S
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1998,11 +1998,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 8 12 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2041,12 +2041,12 @@ Pass    Pass    1C      Pass
 {HCP 15 7 12 6}
 {TP 15 9 14 6}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
-2S      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+Pass    Pass    1N     Pass
+2S      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2063,11 +2063,11 @@ Pass    Pass
 {HCP 14 8 14 4}
 {TP 14 8 14 4}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2084,11 +2084,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 8 14 7}
 {Losers 8 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      2D
-3C      3D      3NT     Pass
+3C      3D      3N     Pass
 Pass    Pass    
 
 
@@ -2105,10 +2105,10 @@ Pass    Pass
 {HCP 13 6 12 9}
 {TP 13 8 12 9}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 

--- a/GIB/1m-3N_forced.pbn
+++ b/GIB/1m-3N_forced.pbn
@@ -12,10 +12,10 @@
 {HCP 14 8 14 4}
 {TP 14 9 14 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -32,11 +32,11 @@ Pass    Pass
 {HCP 14 2 19 5}
 {TP 14 3 19 7}
 {Losers 8 11 5 8}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1D      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -53,10 +53,10 @@ Pass    Pass
 {HCP 14 7 11 8}
 {TP 14 8 12 8}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -73,10 +73,10 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 9 14 4}
 {Losers 7 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass   
 
 
@@ -93,10 +93,10 @@ Pass    Pass
 {HCP 15 12 12 1}
 {TP 15 13 14 2}
 {Losers 7 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -113,10 +113,10 @@ Pass    Pass
 {HCP 15 4 13 8}
 {TP 15 6 14 9}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -133,10 +133,10 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 6 13 8}
 {Losers 7 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -153,10 +153,10 @@ Pass    Pass
 {HCP 13 11 14 2}
 {TP 13 11 14 3}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -173,10 +173,10 @@ Pass    Pass
 {HCP 15 8 16 1}
 {TP 15 11 16 4}
 {Losers 8 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -193,10 +193,10 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 12 12 6}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -213,10 +213,10 @@ Pass    Pass
 {HCP 13 14 12 1}
 {TP 13 14 13 3}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -233,10 +233,10 @@ Pass    Pass
 {HCP 14 10 13 3}
 {TP 14 12 14 5}
 {Losers 8 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -253,10 +253,10 @@ Pass    Pass
 {HCP 13 6 12 9}
 {TP 13 6 12 9}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -273,10 +273,10 @@ Pass    Pass
 {HCP 15 9 14 2}
 {TP 15 10 14 3}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -293,10 +293,10 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 6 13 6}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -313,11 +313,11 @@ Pass    Pass
 {HCP 14 4 18 4}
 {TP 14 4 20 6}
 {Losers 8 10 4 9}
-[Contract "5NT"]
+[Contract "5N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
-4NT     Pass    5NT     Pass
+1D      Pass    3N     Pass
+4N     Pass    5N     Pass
 Pass    Pass    
 
 
@@ -334,10 +334,10 @@ Pass    Pass
 {HCP 14 9 12 5}
 {TP 14 11 15 6}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -354,10 +354,10 @@ Pass    Pass
 {HCP 15 3 13 9}
 {TP 15 4 13 9}
 {Losers 7 10 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -374,10 +374,10 @@ Pass    Pass
 {HCP 15 8 14 3}
 {TP 15 10 14 4}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -394,10 +394,10 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 7 14 7}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -414,10 +414,10 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 8 12 8}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -434,10 +434,10 @@ Pass    Pass
 {HCP 15 11 11 3}
 {TP 15 12 12 4}
 {Losers 8 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -454,10 +454,10 @@ Pass    Pass
 {HCP 15 7 14 4}
 {TP 15 7 16 5}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -474,10 +474,10 @@ Pass    Pass
 {HCP 13 6 12 9}
 {TP 13 6 13 9}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -494,10 +494,10 @@ Pass    Pass
 {HCP 15 7 15 3}
 {TP 15 8 16 3}
 {Losers 8 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -514,10 +514,10 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 8 13 6}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -534,10 +534,10 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 9 12 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -554,10 +554,10 @@ Pass    Pass
 {HCP 15 4 14 7}
 {TP 15 4 14 7}
 {Losers 7 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -574,10 +574,10 @@ Pass    Pass
 {HCP 15 4 13 8}
 {TP 15 4 13 8}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -594,10 +594,10 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 9 14 5}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -614,10 +614,10 @@ Pass    Pass
 {HCP 13 11 12 4}
 {TP 13 12 13 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -634,10 +634,10 @@ Pass    Pass
 {HCP 15 1 15 9}
 {TP 15 4 17 10}
 {Losers 7 9 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -654,10 +654,10 @@ Pass    Pass
 {HCP 14 6 12 8}
 {TP 14 7 13 8}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -674,10 +674,10 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 10 12 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -694,10 +694,10 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 10 12 8}
 {Losers 8 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -714,10 +714,10 @@ Pass    Pass
 {HCP 13 8 17 2}
 {TP 13 9 19 3}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -734,10 +734,10 @@ Pass    Pass
 {HCP 13 11 12 4}
 {TP 13 11 14 5}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -754,10 +754,10 @@ Pass    Pass
 {HCP 15 7 13 5}
 {TP 15 7 13 6}
 {Losers 7 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -774,10 +774,10 @@ Pass    Pass
 {HCP 13 11 12 4}
 {TP 13 11 12 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -794,10 +794,10 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 8 12 6}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -814,10 +814,10 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 9 13 6}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -834,10 +834,10 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 10 13 4}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -854,10 +854,10 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 8 13 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -874,10 +874,10 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 15 9 12 5}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -894,10 +894,10 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 11 13 4}
 {Losers 8 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -914,10 +914,10 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 7 15 6}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -934,10 +934,10 @@ Pass    Pass
 {HCP 15 7 13 5}
 {TP 15 7 13 5}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -954,10 +954,10 @@ Pass    Pass
 {HCP 13 6 14 7}
 {TP 13 7 14 7}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -974,10 +974,10 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 15 5 13 7}
 {Losers 7 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -994,10 +994,10 @@ Pass    Pass
 {HCP 15 10 11 4}
 {TP 15 10 13 4}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1014,10 +1014,10 @@ Pass    Pass
 {HCP 14 6 17 3}
 {TP 14 6 18 4}
 {Losers 8 10 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1034,10 +1034,10 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 15 6 15 8}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1054,10 +1054,10 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 15 5 13 7}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1074,10 +1074,10 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 7 13 8}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1094,10 +1094,10 @@ Pass    Pass
 {HCP 15 12 12 1}
 {TP 15 12 12 3}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1114,10 +1114,10 @@ Pass    Pass
 {HCP 15 2 12 11}
 {TP 15 2 14 11}
 {Losers 7 11 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1134,10 +1134,10 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 8 12 9}
 {Losers 8 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1154,10 +1154,10 @@ Pass    Pass
 {HCP 14 3 12 11}
 {TP 14 3 12 11}
 {Losers 8 11 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1174,11 +1174,11 @@ Pass    Pass
 {HCP 15 4 19 2}
 {TP 15 5 19 3}
 {Losers 7 9 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1D      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -1195,10 +1195,10 @@ Pass    Pass
 {HCP 14 6 12 8}
 {TP 14 6 12 8}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1215,10 +1215,10 @@ Pass    Pass
 {HCP 15 2 13 10}
 {TP 15 2 13 10}
 {Losers 7 11 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1235,10 +1235,10 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 14 5 15 8}
 {Losers 8 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1255,10 +1255,10 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 9 14 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1275,10 +1275,10 @@ Pass    Pass
 {HCP 14 13 12 1}
 {TP 14 14 13 3}
 {Losers 7 5 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1295,10 +1295,10 @@ Pass    Pass
 {HCP 15 5 16 4}
 {TP 15 6 17 6}
 {Losers 7 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1315,10 +1315,10 @@ Pass    Pass
 {HCP 15 13 12 0}
 {TP 15 14 13 1}
 {Losers 7 6 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1335,10 +1335,10 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 7 13 7}
 {Losers 7 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1355,11 +1355,11 @@ Pass    Pass
 {HCP 14 7 18 1}
 {TP 14 8 19 2}
 {Losers 8 9 5 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1D      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -1376,10 +1376,10 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 7 13 6}
 {Losers 7 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1396,11 +1396,11 @@ Pass    Pass
 {HCP 13 8 18 1}
 {TP 13 9 18 1}
 {Losers 8 8 6 12}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -1417,10 +1417,10 @@ Pass    Pass
 {HCP 15 9 14 2}
 {TP 15 13 16 4}
 {Losers 8 5 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1437,10 +1437,10 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 10 15 4}
 {Losers 8 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1457,11 +1457,11 @@ Pass    Pass
 {HCP 14 3 18 5}
 {TP 14 3 18 5}
 {Losers 8 11 7 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -1478,10 +1478,10 @@ Pass    Pass
 {HCP 14 4 14 8}
 {TP 14 5 14 8}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1498,11 +1498,11 @@ Pass    Pass
 {HCP 14 1 19 6}
 {TP 14 2 19 6}
 {Losers 7 11 6 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 [Event "autoCapture"]
@@ -1518,10 +1518,10 @@ Pass    Pass
 {HCP 13 7 14 6}
 {TP 13 8 14 6}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1538,10 +1538,10 @@ Pass    Pass
 {HCP 15 8 14 3}
 {TP 15 9 15 3}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1558,11 +1558,11 @@ Pass    Pass
 {HCP 15 1 18 6}
 {TP 15 3 18 8}
 {Losers 8 10 6 8}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
-4NT     Pass    6NT     Pass
+1D      Pass    3N     Pass
+4N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -1579,10 +1579,10 @@ Pass    Pass
 {HCP 14 5 12 9}
 {TP 14 6 12 9}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1599,10 +1599,10 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 10 13 3}
 {Losers 8 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1622,7 +1622,7 @@ Pass    Pass
 [Contract "4CX"]
 [Declarer "E"]
 [Auction "S"]
-1D      Pass    3NT     4C
+1D      Pass    3N     4C
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -1640,10 +1640,10 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 7 12 9}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1660,12 +1660,12 @@ Pass    Pass
 {HCP 15 10 11 4}
 {TP 15 10 12 5}
 {Losers 7 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1682,10 +1682,10 @@ Pass    Pass    1NT     Pass
 {HCP 13 9 12 6}
 {TP 13 10 14 7}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1702,10 +1702,10 @@ Pass    Pass
 {HCP 14 8 11 7}
 {TP 14 9 14 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1722,10 +1722,10 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 15 6 13 7}
 {Losers 6 10 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1742,10 +1742,10 @@ Pass    Pass
 {HCP 15 10 11 4}
 {TP 15 11 12 5}
 {Losers 8 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1762,10 +1762,10 @@ Pass    Pass
 {HCP 13 4 14 9}
 {TP 13 4 14 9}
 {Losers 8 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1782,11 +1782,11 @@ Pass    Pass
 {HCP 13 5 18 4}
 {TP 13 5 19 6}
 {Losers 8 11 5 8}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1D      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 [Event "autoCapture"]
@@ -1802,10 +1802,10 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 7 13 7}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1822,10 +1822,10 @@ Pass    Pass
 {HCP 13 10 13 4}
 {TP 13 10 14 4}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1842,10 +1842,10 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 12 13 4}
 {Losers 8 6 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1865,7 +1865,7 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -1883,9 +1883,9 @@ Pass    Pass
 {HCP 13 9 14 4}
 {TP 13 9 14 4}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 

--- a/GIB/1m-3N_freebid.pbn
+++ b/GIB/1m-3N_freebid.pbn
@@ -12,11 +12,11 @@
 {HCP 14 7 14 5}
 {TP 14 7 14 5}
 {Losers 7 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -33,13 +33,13 @@ Pass    Pass
 {HCP 15 3 13 9}
 {TP 15 4 13 9}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -79,11 +79,11 @@ Pass    Pass
 {HCP 14 3 13 10}
 {TP 14 6 13 10}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -100,12 +100,12 @@ Pass    Pass
 {HCP 15 3 19 3}
 {TP 15 3 19 5}
 {Losers 8 11 5 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    4C      Pass
-4NT     Pass    6NT     Pass
+2N     Pass    4C      Pass
+4N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -122,12 +122,12 @@ Pass    Pass
 {HCP 15 11 12 2}
 {TP 15 13 13 4}
 {Losers 7 6 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -144,10 +144,10 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 11 12 7}
 {Losers 8 6 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -164,10 +164,10 @@ Pass    Pass
 {HCP 15 3 14 8}
 {TP 15 3 14 8}
 {Losers 8 11 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -205,11 +205,11 @@ Pass    Pass
 {HCP 14 6 12 8}
 {TP 14 7 13 8}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -226,10 +226,10 @@ Pass    Pass
 {HCP 13 9 12 6}
 {TP 13 10 13 6}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -249,7 +249,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -267,13 +267,13 @@ Pass    Pass
 {HCP 14 9 12 5}
 {TP 14 11 12 6}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -290,11 +290,11 @@ Pass    Pass
 {HCP 14 9 14 3}
 {TP 14 10 14 5}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      3D
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -332,12 +332,12 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 7 13 7}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -354,11 +354,11 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 13 8 12 9}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -375,12 +375,12 @@ Pass    Pass
 {HCP 14 6 14 6}
 {TP 14 6 15 8}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -397,11 +397,11 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 11 14 2}
 {Losers 7 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -439,10 +439,10 @@ Pass    Pass
 {HCP 14 9 12 5}
 {TP 14 10 13 5}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -459,11 +459,11 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 11 13 4}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -501,11 +501,11 @@ Pass    Pass
 {HCP 13 4 14 9}
 {TP 13 5 14 9}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -522,11 +522,11 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 7 14 6}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -543,11 +543,11 @@ Pass    Pass
 {HCP 13 4 12 11}
 {TP 13 5 13 12}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      X       XX      1H
-Pass    2H      3NT     Pass
+Pass    2H      3N     Pass
 Pass    Pass    
 
 
@@ -564,10 +564,10 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 14 11 13 4}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -584,10 +584,10 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 8 12 6}
 {Losers 7 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -604,11 +604,11 @@ Pass    Pass
 {HCP 15 0 14 11}
 {TP 15 1 14 12}
 {Losers 7 11 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      1S      2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -667,10 +667,10 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 9 13 5}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -687,11 +687,11 @@ Pass    Pass
 {HCP 13 13 13 1}
 {TP 13 13 13 2}
 {Losers 8 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -708,12 +708,12 @@ Pass    Pass
 {HCP 15 7 11 7}
 {TP 15 7 12 7}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -730,11 +730,11 @@ Pass    Pass    1NT     Pass
 {HCP 15 10 14 1}
 {TP 15 11 16 3}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -751,10 +751,10 @@ Pass    Pass
 {HCP 15 10 11 4}
 {TP 15 11 12 6}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -792,12 +792,12 @@ Pass    Pass
 {HCP 15 11 11 3}
 {TP 15 13 15 4}
 {Losers 7 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      2H
 Pass    Pass    X       Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -835,11 +835,11 @@ Pass    Pass
 {HCP 13 6 14 7}
 {TP 13 6 14 8}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -856,10 +856,10 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 6 16 6}
 {Losers 8 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -876,11 +876,11 @@ Pass    Pass
 {HCP 13 11 14 2}
 {TP 13 11 14 4}
 {Losers 7 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -897,11 +897,11 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 7 12 7}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -939,11 +939,11 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 13 11 13 6}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      2C
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -960,11 +960,11 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 6 13 8}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -981,12 +981,12 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 8 13 4}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1025,10 +1025,10 @@ Pass    Pass
 {HCP 15 11 12 2}
 {TP 15 12 13 4}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1045,11 +1045,11 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 15 9 13 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1087,11 +1087,11 @@ Pass    Pass    1C      Pass
 {HCP 15 6 12 7}
 {TP 15 6 13 8}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1108,11 +1108,11 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 8 14 7}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1129,12 +1129,12 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 14 7 14 8}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1155,7 +1155,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1C      X
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 Pass    Pass    
 
 
@@ -1172,11 +1172,11 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 13 9 14 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1214,11 +1214,11 @@ Pass    Pass
 {HCP 13 7 14 6}
 {TP 13 10 14 7}
 {Losers 8 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1235,11 +1235,11 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 15 9 13 5}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1260,7 +1260,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-3D      Pass    4NT     Pass
+3D      Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -1301,13 +1301,13 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 7 14 9}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1324,10 +1324,10 @@ Pass    Pass
 {HCP 14 9 14 3}
 {TP 14 9 15 3}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1344,12 +1344,12 @@ Pass    Pass
 {HCP 13 6 11 10}
 {TP 13 8 12 11}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1D      Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1366,11 +1366,11 @@ Pass    Pass    1D      Pass
 {HCP 13 3 13 11}
 {TP 13 4 13 11}
 {Losers 8 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1387,10 +1387,10 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 7 14 7}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1428,11 +1428,11 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 8 12 7}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1454,7 +1454,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2H      Pass    3D      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -1472,11 +1472,11 @@ Pass    Pass
 {HCP 13 15 11 1}
 {TP 13 16 14 2}
 {Losers 8 5 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      2D
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1493,11 +1493,11 @@ Pass    Pass
 {HCP 15 5 12 8}
 {TP 15 6 12 8}
 {Losers 7 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1535,10 +1535,10 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 10 12 4}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1555,12 +1555,12 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 14 6 14 9}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1577,10 +1577,10 @@ Pass    Pass
 {HCP 15 4 14 7}
 {TP 15 5 15 8}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1618,10 +1618,10 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 8 14 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1638,10 +1638,10 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 8 14 6}
 {Losers 7 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1658,11 +1658,11 @@ Pass    Pass
 {HCP 13 6 12 9}
 {TP 13 7 13 9}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1679,11 +1679,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 13 9 15 6}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1700,11 +1700,11 @@ Pass    Pass
 {HCP 13 13 11 3}
 {TP 13 16 12 3}
 {Losers 8 5 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      2C
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1724,7 +1724,7 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -1742,11 +1742,11 @@ Pass    Pass
 {HCP 14 4 18 4}
 {TP 14 5 18 6}
 {Losers 8 10 6 9}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -1763,11 +1763,11 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 14 5 15 7}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1784,10 +1784,10 @@ Pass    Pass
 {HCP 15 10 12 3}
 {TP 15 12 12 5}
 {Losers 7 7 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1804,10 +1804,10 @@ Pass    Pass
 {HCP 13 8 13 6}
 {TP 13 9 14 6}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1824,10 +1824,10 @@ Pass    Pass
 {HCP 14 12 12 2}
 {TP 14 14 14 3}
 {Losers 8 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1844,10 +1844,10 @@ Pass    Pass
 {HCP 15 12 11 2}
 {TP 15 14 13 4}
 {Losers 8 6 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1864,10 +1864,10 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 10 13 2}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1889,7 +1889,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1C      Pass
 1H      Pass    1S      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -1906,10 +1906,10 @@ Pass    Pass
 {HCP 15 3 12 10}
 {TP 15 4 14 11}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1926,11 +1926,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 8 13 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1972,7 +1972,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -1990,12 +1990,12 @@ Pass    Pass
 {HCP 14 3 12 11}
 {TP 14 5 14 11}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2012,10 +2012,10 @@ Pass    Pass
 {HCP 14 12 12 2}
 {TP 14 12 12 2}
 {Losers 8 7 9 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2032,10 +2032,10 @@ Pass    Pass
 {HCP 13 3 16 8}
 {TP 13 5 18 8}
 {Losers 8 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2052,13 +2052,13 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 7 12 8}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2075,10 +2075,10 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 11 13 4}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2095,12 +2095,12 @@ Pass    Pass
 {HCP 15 13 11 1}
 {TP 15 13 12 2}
 {Losers 8 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2117,10 +2117,10 @@ Pass    Pass    1NT     Pass
 {HCP 13 6 11 10}
 {TP 13 7 13 10}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2137,11 +2137,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 7 13 6}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2179,13 +2179,13 @@ Pass    Pass
 {HCP 13 7 13 7}
 {TP 13 8 15 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2202,11 +2202,11 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 15 9 12 6}
 {Losers 7 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2223,10 +2223,10 @@ Pass    Pass
 {HCP 14 2 14 10}
 {TP 14 3 14 10}
 {Losers 7 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2243,13 +2243,13 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 7 13 6}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2270,7 +2270,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1C      1D
-1H      Pass    1NT     2S
+1H      Pass    1N     2S
 3C      Pass    Pass    Pass
 
 
@@ -2288,10 +2288,10 @@ Pass    Pass    1C      1D
 {HCP 14 13 12 1}
 {TP 14 13 14 2}
 {Losers 8 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2352,11 +2352,11 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 6 13 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2378,7 +2378,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1C      Pass
 1H      Pass    1S      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -2395,13 +2395,13 @@ Pass    Pass
 {HCP 15 9 14 2}
 {TP 15 11 15 3}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2418,12 +2418,12 @@ Pass    Pass
 {HCP 14 10 11 5}
 {TP 14 11 14 6}
 {Losers 8 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2440,10 +2440,10 @@ Pass    Pass
 {HCP 14 8 16 2}
 {TP 14 9 18 2}
 {Losers 7 8 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2460,12 +2460,12 @@ Pass    Pass
 {HCP 14 11 12 3}
 {TP 14 11 13 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2482,10 +2482,10 @@ Pass    Pass
 {HCP 14 5 15 6}
 {TP 14 7 17 6}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2502,12 +2502,12 @@ Pass    Pass
 {HCP 13 9 11 7}
 {TP 13 10 12 7}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2524,11 +2524,11 @@ Pass    Pass
 {HCP 15 5 14 6}
 {TP 15 5 14 6}
 {Losers 7 11 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2545,11 +2545,11 @@ Pass    Pass
 {HCP 15 0 14 11}
 {TP 15 2 15 12}
 {Losers 8 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      X       XX      1H
-Pass    2H      3NT     Pass
+Pass    2H      3N     Pass
 Pass    Pass    
 
 
@@ -2587,11 +2587,11 @@ Pass    Pass
 {HCP 14 6 12 8}
 {TP 14 6 12 8}
 {Losers 8 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2608,11 +2608,11 @@ Pass    Pass
 {HCP 15 7 13 5}
 {TP 15 8 13 6}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2653,7 +2653,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -2675,7 +2675,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -2693,10 +2693,10 @@ Pass    Pass
 {HCP 14 12 12 2}
 {TP 14 14 14 4}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2713,11 +2713,11 @@ Pass    Pass
 {HCP 13 7 13 7}
 {TP 13 8 13 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2734,11 +2734,11 @@ Pass    Pass
 {HCP 13 9 12 6}
 {TP 13 9 12 6}
 {Losers 8 9 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2755,12 +2755,12 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 14 11 13 5}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2777,11 +2777,11 @@ Pass    Pass
 {HCP 14 3 13 10}
 {TP 14 3 14 11}
 {Losers 8 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2798,10 +2798,10 @@ Pass    Pass
 {HCP 15 8 14 3}
 {TP 15 10 14 5}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2818,10 +2818,10 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 9 13 7}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2859,11 +2859,11 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 14 10 13 5}
 {Losers 8 8 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2901,11 +2901,11 @@ Pass    Pass
 {HCP 14 5 12 9}
 {TP 14 5 13 9}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2922,10 +2922,10 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 7 12 9}
 {Losers 7 9 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2942,12 +2942,12 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 6 15 5}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3006,10 +3006,10 @@ Pass    Pass
 {HCP 14 11 14 1}
 {TP 14 13 14 3}
 {Losers 7 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3026,11 +3026,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 9 13 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3047,11 +3047,11 @@ Pass    Pass
 {HCP 15 9 13 3}
 {TP 15 11 13 3}
 {Losers 8 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3068,11 +3068,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 11 13 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3089,11 +3089,11 @@ Pass    Pass
 {HCP 15 0 19 6}
 {TP 15 2 19 7}
 {Losers 8 10 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1D      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -3110,11 +3110,11 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 8 12 7}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3131,11 +3131,11 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 14 7 16 7}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3152,11 +3152,11 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 8 12 6}
 {Losers 7 9 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3194,11 +3194,11 @@ Pass    Pass
 {HCP 14 4 18 4}
 {TP 14 4 18 5}
 {Losers 8 11 5 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -3215,10 +3215,10 @@ Pass    Pass
 {HCP 15 7 13 5}
 {TP 15 8 13 5}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3235,10 +3235,10 @@ Pass    Pass
 {HCP 14 10 13 3}
 {TP 14 11 13 4}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3255,12 +3255,12 @@ Pass    Pass
 {HCP 15 12 11 2}
 {TP 15 14 12 3}
 {Losers 8 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3277,12 +3277,12 @@ Pass    Pass    1NT     Pass
 {HCP 15 2 19 4}
 {TP 15 3 19 6}
 {Losers 7 10 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    4C      Pass
-4S      Pass    6NT     Pass
+2N     Pass    4C      Pass
+4S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -3299,10 +3299,10 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 8 13 8}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3319,10 +3319,10 @@ Pass    Pass
 {HCP 15 3 14 8}
 {TP 15 3 14 8}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3364,7 +3364,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 5C      Pass    6C      Pass
 Pass    Pass    
 
@@ -3382,12 +3382,12 @@ Pass    Pass
 {HCP 13 1 16 10}
 {TP 13 2 17 10}
 {Losers 8 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3404,11 +3404,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 9 15 6}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3489,11 +3489,11 @@ Pass    Pass
 {HCP 13 8 16 3}
 {TP 13 9 18 4}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3510,11 +3510,11 @@ Pass    Pass
 {HCP 15 7 14 4}
 {TP 15 8 14 5}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3531,11 +3531,11 @@ Pass    Pass
 {HCP 13 6 14 7}
 {TP 13 7 16 7}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3552,11 +3552,11 @@ Pass    Pass
 {HCP 13 10 13 4}
 {TP 13 10 13 5}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3573,10 +3573,10 @@ Pass    Pass
 {HCP 14 4 13 9}
 {TP 14 4 13 9}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3593,13 +3593,13 @@ Pass    Pass
 {HCP 14 10 13 3}
 {TP 14 10 14 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3616,11 +3616,11 @@ Pass    Pass
 {HCP 14 12 12 2}
 {TP 14 12 12 4}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3637,11 +3637,11 @@ Pass    Pass
 {HCP 15 5 14 6}
 {TP 15 6 14 6}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3658,11 +3658,11 @@ Pass    Pass
 {HCP 13 12 11 4}
 {TP 13 12 13 5}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      2H
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3679,11 +3679,11 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 9 12 6}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3743,11 +3743,11 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 6 13 7}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3764,10 +3764,10 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 13 7 12 8}
 {Losers 8 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3784,10 +3784,10 @@ Pass    Pass
 {HCP 13 8 13 6}
 {TP 13 8 13 7}
 {Losers 8 8 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3804,13 +3804,13 @@ Pass    Pass
 {HCP 13 8 11 8}
 {TP 13 10 13 9}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
 2S      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3827,11 +3827,11 @@ Pass    Pass
 {HCP 14 3 13 10}
 {TP 14 4 13 10}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3848,11 +3848,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 8 13 5}
 {Losers 7 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3869,12 +3869,12 @@ Pass    Pass
 {HCP 14 3 14 9}
 {TP 14 4 14 10}
 {Losers 7 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3891,11 +3891,11 @@ Pass    Pass
 {HCP 15 3 12 10}
 {TP 15 3 13 10}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3912,11 +3912,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 9 13 7}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3933,10 +3933,10 @@ Pass    Pass
 {HCP 15 10 12 3}
 {TP 15 12 12 3}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3953,10 +3953,10 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 10 13 6}
 {Losers 8 7 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3973,10 +3973,10 @@ Pass    Pass
 {HCP 14 8 14 4}
 {TP 14 10 14 6}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3993,11 +3993,11 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 9 14 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4014,11 +4014,11 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 11 13 6}
 {Losers 8 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      1S
-X       2S      3NT     Pass
+X       2S      3N     Pass
 Pass    Pass    
 
 
@@ -4035,10 +4035,10 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 8 15 8}
 {Losers 7 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4055,11 +4055,11 @@ Pass    Pass
 {HCP 14 10 14 2}
 {TP 14 11 14 2}
 {Losers 7 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4076,13 +4076,13 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 8 14 9}
 {Losers 8 8 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
 2S      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4099,12 +4099,12 @@ Pass    Pass
 {HCP 15 4 19 2}
 {TP 15 5 19 3}
 {Losers 8 9 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    4C      Pass
-4H      Pass    6NT     Pass
+2N     Pass    4C      Pass
+4H      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -4121,11 +4121,11 @@ Pass    Pass
 {HCP 14 11 12 3}
 {TP 14 14 12 5}
 {Losers 7 6 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4142,11 +4142,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 13 9 15 6}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4163,12 +4163,12 @@ Pass    Pass
 {HCP 15 4 15 6}
 {TP 15 5 16 7}
 {Losers 8 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4185,10 +4185,10 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 7 13 6}
 {Losers 8 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4226,11 +4226,11 @@ Pass    Pass
 {HCP 14 10 11 5}
 {TP 14 11 12 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4290,13 +4290,13 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 8 13 4}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4313,11 +4313,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 10 12 4}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4355,10 +4355,10 @@ Pass    Pass
 {HCP 15 7 15 3}
 {TP 15 8 16 4}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4375,12 +4375,12 @@ Pass    Pass
 {HCP 13 1 19 7}
 {TP 13 2 19 8}
 {Losers 8 11 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+2N     Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -4397,10 +4397,10 @@ Pass    Pass
 {HCP 13 11 14 2}
 {TP 13 11 14 3}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4417,11 +4417,11 @@ Pass    Pass
 {HCP 15 5 19 1}
 {TP 15 5 19 2}
 {Losers 7 10 6 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -4459,10 +4459,10 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 13 9 14 5}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4479,10 +4479,10 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 7 13 8}
 {Losers 7 8 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4499,11 +4499,11 @@ Pass    Pass
 {HCP 13 4 14 9}
 {TP 13 4 14 9}
 {Losers 8 11 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4520,10 +4520,10 @@ Pass    Pass
 {HCP 15 9 13 3}
 {TP 15 9 13 3}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4540,12 +4540,12 @@ Pass    Pass
 {HCP 14 9 11 6}
 {TP 14 9 13 6}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-1H      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1H      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4562,10 +4562,10 @@ Pass    Pass
 {HCP 13 9 12 6}
 {TP 13 9 12 6}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4582,11 +4582,11 @@ Pass    Pass
 {HCP 14 4 14 8}
 {TP 14 5 14 8}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4603,12 +4603,12 @@ Pass    Pass
 {HCP 13 6 17 4}
 {TP 13 6 19 5}
 {Losers 8 10 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4625,12 +4625,12 @@ Pass    Pass
 {HCP 14 10 11 5}
 {TP 14 12 13 6}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4647,11 +4647,11 @@ Pass    Pass
 {HCP 14 3 14 9}
 {TP 14 4 14 10}
 {Losers 8 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4668,12 +4668,12 @@ Pass    Pass
 {HCP 15 10 11 4}
 {TP 15 11 12 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 2C      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4690,10 +4690,10 @@ Pass    Pass    1NT     Pass
 {HCP 15 8 12 5}
 {TP 15 10 14 5}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4710,10 +4710,10 @@ Pass    Pass
 {HCP 14 4 14 8}
 {TP 14 4 14 8}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4730,11 +4730,11 @@ Pass    Pass
 {HCP 14 11 14 1}
 {TP 14 11 14 2}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4751,10 +4751,10 @@ Pass    Pass
 {HCP 15 10 11 4}
 {TP 15 12 12 4}
 {Losers 7 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4813,12 +4813,12 @@ Pass    Pass
 {HCP 14 14 11 1}
 {TP 14 15 13 2}
 {Losers 8 6 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1C      1S
-2S      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2S      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4856,10 +4856,10 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 7 14 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4876,11 +4876,11 @@ Pass    Pass
 {HCP 14 7 15 4}
 {TP 14 8 15 4}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4897,10 +4897,10 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 14 6 14 9}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4920,7 +4920,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-Pass    Pass    1NT     2C
+Pass    Pass    1N     2C
 X       Pass    2D      2H
 Pass    Pass    Pass    
 
@@ -4938,10 +4938,10 @@ Pass    Pass    Pass
 {HCP 13 5 16 6}
 {TP 13 7 18 9}
 {Losers 8 9 5 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4958,10 +4958,10 @@ Pass    Pass
 {HCP 14 2 13 11}
 {TP 14 3 13 11}
 {Losers 7 10 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4978,11 +4978,11 @@ Pass    Pass
 {HCP 14 4 13 9}
 {TP 14 4 13 9}
 {Losers 7 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4999,11 +4999,11 @@ Pass    Pass
 {HCP 15 9 13 3}
 {TP 15 10 13 4}
 {Losers 7 8 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5020,11 +5020,11 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 13 11 13 6}
 {Losers 8 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5062,13 +5062,13 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 10 12 7}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5085,11 +5085,11 @@ Pass    Pass
 {HCP 14 3 16 7}
 {TP 14 4 18 9}
 {Losers 8 10 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5106,11 +5106,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 7 13 6}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5127,12 +5127,12 @@ Pass    Pass
 {HCP 15 7 15 3}
 {TP 15 9 16 4}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5149,10 +5149,10 @@ Pass    Pass
 {HCP 14 5 15 6}
 {TP 14 5 17 7}
 {Losers 7 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5169,11 +5169,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 7 14 6}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5190,10 +5190,10 @@ Pass    Pass
 {HCP 13 6 11 10}
 {TP 13 9 14 10}
 {Losers 8 6 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5231,11 +5231,11 @@ Pass    Pass
 {HCP 15 7 13 5}
 {TP 15 8 13 6}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5252,11 +5252,11 @@ Pass    Pass
 {HCP 14 4 12 10}
 {TP 14 4 12 10}
 {Losers 8 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5295,11 +5295,11 @@ Pass    Pass
 {HCP 13 6 13 8}
 {TP 13 8 14 9}
 {Losers 7 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5316,10 +5316,10 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 13 10 13 5}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5336,11 +5336,11 @@ Pass    Pass
 {HCP 14 12 12 2}
 {TP 14 12 13 4}
 {Losers 7 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5399,11 +5399,11 @@ Pass    Pass    1C      Pass
 {HCP 14 4 12 10}
 {TP 14 6 12 11}
 {Losers 8 9 9 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5420,10 +5420,10 @@ Pass    Pass
 {HCP 14 7 15 4}
 {TP 14 8 17 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5440,11 +5440,11 @@ Pass    Pass
 {HCP 13 5 12 10}
 {TP 13 5 12 10}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5461,10 +5461,10 @@ Pass    Pass
 {HCP 15 10 12 3}
 {TP 15 10 14 3}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5481,11 +5481,11 @@ Pass    Pass
 {HCP 13 11 12 4}
 {TP 13 11 12 5}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5502,11 +5502,11 @@ Pass    Pass
 {HCP 14 11 12 3}
 {TP 14 11 12 3}
 {Losers 8 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5523,10 +5523,10 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 8 15 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5564,12 +5564,12 @@ Pass    Pass
 {HCP 15 2 18 5}
 {TP 15 3 18 6}
 {Losers 8 10 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    4C      Pass
-4H      Pass    6NT     Pass
+2N     Pass    4C      Pass
+4H      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5607,11 +5607,11 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 9 12 7}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5633,7 +5633,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    3C      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -5673,10 +5673,10 @@ Pass    Pass    1C      Pass
 {HCP 15 8 12 5}
 {TP 15 8 12 6}
 {Losers 7 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5693,11 +5693,11 @@ Pass    Pass
 {HCP 13 3 15 9}
 {TP 13 5 16 9}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5714,11 +5714,11 @@ Pass    Pass
 {HCP 14 9 14 3}
 {TP 14 11 14 4}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5735,11 +5735,11 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 14 6 16 7}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5777,12 +5777,12 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 10 12 8}
 {Losers 8 7 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      1S
 Pass    Pass    X       Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5799,11 +5799,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 9 13 8}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      3C
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5820,12 +5820,12 @@ Pass    Pass
 {HCP 15 2 19 4}
 {TP 15 2 19 4}
 {Losers 7 11 7 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    4C      Pass
-4S      Pass    6NT     Pass
+2N     Pass    4C      Pass
+4S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5842,11 +5842,11 @@ Pass    Pass
 {HCP 13 2 17 8}
 {TP 13 3 17 8}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5863,10 +5863,10 @@ Pass    Pass
 {HCP 15 4 13 8}
 {TP 15 4 13 9}
 {Losers 7 10 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5904,11 +5904,11 @@ Pass    Pass
 {HCP 15 2 13 10}
 {TP 15 3 13 10}
 {Losers 7 11 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5925,13 +5925,13 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 7 14 6}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5969,11 +5969,11 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 6 14 5}
 {Losers 7 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6011,11 +6011,11 @@ Pass    Pass
 {HCP 14 3 18 5}
 {TP 14 4 18 6}
 {Losers 7 10 7 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2NT     Pass    4NT     Pass
+2N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -6032,11 +6032,11 @@ Pass    Pass
 {HCP 15 3 14 8}
 {TP 15 3 14 9}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6058,7 +6058,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    3C      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -6076,12 +6076,12 @@ Pass    Pass
 {HCP 13 6 11 10}
 {TP 13 8 14 11}
 {Losers 8 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6098,11 +6098,11 @@ Pass    Pass
 {HCP 15 5 14 6}
 {TP 15 6 14 7}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6161,11 +6161,11 @@ Pass    Pass
 {HCP 15 9 13 3}
 {TP 15 11 14 4}
 {Losers 8 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      1S
-2C      3S      3NT     Pass
+2C      3S      3N     Pass
 Pass    Pass    
 
 
@@ -6182,11 +6182,11 @@ Pass    Pass
 {HCP 13 4 18 5}
 {TP 13 4 18 6}
 {Losers 8 10 6 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -6203,11 +6203,11 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 10 14 6}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6224,11 +6224,11 @@ Pass    Pass
 {HCP 14 6 12 8}
 {TP 14 7 12 8}
 {Losers 7 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6245,11 +6245,11 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 8 12 6}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6266,11 +6266,11 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 7 13 6}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6287,12 +6287,12 @@ Pass    Pass
 {HCP 15 4 18 3}
 {TP 15 4 18 3}
 {Losers 8 11 6 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    4C      Pass
-4H      Pass    6NT     Pass
+2N     Pass    4C      Pass
+4H      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -6309,10 +6309,10 @@ Pass    Pass
 {HCP 14 8 14 4}
 {TP 14 9 14 5}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6329,11 +6329,11 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 9 12 8}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6354,7 +6354,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -6394,13 +6394,13 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 10 14 8}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6438,13 +6438,13 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 8 12 8}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6461,11 +6461,11 @@ Pass    Pass
 {HCP 15 6 11 8}
 {TP 15 7 12 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+Pass    Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6482,10 +6482,10 @@ Pass    Pass    1NT     Pass
 {HCP 14 7 13 6}
 {TP 14 8 13 8}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6502,12 +6502,12 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 9 14 8}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6524,10 +6524,10 @@ Pass    Pass
 {HCP 15 7 15 3}
 {TP 15 8 15 4}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6566,10 +6566,10 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 15 11 14 5}
 {Losers 8 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6586,11 +6586,11 @@ Pass    Pass
 {HCP 14 9 12 5}
 {TP 14 10 12 7}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6607,10 +6607,10 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 8 12 8}
 {Losers 7 8 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6627,11 +6627,11 @@ Pass    Pass
 {HCP 14 3 18 5}
 {TP 14 4 18 6}
 {Losers 8 10 6 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -6648,11 +6648,11 @@ Pass    Pass
 {HCP 15 8 14 3}
 {TP 15 9 14 4}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6669,10 +6669,10 @@ Pass    Pass
 {HCP 14 3 13 10}
 {TP 14 4 13 11}
 {Losers 8 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6689,11 +6689,11 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 14 6 13 8}
 {Losers 7 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6710,13 +6710,13 @@ Pass    Pass
 {HCP 15 5 12 8}
 {TP 15 5 12 9}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6733,11 +6733,11 @@ Pass    Pass
 {HCP 15 2 13 10}
 {TP 15 4 13 10}
 {Losers 7 9 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6757,7 +6757,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -6859,12 +6859,12 @@ Pass    Pass
 {HCP 15 12 12 1}
 {TP 15 12 12 2}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6881,11 +6881,11 @@ Pass    Pass
 {HCP 15 11 12 2}
 {TP 15 12 12 3}
 {Losers 7 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6902,11 +6902,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 12 12 5}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      X
-XX      2C      3NT     Pass
+XX      2C      3N     Pass
 Pass    Pass    
 
 
@@ -6923,10 +6923,10 @@ Pass    Pass
 {HCP 14 6 12 8}
 {TP 14 7 12 8}
 {Losers 8 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6943,11 +6943,11 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 6 14 6}
 {Losers 7 11 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6964,11 +6964,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 10 12 6}
 {Losers 7 8 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6985,10 +6985,10 @@ Pass    Pass
 {HCP 13 4 13 10}
 {TP 13 4 14 10}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7005,11 +7005,11 @@ Pass    Pass
 {HCP 14 4 16 6}
 {TP 14 7 17 7}
 {Losers 8 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7068,11 +7068,11 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 13 8 13 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7089,11 +7089,11 @@ Pass    Pass
 {HCP 14 3 13 10}
 {TP 14 5 13 11}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7110,11 +7110,11 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 9 12 7}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7131,11 +7131,11 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 6 13 8}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7152,10 +7152,10 @@ Pass    Pass
 {HCP 13 5 17 5}
 {TP 13 6 17 6}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7176,7 +7176,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      2S
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 4H      Pass    5D      Pass
 Pass    Pass    
 
@@ -7194,11 +7194,11 @@ Pass    Pass
 {HCP 13 5 14 8}
 {TP 13 5 15 9}
 {Losers 8 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7215,11 +7215,11 @@ Pass    Pass
 {HCP 14 9 12 5}
 {TP 14 9 13 5}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7257,11 +7257,11 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 15 11 13 5}
 {Losers 7 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7278,11 +7278,11 @@ Pass    Pass
 {HCP 14 6 17 3}
 {TP 14 9 19 3}
 {Losers 8 7 4 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      3D
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7299,10 +7299,10 @@ Pass    Pass
 {HCP 15 10 14 1}
 {TP 15 11 14 2}
 {Losers 8 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7319,11 +7319,11 @@ Pass    Pass
 {HCP 13 11 13 3}
 {TP 13 11 13 4}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7361,12 +7361,12 @@ Pass    Pass
 {HCP 15 8 11 6}
 {TP 15 10 12 9}
 {Losers 7 8 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 3C      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7383,11 +7383,11 @@ Pass    Pass
 {HCP 15 13 11 1}
 {TP 15 15 13 2}
 {Losers 7 6 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      2D
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7425,10 +7425,10 @@ Pass    Pass
 {HCP 14 3 13 10}
 {TP 14 4 13 10}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7445,11 +7445,11 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 8 13 7}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7466,10 +7466,10 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 7 12 7}
 {Losers 8 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7486,11 +7486,11 @@ Pass    Pass
 {HCP 14 8 13 5}
 {TP 14 8 13 6}
 {Losers 7 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7507,10 +7507,10 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 9 12 7}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7527,10 +7527,10 @@ Pass    Pass
 {HCP 13 12 14 1}
 {TP 13 13 14 2}
 {Losers 7 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7547,11 +7547,11 @@ Pass    Pass
 {HCP 14 4 18 4}
 {TP 14 5 18 4}
 {Losers 8 9 6 11}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1D      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -7568,11 +7568,11 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 14 6 14 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7589,10 +7589,10 @@ Pass    Pass
 {HCP 15 7 15 3}
 {TP 15 8 16 3}
 {Losers 7 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7609,13 +7609,13 @@ Pass    Pass
 {HCP 13 7 11 9}
 {TP 13 10 13 9}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7632,10 +7632,10 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 12 15 2}
 {Losers 8 6 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7652,10 +7652,10 @@ Pass    Pass
 {HCP 13 7 14 6}
 {TP 13 9 15 6}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7676,7 +7676,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1C      1S
-2S      Pass    2NT     Pass
+2S      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -7694,10 +7694,10 @@ Pass    Pass    1C      1S
 {HCP 15 2 13 10}
 {TP 15 2 13 10}
 {Losers 8 12 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7735,12 +7735,12 @@ Pass    Pass
 {HCP 14 5 11 10}
 {TP 14 5 12 10}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-1S      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1S      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7757,11 +7757,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 13 9 15 7}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7781,7 +7781,7 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -7820,11 +7820,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 10 13 6}
 {Losers 8 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      3H
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7841,10 +7841,10 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 14 9 13 4}
 {Losers 8 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7861,11 +7861,11 @@ Pass    Pass
 {HCP 15 5 11 9}
 {TP 15 6 12 9}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+Pass    Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7882,11 +7882,11 @@ Pass    Pass    1NT     Pass
 {HCP 13 7 13 7}
 {TP 13 7 13 7}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7903,13 +7903,13 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 7 14 7}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7947,12 +7947,12 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 6 14 7}
 {Losers 7 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7973,7 +7973,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 6C      Pass    6H      Pass
 Pass    Pass    
@@ -7992,11 +7992,11 @@ Pass    Pass
 {HCP 15 5 12 8}
 {TP 15 5 13 8}
 {Losers 7 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8013,11 +8013,11 @@ Pass    Pass
 {HCP 15 9 14 2}
 {TP 15 10 14 3}
 {Losers 7 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8034,11 +8034,11 @@ Pass    Pass
 {HCP 15 9 11 5}
 {TP 15 11 12 6}
 {Losers 7 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+Pass    Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8055,11 +8055,11 @@ Pass    Pass    1NT     Pass
 {HCP 13 12 12 3}
 {TP 13 12 13 4}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8076,11 +8076,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 10 13 6}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8097,13 +8097,13 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 8 12 5}
 {Losers 7 9 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8120,13 +8120,13 @@ Pass    Pass
 {HCP 13 10 13 4}
 {TP 13 10 13 5}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8143,12 +8143,12 @@ Pass    Pass
 {HCP 15 8 11 6}
 {TP 15 10 12 7}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
-2S      Pass    2NT     Pass
-3S      Pass    3NT     Pass
+Pass    Pass    1N     Pass
+2S      Pass    2N     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8165,11 +8165,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 10 13 5}
 {Losers 7 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8186,10 +8186,10 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 8 14 6}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8209,7 +8209,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -8269,11 +8269,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 14 10 12 5}
 {Losers 8 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8290,11 +8290,11 @@ Pass    Pass
 {HCP 14 8 12 6}
 {TP 14 10 13 6}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8311,10 +8311,10 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 14 8 15 7}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8331,11 +8331,11 @@ Pass    Pass
 {HCP 15 4 14 7}
 {TP 15 5 14 7}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8352,13 +8352,13 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 7 13 9}
 {Losers 7 9 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8375,10 +8375,10 @@ Pass    Pass
 {HCP 15 7 13 5}
 {TP 15 10 14 5}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8395,12 +8395,12 @@ Pass    Pass
 {HCP 13 6 12 9}
 {TP 13 7 13 9}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8417,10 +8417,10 @@ Pass    Pass
 {HCP 13 12 13 2}
 {TP 13 13 14 3}
 {Losers 8 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8440,7 +8440,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-Pass    Pass    1C      1NT
+Pass    Pass    1C      1N
 X       XX      Pass    2C
 2D      Pass    Pass    Pass
 
@@ -8459,12 +8459,12 @@ X       XX      Pass    2C
 {HCP 15 4 16 5}
 {TP 15 5 16 6}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8523,12 +8523,12 @@ Pass    Pass
 {HCP 15 12 11 2}
 {TP 15 12 13 3}
 {Losers 8 6 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     2C
-2S      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+Pass    Pass    1N     2C
+2S      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8609,10 +8609,10 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 14 7 15 8}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8650,11 +8650,11 @@ Pass    Pass
 {HCP 14 3 14 9}
 {TP 14 4 14 9}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8692,11 +8692,11 @@ Pass    Pass
 {HCP 13 10 12 5}
 {TP 13 12 13 6}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8713,10 +8713,10 @@ Pass    Pass
 {HCP 15 5 14 6}
 {TP 15 7 14 6}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8733,12 +8733,12 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 7 15 8}
 {Losers 8 9 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8760,7 +8760,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1C      Pass
 1H      Pass    1S      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -8777,11 +8777,11 @@ Pass    Pass
 {HCP 14 4 14 8}
 {TP 14 4 14 8}
 {Losers 8 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8798,11 +8798,11 @@ Pass    Pass
 {HCP 15 9 13 3}
 {TP 15 11 13 4}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8840,10 +8840,10 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 13 9 15 8}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8860,11 +8860,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 15 8 13 5}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8881,10 +8881,10 @@ Pass    Pass
 {HCP 13 6 12 9}
 {TP 13 6 12 9}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8901,12 +8901,12 @@ Pass    Pass
 {HCP 15 6 11 8}
 {TP 15 8 12 9}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 2C      Pass    2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8923,13 +8923,13 @@ Pass    Pass    1NT     Pass
 {HCP 15 7 11 7}
 {TP 15 8 13 8}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9010,11 +9010,11 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 14 6 15 9}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9031,13 +9031,13 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 8 14 5}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9054,11 +9054,11 @@ Pass    Pass
 {HCP 13 5 13 9}
 {TP 13 5 13 10}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9075,11 +9075,11 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 7 14 5}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9096,11 +9096,11 @@ Pass    Pass
 {HCP 15 4 13 8}
 {TP 15 6 14 9}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9117,11 +9117,11 @@ Pass    Pass
 {HCP 14 8 13 5}
 {TP 14 9 13 6}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9138,11 +9138,11 @@ Pass    Pass
 {HCP 15 10 12 3}
 {TP 15 12 13 3}
 {Losers 8 6 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      2H
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9159,11 +9159,11 @@ Pass    Pass
 {HCP 15 11 14 0}
 {TP 15 13 15 2}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      1S
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9180,10 +9180,10 @@ Pass    Pass
 {HCP 14 12 13 1}
 {TP 14 12 13 3}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9200,10 +9200,10 @@ Pass    Pass
 {HCP 13 5 12 10}
 {TP 13 6 13 10}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9220,11 +9220,11 @@ Pass    Pass
 {HCP 15 12 12 1}
 {TP 15 12 12 1}
 {Losers 7 7 8 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9241,11 +9241,11 @@ Pass    Pass
 {HCP 15 7 12 6}
 {TP 15 8 12 7}
 {Losers 7 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9262,11 +9262,11 @@ Pass    Pass
 {HCP 14 8 14 4}
 {TP 14 9 15 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9304,10 +9304,10 @@ Pass    Pass
 {HCP 15 8 12 5}
 {TP 15 10 13 6}
 {Losers 7 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9324,11 +9324,11 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 8 14 6}
 {Losers 7 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9345,10 +9345,10 @@ Pass    Pass
 {HCP 15 2 14 9}
 {TP 15 2 14 9}
 {Losers 8 11 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9365,11 +9365,11 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 7 12 8}
 {Losers 7 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9386,12 +9386,12 @@ Pass    Pass
 {HCP 15 5 11 9}
 {TP 15 6 12 10}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
-2S      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+Pass    Pass    1N     Pass
+2S      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9408,10 +9408,10 @@ Pass    Pass
 {HCP 13 8 13 6}
 {TP 13 9 15 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9470,11 +9470,11 @@ Pass    Pass
 {HCP 15 4 18 3}
 {TP 15 5 19 3}
 {Losers 7 10 6 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-4NT     Pass    6NT     Pass
+1C      Pass    3N     Pass
+4N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -9491,10 +9491,10 @@ Pass    Pass
 {HCP 14 3 13 10}
 {TP 14 5 15 11}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9511,12 +9511,12 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 10 14 7}
 {Losers 7 6 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9533,11 +9533,11 @@ Pass    Pass
 {HCP 14 3 12 11}
 {TP 14 3 12 12}
 {Losers 8 11 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      X       XX      1H
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9554,13 +9554,13 @@ Pass    Pass
 {HCP 14 6 17 3}
 {TP 14 9 18 5}
 {Losers 7 7 6 9}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      3C
 Pass    Pass    X       Pass
-3H      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+3H      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -9577,11 +9577,11 @@ Pass    Pass    X       Pass
 {HCP 15 7 12 6}
 {TP 15 8 12 7}
 {Losers 7 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9598,11 +9598,11 @@ Pass    Pass
 {HCP 14 10 13 3}
 {TP 14 13 13 5}
 {Losers 8 6 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9624,7 +9624,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 2S      Pass    3D      Pass
-3NT     Pass    6D      Pass
+3N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -9641,11 +9641,11 @@ Pass    Pass
 {HCP 13 9 12 6}
 {TP 13 9 13 6}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9662,13 +9662,13 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 7 13 7}
 {Losers 8 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9685,11 +9685,11 @@ Pass    Pass
 {HCP 14 10 16 0}
 {TP 14 11 16 2}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9706,11 +9706,11 @@ Pass    Pass
 {HCP 13 5 19 3}
 {TP 13 6 19 3}
 {Losers 8 9 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1D      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -9733,7 +9733,7 @@ Pass    Pass
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
 2S      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -9751,11 +9751,11 @@ Pass    Pass
 {HCP 15 2 19 4}
 {TP 15 3 19 6}
 {Losers 7 10 7 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -9814,13 +9814,13 @@ Pass    Pass
 {HCP 15 3 12 10}
 {TP 15 3 12 10}
 {Losers 8 11 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9837,12 +9837,12 @@ Pass    Pass
 {HCP 15 9 11 5}
 {TP 15 11 13 6}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2D      Pass    2H      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9859,10 +9859,10 @@ Pass    Pass
 {HCP 13 10 13 4}
 {TP 13 10 13 4}
 {Losers 8 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9943,11 +9943,11 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 15 10 13 5}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      1S
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9964,13 +9964,13 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 11 14 9}
 {Losers 8 6 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9987,12 +9987,12 @@ Pass    Pass
 {HCP 14 11 12 3}
 {TP 14 11 13 4}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10030,10 +10030,10 @@ Pass    Pass
 {HCP 14 6 15 5}
 {TP 14 9 16 8}
 {Losers 7 7 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10050,11 +10050,11 @@ Pass    Pass
 {HCP 13 12 12 3}
 {TP 13 13 12 4}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      X
-Pass    2H      3NT     Pass
+Pass    2H      3N     Pass
 Pass    Pass    
 
 
@@ -10071,11 +10071,11 @@ Pass    Pass
 {HCP 14 3 16 7}
 {TP 14 5 16 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10114,11 +10114,11 @@ Pass    Pass
 {HCP 13 10 12 5}
 {TP 13 11 12 6}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10135,11 +10135,11 @@ Pass    Pass
 {HCP 14 6 14 6}
 {TP 14 7 14 7}
 {Losers 8 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10156,10 +10156,10 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 8 14 6}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10176,10 +10176,10 @@ Pass    Pass
 {HCP 13 5 15 7}
 {TP 13 5 16 8}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10196,10 +10196,10 @@ Pass    Pass
 {HCP 15 7 13 5}
 {TP 15 7 13 7}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10216,13 +10216,13 @@ Pass    Pass
 {HCP 15 9 13 3}
 {TP 15 10 13 5}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10260,10 +10260,10 @@ Pass    Pass
 {HCP 15 4 12 9}
 {TP 15 5 13 9}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      Pass    3NT     Pass
+1D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10280,13 +10280,13 @@ Pass    Pass
 {HCP 15 4 13 8}
 {TP 15 4 13 8}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10303,11 +10303,11 @@ Pass    Pass
 {HCP 13 8 13 6}
 {TP 13 9 13 6}
 {Losers 8 7 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10366,13 +10366,13 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 14 5 13 9}
 {Losers 8 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10389,11 +10389,11 @@ Pass    Pass
 {HCP 14 4 14 8}
 {TP 14 5 14 8}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10431,12 +10431,12 @@ Pass    Pass
 {HCP 13 3 17 7}
 {TP 13 4 17 9}
 {Losers 8 10 6 8}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+2S      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -10453,12 +10453,12 @@ Pass    Pass
 {HCP 15 7 13 5}
 {TP 15 8 15 5}
 {Losers 7 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10539,10 +10539,10 @@ Pass    Pass    X       Pass
 {HCP 13 9 13 5}
 {TP 13 10 13 6}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 

--- a/GIB/3_Under_Invitational_Jump.pbn
+++ b/GIB/3_Under_Invitational_Jump.pbn
@@ -16,7 +16,7 @@
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -34,11 +34,11 @@
 {HCP 10 9 17 4}
 {TP 14 9 19 4}
 {Losers 5 8 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -161,11 +161,11 @@ Pass    Pass
 {HCP 11 11 14 4}
 {TP 13 12 16 5}
 {Losers 6 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -203,11 +203,11 @@ Pass    Pass
 {HCP 9 5 16 10}
 {TP 11 6 18 11}
 {Losers 6 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -308,11 +308,11 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 9 10 17 8}
 {Losers 8 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -391,11 +391,11 @@ Pass    Pass
 {HCP 9 10 16 5}
 {TP 13 14 18 6}
 {Losers 5 5 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      3H
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -433,11 +433,11 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 12 11 16 6}
 {Losers 6 7 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -515,11 +515,11 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 15 8 17 8}
 {Losers 5 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -659,11 +659,11 @@ Pass    Pass
 {HCP 9 10 17 4}
 {TP 12 10 19 4}
 {Losers 7 8 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -764,11 +764,11 @@ Pass    Pass
 {HCP 11 5 15 9}
 {TP 12 5 16 9}
 {Losers 7 11 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -785,11 +785,11 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 13 10 17 6}
 {Losers 6 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -850,7 +850,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3C      Pass
-4C      Pass    4NT     Pass
+4C      Pass    4N     Pass
 5S      Pass    6C      Pass
 Pass    Pass    
 
@@ -890,11 +890,11 @@ Pass    Pass
 {HCP 11 10 13 6}
 {TP 13 11 14 7}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -993,11 +993,11 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 15 8 18 6}
 {Losers 5 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1014,11 +1014,11 @@ Pass    Pass
 {HCP 10 14 15 1}
 {TP 11 14 16 1}
 {Losers 6 8 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1035,11 +1035,11 @@ Pass    Pass
 {HCP 9 13 15 3}
 {TP 12 14 17 5}
 {Losers 6 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1077,11 +1077,11 @@ Pass    Pass
 {HCP 9 11 19 1}
 {TP 9 12 20 3}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1098,11 +1098,11 @@ Pass    Pass
 {HCP 10 6 17 7}
 {TP 11 8 18 8}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1139,11 +1139,11 @@ Pass    Pass
 {HCP 9 14 17 0}
 {TP 11 14 20 0}
 {Losers 7 7 4 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1160,11 +1160,11 @@ Pass    Pass
 {HCP 9 12 14 5}
 {TP 10 14 15 6}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1181,11 +1181,11 @@ Pass    Pass
 {HCP 9 12 14 5}
 {TP 12 13 15 6}
 {Losers 6 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1412,7 +1412,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -1450,11 +1450,11 @@ Pass    Pass
 {HCP 10 5 17 8}
 {TP 11 5 19 9}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1532,11 +1532,11 @@ Pass    Pass
 {HCP 10 2 18 10}
 {TP 12 4 19 11}
 {Losers 6 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1595,11 +1595,11 @@ Pass    Pass
 {HCP 9 13 13 5}
 {TP 10 15 14 7}
 {Losers 8 6 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1656,11 +1656,11 @@ Pass    Pass
 {HCP 9 10 19 2}
 {TP 11 11 20 2}
 {Losers 7 7 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1739,11 +1739,11 @@ Pass    Pass
 {HCP 9 6 15 10}
 {TP 12 7 16 10}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1803,11 +1803,11 @@ Pass    Pass
 {HCP 10 4 18 8}
 {TP 12 4 19 8}
 {Losers 7 11 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1824,11 +1824,11 @@ Pass    Pass
 {HCP 11 11 14 4}
 {TP 12 12 15 4}
 {Losers 6 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1865,11 +1865,11 @@ Pass    Pass
 {HCP 10 3 17 10}
 {TP 12 3 19 10}
 {Losers 7 11 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1931,7 +1931,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -1970,11 +1970,11 @@ Pass    Pass
 {HCP 10 15 13 2}
 {TP 12 15 15 3}
 {Losers 6 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1991,11 +1991,11 @@ Pass    Pass
 {HCP 11 8 11 10}
 {TP 12 8 14 11}
 {Losers 7 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2012,11 +2012,11 @@ Pass    Pass
 {HCP 11 8 18 3}
 {TP 12 8 20 3}
 {Losers 7 9 4 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2096,11 +2096,11 @@ Pass    Pass
 {HCP 10 8 16 6}
 {TP 11 8 17 6}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2117,11 +2117,11 @@ Pass    Pass
 {HCP 9 8 18 5}
 {TP 12 8 19 7}
 {Losers 6 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2180,11 +2180,11 @@ Pass    Pass
 {HCP 10 8 13 9}
 {TP 11 8 15 9}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2201,11 +2201,11 @@ Pass    Pass
 {HCP 9 3 19 9}
 {TP 10 4 19 10}
 {Losers 8 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2222,11 +2222,11 @@ Pass    Pass
 {HCP 10 12 14 4}
 {TP 11 12 15 5}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2305,11 +2305,11 @@ Pass    Pass
 {HCP 10 2 18 10}
 {TP 11 4 18 10}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2347,11 +2347,11 @@ X       Pass    Pass    Pass
 {HCP 10 12 14 4}
 {TP 12 12 17 4}
 {Losers 7 8 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2368,11 +2368,11 @@ X       Pass    Pass    Pass
 {HCP 10 12 16 2}
 {TP 12 12 18 3}
 {Losers 6 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2431,11 +2431,11 @@ Pass    Pass
 {HCP 10 6 18 6}
 {TP 11 7 18 7}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2473,11 +2473,11 @@ Pass    Pass
 {HCP 10 4 16 10}
 {TP 11 6 19 10}
 {Losers 7 9 3 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2535,11 +2535,11 @@ Pass    Pass
 {HCP 9 9 18 4}
 {TP 10 11 20 6}
 {Losers 7 6 4 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2698,11 +2698,11 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 12 8 18 7}
 {Losers 6 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2739,11 +2739,11 @@ Pass    Pass
 {HCP 10 6 17 7}
 {TP 10 7 19 7}
 {Losers 7 9 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2821,11 +2821,11 @@ Pass    Pass
 {HCP 9 12 14 5}
 {TP 10 12 16 5}
 {Losers 7 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2842,11 +2842,11 @@ Pass    Pass
 {HCP 11 5 15 9}
 {TP 14 7 16 10}
 {Losers 4 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2863,11 +2863,11 @@ Pass    Pass
 {HCP 10 5 17 8}
 {TP 12 6 19 9}
 {Losers 7 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2947,11 +2947,11 @@ Pass    Pass
 {HCP 11 6 17 6}
 {TP 12 7 18 6}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2968,11 +2968,11 @@ Pass    Pass
 {HCP 11 10 14 5}
 {TP 13 11 15 6}
 {Losers 6 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3029,11 +3029,11 @@ Pass    Pass
 {HCP 10 13 14 3}
 {TP 12 14 15 5}
 {Losers 8 7 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3090,11 +3090,11 @@ Pass    Pass
 {HCP 11 4 17 8}
 {TP 13 5 19 8}
 {Losers 6 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3131,11 +3131,11 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 13 9 15 7}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3214,11 +3214,11 @@ Pass    Pass
 {HCP 10 11 17 2}
 {TP 11 12 18 2}
 {Losers 7 8 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3235,11 +3235,11 @@ Pass    Pass
 {HCP 10 8 18 4}
 {TP 13 9 18 5}
 {Losers 6 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3296,11 +3296,11 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 13 8 18 5}
 {Losers 6 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3317,11 +3317,11 @@ Pass    Pass
 {HCP 11 9 16 4}
 {TP 12 10 18 6}
 {Losers 6 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3358,11 +3358,11 @@ Pass    Pass
 {HCP 9 7 15 9}
 {TP 10 9 18 9}
 {Losers 7 8 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3399,11 +3399,11 @@ Pass    Pass
 {HCP 10 11 14 5}
 {TP 12 13 15 5}
 {Losers 6 6 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3440,11 +3440,11 @@ Pass    Pass
 {HCP 11 6 16 7}
 {TP 14 7 16 8}
 {Losers 6 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3481,11 +3481,11 @@ Pass    Pass
 {HCP 11 12 14 3}
 {TP 11 14 15 5}
 {Losers 6 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      3H
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3630,11 +3630,11 @@ Pass    Pass
 {HCP 9 5 16 10}
 {TP 11 6 18 10}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3693,11 +3693,11 @@ Pass    Pass
 {HCP 11 3 17 9}
 {TP 14 6 18 9}
 {Losers 6 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3714,11 +3714,11 @@ Pass    Pass
 {HCP 9 10 17 4}
 {TP 10 11 18 6}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3755,11 +3755,11 @@ Pass    Pass
 {HCP 10 10 17 3}
 {TP 12 10 20 4}
 {Losers 6 8 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3776,11 +3776,11 @@ Pass    Pass
 {HCP 11 4 15 10}
 {TP 13 5 18 10}
 {Losers 6 9 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3938,11 +3938,11 @@ Pass    Pass    Pass
 {HCP 9 10 14 7}
 {TP 11 11 15 8}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3959,11 +3959,11 @@ Pass    Pass    Pass
 {HCP 11 4 18 7}
 {TP 12 5 18 7}
 {Losers 6 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4062,11 +4062,11 @@ Pass    Pass
 {HCP 9 7 15 9}
 {TP 11 9 16 10}
 {Losers 8 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4083,11 +4083,11 @@ Pass    Pass
 {HCP 11 14 13 2}
 {TP 14 14 15 3}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4104,11 +4104,11 @@ Pass    Pass
 {HCP 10 9 14 7}
 {TP 11 9 15 7}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4146,11 +4146,11 @@ Pass    Pass
 {HCP 10 8 17 5}
 {TP 14 10 18 5}
 {Losers 6 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4167,11 +4167,11 @@ Pass    Pass
 {HCP 10 9 17 4}
 {TP 13 9 20 4}
 {Losers 6 9 4 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4311,11 +4311,11 @@ Pass    Pass
 {HCP 10 11 16 3}
 {TP 11 13 16 4}
 {Losers 8 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4353,11 +4353,11 @@ Pass    Pass
 {HCP 9 12 15 4}
 {TP 11 14 15 4}
 {Losers 8 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4374,11 +4374,11 @@ Pass    Pass
 {HCP 9 2 19 10}
 {TP 11 4 20 11}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4395,11 +4395,11 @@ Pass    Pass
 {HCP 9 6 18 7}
 {TP 10 8 19 7}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4416,11 +4416,11 @@ Pass    Pass
 {HCP 11 7 17 5}
 {TP 11 8 17 5}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4437,11 +4437,11 @@ Pass    Pass
 {HCP 10 11 14 5}
 {TP 11 12 15 5}
 {Losers 7 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4458,11 +4458,11 @@ Pass    Pass
 {HCP 9 7 19 5}
 {TP 11 8 20 7}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4545,7 +4545,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1H      Pass    3C      Pass
-4C      Pass    4NT     Pass
+4C      Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -4585,11 +4585,11 @@ Pass    Pass
 {HCP 10 7 14 9}
 {TP 11 8 15 10}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4752,11 +4752,11 @@ Pass    Pass
 {HCP 11 5 16 8}
 {TP 13 5 18 8}
 {Losers 6 10 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4795,11 +4795,11 @@ Pass    Pass
 {HCP 10 9 14 7}
 {TP 13 9 15 8}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4820,7 +4820,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3H      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5H      Pass    6H      Pass
 Pass    Pass    
 
@@ -4858,11 +4858,11 @@ Pass    Pass
 {HCP 10 12 13 5}
 {TP 13 13 15 5}
 {Losers 6 8 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4900,11 +4900,11 @@ Pass
 {HCP 10 6 18 6}
 {TP 13 6 19 8}
 {Losers 6 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4964,11 +4964,11 @@ Pass    Pass
 {HCP 9 11 17 3}
 {TP 11 12 19 4}
 {Losers 7 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5049,11 +5049,11 @@ Pass    Pass
 {HCP 10 11 14 5}
 {TP 12 13 17 6}
 {Losers 6 7 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5177,11 +5177,11 @@ Pass    Pass
 {HCP 9 7 17 7}
 {TP 12 10 20 8}
 {Losers 6 7 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5341,11 +5341,11 @@ Pass    Pass
 {HCP 11 10 15 4}
 {TP 12 13 15 5}
 {Losers 6 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5404,11 +5404,11 @@ X       Pass    Pass    Pass
 {HCP 9 11 16 4}
 {TP 11 12 18 5}
 {Losers 7 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5507,11 +5507,11 @@ Pass    Pass
 {HCP 9 7 16 8}
 {TP 9 7 19 9}
 {Losers 8 10 4 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5610,11 +5610,11 @@ Pass    Pass
 {HCP 9 9 14 8}
 {TP 9 12 15 8}
 {Losers 8 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5711,11 +5711,11 @@ Pass    Pass
 {HCP 10 10 17 3}
 {TP 12 11 20 5}
 {Losers 6 7 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5732,11 +5732,11 @@ Pass    Pass
 {HCP 10 4 17 9}
 {TP 12 5 18 9}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5916,11 +5916,11 @@ Pass    Pass
 {HCP 11 10 14 5}
 {TP 13 11 15 6}
 {Losers 6 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5981,7 +5981,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3D      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5S      Pass    6D      Pass
 Pass    Pass    
 
@@ -5999,11 +5999,11 @@ Pass    Pass
 {HCP 9 9 18 4}
 {TP 11 10 18 5}
 {Losers 7 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6020,11 +6020,11 @@ Pass    Pass
 {HCP 10 14 15 1}
 {TP 12 14 15 1}
 {Losers 6 6 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6061,11 +6061,11 @@ Pass    Pass
 {HCP 9 7 18 6}
 {TP 13 7 20 8}
 {Losers 5 10 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6164,11 +6164,11 @@ Pass    Pass
 {HCP 9 12 13 6}
 {TP 11 12 16 7}
 {Losers 7 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6205,11 +6205,11 @@ Pass    Pass
 {HCP 9 13 13 5}
 {TP 11 15 14 6}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6226,11 +6226,11 @@ Pass    Pass
 {HCP 9 12 14 5}
 {TP 12 13 17 5}
 {Losers 6 7 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6290,7 +6290,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    3H      3NT
+1S      Pass    3H      3N
 Pass    4C      4H      Pass
 4S      Pass    Pass    Pass
 
@@ -6452,11 +6452,11 @@ Pass    Pass
 {HCP 10 6 16 8}
 {TP 10 6 18 8}
 {Losers 7 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6493,11 +6493,11 @@ Pass    Pass
 {HCP 10 7 15 8}
 {TP 11 7 18 8}
 {Losers 8 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6514,11 +6514,11 @@ Pass    Pass
 {HCP 11 8 17 4}
 {TP 14 9 20 5}
 {Losers 6 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6535,11 +6535,11 @@ Pass    Pass
 {HCP 10 10 15 5}
 {TP 14 10 17 5}
 {Losers 6 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6618,11 +6618,11 @@ Pass    Pass
 {HCP 10 5 16 9}
 {TP 12 6 17 10}
 {Losers 6 9 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6726,8 +6726,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3H      Pass
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6D      Pass    6H      Pass
 Pass    Pass    
 
@@ -6912,7 +6912,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -6950,11 +6950,11 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 13 9 18 6}
 {Losers 7 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7012,11 +7012,11 @@ Pass    Pass
 {HCP 9 9 17 5}
 {TP 11 10 20 5}
 {Losers 7 8 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7118,7 +7118,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3C      Pass
-4C      Pass    4NT     Pass
+4C      Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -7136,11 +7136,11 @@ Pass    Pass
 {HCP 11 9 14 6}
 {TP 12 9 15 7}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7258,11 +7258,11 @@ Pass    Pass
 {HCP 10 10 16 4}
 {TP 13 11 17 5}
 {Losers 6 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7279,11 +7279,11 @@ Pass    Pass
 {HCP 9 13 17 1}
 {TP 11 13 18 1}
 {Losers 7 8 5 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7341,11 +7341,11 @@ Pass    Pass
 {HCP 10 6 19 5}
 {TP 13 6 20 6}
 {Losers 6 11 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7382,11 +7382,11 @@ Pass    Pass
 {HCP 9 5 16 10}
 {TP 11 5 18 10}
 {Losers 7 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7469,7 +7469,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3D      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -7695,11 +7695,11 @@ Pass    Pass
 {HCP 10 5 18 7}
 {TP 12 5 21 8}
 {Losers 8 10 4 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7716,11 +7716,11 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 12 8 17 8}
 {Losers 6 9 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7737,11 +7737,11 @@ Pass    Pass
 {HCP 9 7 19 5}
 {TP 10 9 19 6}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7798,11 +7798,11 @@ Pass    Pass
 {HCP 11 13 14 2}
 {TP 13 14 15 3}
 {Losers 7 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7819,11 +7819,11 @@ Pass    Pass
 {HCP 11 14 14 1}
 {TP 12 14 16 1}
 {Losers 7 7 5 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7902,11 +7902,11 @@ Pass    Pass
 {HCP 9 13 17 1}
 {TP 9 14 17 2}
 {Losers 8 5 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      3H
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7923,11 +7923,11 @@ Pass    Pass
 {HCP 11 7 13 9}
 {TP 14 9 14 9}
 {Losers 5 6 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8004,11 +8004,11 @@ Pass    Pass
 {HCP 9 7 17 7}
 {TP 9 7 17 7}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8107,11 +8107,11 @@ Pass    Pass
 {HCP 9 4 17 10}
 {TP 10 6 20 11}
 {Losers 7 9 4 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8148,11 +8148,11 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 12 8 18 6}
 {Losers 6 9 4 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8230,11 +8230,11 @@ Pass    Pass
 {HCP 10 14 13 3}
 {TP 13 14 16 4}
 {Losers 6 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8475,11 +8475,11 @@ Pass    Pass
 {HCP 10 13 15 2}
 {TP 11 13 16 2}
 {Losers 7 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8496,11 +8496,11 @@ Pass    Pass
 {HCP 10 10 17 3}
 {TP 13 12 17 3}
 {Losers 6 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8517,11 +8517,11 @@ Pass    Pass
 {HCP 9 14 16 1}
 {TP 10 14 18 2}
 {Losers 7 6 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8580,11 +8580,11 @@ Pass    Pass
 {HCP 9 8 13 10}
 {TP 11 9 16 11}
 {Losers 8 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8641,11 +8641,11 @@ Pass    Pass
 {HCP 11 11 14 4}
 {TP 12 12 15 5}
 {Losers 6 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8662,11 +8662,11 @@ Pass    Pass
 {HCP 9 13 15 3}
 {TP 12 13 18 4}
 {Losers 6 8 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8683,11 +8683,11 @@ Pass    Pass
 {HCP 9 10 19 2}
 {TP 10 11 19 3}
 {Losers 7 6 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8745,11 +8745,11 @@ Pass    Pass
 {HCP 10 5 16 9}
 {TP 12 6 19 9}
 {Losers 7 9 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8766,11 +8766,11 @@ Pass    Pass
 {HCP 11 10 14 5}
 {TP 13 10 16 5}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8787,11 +8787,11 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 12 10 17 7}
 {Losers 5 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8848,11 +8848,11 @@ Pass    Pass    Pass
 {HCP 10 9 14 7}
 {TP 12 9 17 8}
 {Losers 7 10 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8950,11 +8950,11 @@ Pass    Pass
 {HCP 11 2 19 8}
 {TP 12 4 19 9}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9118,7 +9118,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3H      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5H      Pass    6H      Pass
 Pass    Pass    
 
@@ -9177,11 +9177,11 @@ Pass    Pass
 {HCP 11 6 18 5}
 {TP 11 7 20 5}
 {Losers 8 9 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9342,11 +9342,11 @@ Pass    Pass
 {HCP 10 7 16 7}
 {TP 12 7 18 8}
 {Losers 7 9 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9446,11 +9446,11 @@ Pass    Pass
 {HCP 10 7 14 9}
 {TP 12 8 16 10}
 {Losers 7 9 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9487,11 +9487,11 @@ Pass    Pass
 {HCP 9 10 17 4}
 {TP 11 13 17 4}
 {Losers 7 6 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9528,11 +9528,11 @@ Pass    Pass
 {HCP 10 8 16 6}
 {TP 11 9 18 7}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9590,11 +9590,11 @@ Pass    Pass
 {HCP 9 8 19 4}
 {TP 11 8 20 6}
 {Losers 7 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9615,8 +9615,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1S      Pass    3H      Pass
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6C      Pass    6H      Pass
 Pass    Pass    
 
@@ -9654,11 +9654,11 @@ Pass    Pass    Pass
 {HCP 11 14 14 1}
 {TP 14 15 15 2}
 {Losers 6 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9675,11 +9675,11 @@ Pass    Pass    Pass
 {HCP 11 7 14 8}
 {TP 12 8 17 8}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9739,11 +9739,11 @@ Pass    Pass
 {HCP 10 11 13 6}
 {TP 12 11 16 6}
 {Losers 6 9 4 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9841,11 +9841,11 @@ Pass    Pass
 {HCP 9 5 17 9}
 {TP 11 5 17 10}
 {Losers 7 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9862,11 +9862,11 @@ Pass    Pass
 {HCP 9 12 14 5}
 {TP 10 12 16 5}
 {Losers 7 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9903,11 +9903,11 @@ Pass    Pass
 {HCP 11 9 17 3}
 {TP 13 9 17 5}
 {Losers 5 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9924,11 +9924,11 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 11 10 16 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9945,11 +9945,11 @@ Pass    Pass
 {HCP 11 5 15 9}
 {TP 13 6 17 9}
 {Losers 5 10 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10007,11 +10007,11 @@ Pass    Pass
 {HCP 10 8 17 5}
 {TP 12 9 18 5}
 {Losers 7 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10150,11 +10150,11 @@ Pass    Pass
 {HCP 9 10 16 5}
 {TP 13 12 17 5}
 {Losers 5 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10175,7 +10175,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -10214,11 +10214,11 @@ Pass    Pass
 {HCP 9 8 17 6}
 {TP 12 9 18 7}
 {Losers 6 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10276,11 +10276,11 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 11 10 16 7}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10297,11 +10297,11 @@ Pass    Pass
 {HCP 9 6 15 10}
 {TP 10 6 17 10}
 {Losers 8 11 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 

--- a/GIB/Cappelletti 2N.pbn
+++ b/GIB/Cappelletti 2N.pbn
@@ -6,7 +6,7 @@
 [Deal "N:65.AT5.J9853.J63 QT94.KQ96.A7.A75 K3.4.KQT64.KQ984 AJ872.J8732.2.T2"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -17,7 +17,7 @@ Pass    Pass
 [Deal "N:Q72.K65.KT943.J4 AT96.AQJT.J8.K98 .832.AQ765.AQ652 KJ8543.974.2.T73"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -28,7 +28,7 @@ Pass    Pass    Pass
 [Deal "N:K8763.QJT.52.764 AJT5.A6.K743.AJT .4.AQJT986.KQ932 Q942.K987532..85"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -37,10 +37,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:T542.96543.T3.97 Q986.KQT.K5.AJ86 3..AQJ986.KQT543 AKJ7.AJ872.742.2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2NT     Db      3D
-3NT     Pass    Pass    Pass
+1N     2N     Db      3D
+3N     Pass    Pass    Pass
 
 
 
@@ -51,7 +51,7 @@ Pass    Pass
 [Deal "N:J9754.JT5.2.AT85 AK32.AQ2.QT97.63 .86.AK653.KQJ974 QT86.K9743.J84.2"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -62,7 +62,7 @@ Pass    Pass    Pass
 [Deal "N:983.K742.JT53.J3 AKT2.QJ65.A2.Q65 75..KQ9764.AK972 QJ64.AT983.8.T84"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -73,7 +73,7 @@ Pass    Pass
 [Deal "N:J4.9642.Q732.632 A872.AK5.T8.AJ94 KT3..KJ954.KQT75 Q965.QJT873.A6.8"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -84,7 +84,7 @@ Pass    Pass
 [Deal "N:74.8654.Q752.862 JT86.AKJ9.A96.Q5 2.2.KJT83.AKT743 AKQ953.QT73.4.J9"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -95,7 +95,7 @@ Pass    Pass
 [Deal "N:A8432.973.942.97 KJT6.KT8.AT8.A65 .AQ.KJ765.KJT842 Q975.J6542.Q3.Q3"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -106,7 +106,7 @@ Pass    Pass    Pass
 [Deal "N:QT832.843.86.863 K654.AQJ5.97.KQ9 .92.AKT32.AJT742 AJ97.KT76.QJ54.5"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     Db      3C
+1N     2N     Db      3C
 Db      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -119,7 +119,7 @@ Db      Pass    3H      Pass
 [Deal "N:A76.QJ9853.3.854 K32.AK742.Q72.K6 T5..KJT98.AQJ932 QJ984.T6.A654.T7"]
 [Contract "4SX"]
 [Auction "E"]
-1NT     2NT     4S      Db
+1N     2N     4S      Db
 Pass    Pass    Pass    
 
 
@@ -130,7 +130,7 @@ Pass    Pass    Pass
 [Deal "N:KT2.KT82.984.985 QJ95.AQJ7.AT3.J7 64.3.KJ765.AKQ43 A873.9654.Q2.T62"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -141,7 +141,7 @@ Pass    Pass    Pass
 [Deal "N:Q873.98762.A53.8 AK5.KQJT5.T4.Q42 42.3.KQJ87.AKJT3 JT96.A4.962.9765"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -152,7 +152,7 @@ Pass    Pass    Pass
 [Deal "N:86.J86543.Q5.852 Q932.AK92.A2.KT4 K5..KJT974.AQJ73 AJT74.QT7.863.96"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -163,7 +163,7 @@ Pass    Pass    Pass
 [Deal "N:A842.T932.84.KJ6 KQJ7.AKJ.Q532.98 95.5.AKJ96.AQ543 T63.Q8764.T7.T72"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -174,7 +174,7 @@ Pass    Pass    Pass
 [Deal "N:AJT643.97643.8.2 KQ9.AKQ2.Q762.T4 52..AJT54.AKJ973 87.JT85.K93.Q865"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -185,7 +185,7 @@ Pass    Pass    Pass
 [Deal "N:T943.KQJ32.97.65 K75.AT.AJ32.KT92 2.54.KQT86.AQJ74 AQJ86.9876.54.83"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -196,7 +196,7 @@ Pass    Pass
 [Deal "N:Q8654.J865..J643 KT7.AQ72.A843.K8 .943.KQJ72.AQT97 AJ932.KT.T965.52"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -207,7 +207,7 @@ Pass    Pass
 [Deal "N:J86.Q98532.4.T98 Q9.AT7.AQ62.A642 7.K6.KJT87.KQJ75 AKT5432.J4.953.3"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -218,7 +218,7 @@ Pass    Pass
 [Deal "N:Q87653.A8.542.97 AKT.9752.A93.KQ6 9.KT.KQJ86.AJT85 J42.QJ643.T7.432"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -229,7 +229,7 @@ Pass    Pass    Pass
 [Deal "N:Q42.QT6.T86.A974 A986.AK9.K92.J86 KJ5..AJ743.KQT52 T73.J875432.Q5.3"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -240,7 +240,7 @@ Pass    Pass    Pass
 [Deal "N:AQ743.Q964.532.4 986.AKJ8.KQ.KT95 T.T.AJ9864.AQJ83 KJ52.7532.T7.762"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -251,7 +251,7 @@ Pass    Pass    Pass
 [Deal "N:T54.AQ4.T754.T86 AKQJ.T875.62.AK9 86..AKJ98.QJ7532 9732.KJ9632.Q3.4"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -262,7 +262,7 @@ Pass    Pass    Pass
 [Deal "N:A832.96532.653.7 9654.AKJ7.72.AK8 Q7..AKJ94.QJT932 KJT.QT84.QT8.654"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -273,7 +273,7 @@ Pass    Pass    Pass
 [Deal "N:JT97.AT953.3.J74 A8.QJ84.AQ987.Q5 Q4..KJT642.AK983 K6532.K762.5.T62"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -284,7 +284,7 @@ Pass    Pass    Pass
 [Deal "N:JT842.Q85.T85.A6 AKQ7.K763.K9.T92 6.T9.AQJ63.KQ743 953.AJ42.742.J85"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -295,7 +295,7 @@ Pass    Pass    Pass
 [Deal "N:QT6432.T6.65.964 J98.AKJ3.K4.KJ82 .854.AQ982.AQT73 AK75.Q972.JT73.5"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     Db      3C
+1N     2N     Db      3C
 Db      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -308,7 +308,7 @@ Db      Pass    3H      Pass
 [Deal "N:K62.T43.852.T952 873.AKJ76.KJ4.K4 .Q2.AQT963.AQ763 AQJT954.985.7.J8"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -319,7 +319,7 @@ Pass    Pass
 [Deal "N:T76.832.J643.QT5 AKJ95.QJ6.AT5.87 .A94.KQ872.KJ963 Q8432.KT75.9.A42"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     3D      Pass
+1N     2N     3D      Pass
 4S      Pass    Pass    Pass
 
 
@@ -331,7 +331,7 @@ Pass    Pass
 [Deal "N:A752.KJT2.JT.J94 KQT9.AQ97.43.AT7 J4.8.AK985.KQ653 863.6543.Q762.82"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -342,7 +342,7 @@ Pass    Pass    Pass
 [Deal "N:QJ764.QJT64.8.75 AT3.A92.K5.AJT63 9.7.AQT93.KQ9842 K852.K853.J7642."]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -353,7 +353,7 @@ Pass    Pass    Pass
 [Deal "N:863.AJ975.9.JT62 AK4.K43.KT853.A9 7.2.AQJ742.KQ873 QJT952.QT86.6.54"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -364,7 +364,7 @@ Pass    Pass    Pass
 [Deal "N:KQJ74.K85.653.JT A93.AQ2.QT2.A982 T6.3.AKJ94.KQ765 852.JT9764.87.43"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -375,7 +375,7 @@ Pass    Pass    Pass
 [Deal "N:AT86.T92.973.532 KQ72.KQJ6.A8.T87 J.75.KQT64.AKJ64 9543.A843.J52.Q9"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -386,7 +386,7 @@ Pass    Pass    Pass
 [Deal "N:J853.J8643.64.Q5 Q764.AK9.A2.A643 A.7.KQ853.KJT972 KT92.QT52.JT97.8"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -397,7 +397,7 @@ Pass    Pass    Pass
 [Deal "N:JT963.83.962.J97 A42.KQ6.K84.A643 Q.T5.AQ753.KQ852 K875.AJ9742.JT.T"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -408,7 +408,7 @@ Pass    Pass
 [Deal "N:QT.AQT32.K74.873 AK98.K8.J85.A942 32.J.AQT32.KQJT6 J7654.97654.96.5"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -419,7 +419,7 @@ Pass    Pass    Pass
 [Deal "N:Q765.Q92.QT972.2 KT9.A64.K4.KQT95 A2.7.AJ653.AJ863 J843.KJT853.8.74"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -430,7 +430,7 @@ Pass    Pass    Pass
 [Deal "N:QT765.A9542..Q74 KJ3.KQT8.K763.AT A4.6.AQT85.KJ832 982.J73.J942.965"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -441,7 +441,7 @@ Pass    Pass    Pass
 [Deal "N:9732.QJ952.T84.3 A4.AT6.K32.AJT64 T.84.AQJ75.KQ975 KQJ865.K73.96.82"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -452,7 +452,7 @@ Pass    Pass
 [Deal "N:K87432.KT43.2.92 AJ6.A986.A6.QT75 Q5.7.KJ873.AKJ84 T9.QJ52.QT954.63"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -463,7 +463,7 @@ Pass    Pass    Pass
 [Deal "N:Q832.KJ653.K73.3 AKJ7.A872.J6.KT4 5.Q.AQ542.AJ9865 T964.T94.T98.Q72"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -474,7 +474,7 @@ Pass    Pass    Pass
 [Deal "N:KJ972.Q765.42.64 AQ4.KJ94.AQ85.J8 6.8.KJT76.AKQ952 T853.AT32.93.T73"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -485,7 +485,7 @@ Pass    Pass    Pass
 [Deal "N:9765.KT53.973.Q6 KQJ4.Q92.KT5.A43 A82..AJ642.KJT72 T3.AJ8764.Q8.985"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -496,7 +496,7 @@ Pass    Pass    Pass
 [Deal "N:982.KQJT52.T2.76 AJ53.A43.Q5.KQ42 4..AJ9763.AJT983 KQT76.9876.K84.5"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     3D      Pass
+1N     2N     3D      Pass
 4S      Pass    Pass    Pass
 
 
@@ -508,7 +508,7 @@ Pass    Pass    Pass
 [Deal "N:T863.AT732.9.754 AJ4.QJ8.A853.KQ9 95..KQJ62.AJ8632 KQ72.K9654.T74.T"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -519,7 +519,7 @@ Pass    Pass
 [Deal "N:8654.T82.Q42.JT6 A7.AK93.A98.Q752 .J5.KJT765.AK983 KQJT932.Q764.3.4"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -530,7 +530,7 @@ Pass    Pass
 [Deal "N:JT43.K3.K862.T96 AK98.AQ2.94.Q742 5.96.AQJ53.AJ853 Q762.JT8754.T7.K"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -541,7 +541,7 @@ Pass    Pass    Pass
 [Deal "N:97642.JT2.QT85.T AJ8.AQ854.94.A63 3.96.AKJ32.KQ852 KQT5.K73.76.J974"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -552,7 +552,7 @@ Pass    Pass    Pass
 [Deal "N:KQJ962.J.9874.86 A43.AT2.KQ63.A73 .Q54.AJT52.KQT54 T875.K98763..J92"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -563,7 +563,7 @@ Pass    Pass    Pass
 [Deal "N:976542.Q6.J2.654 KQT.AJ92.K874.K2 .K7.AQT63.AJ9873 AJ83.T8543.95.QT"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -574,7 +574,7 @@ Pass    Pass    Pass
 [Deal "N:J7532.84.876.K76 A98.A953.K52.A93 6.K.AQJT4.QJT542 KQT4.QJT762.93.8"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -585,7 +585,7 @@ Pass    Pass
 [Deal "N:Q62.KQ87.Q74.T86 A53.AJ954.82.AQ4 T9..AKJT65.KJ972 KJ874.T632.93.53"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -596,7 +596,7 @@ Pass    Pass    Pass
 [Deal "N:T98764.A62.72.64 AKQJ.KJT.K843.T3 .543.AJT96.AKQ75 532.Q987.Q5.J982"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -607,7 +607,7 @@ Pass    Pass    Pass
 [Deal "N:9432.A953.T8.832 KQJT8.Q76.QJ.KQT 7..AK7654.AJ7654 A65.KJT842.932.9"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -618,7 +618,7 @@ Pass    Pass
 [Deal "N:T5.KQ753.AQT.942 AKQJ.AJ98.754.73 4.64.KJ932.AKQ85 987632.T2.86.JT6"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -629,7 +629,7 @@ Pass    Pass    Pass
 [Deal "N:AJ987.T96542.4.T Q3.AKQJ.QT2.QJ72 T.3.KJ875.AK9854 K6542.87.A963.63"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -640,7 +640,7 @@ Pass    Pass
 [Deal "N:T985.KQJT976.4.9 A6.A53.A983.A832 Q.8.KQJ76.KQT765 KJ7432.42.T52.J4"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -649,10 +649,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:T632.T9652.762.4 A874.KJ73.AQ.K96 Q5..KJT984.AQ752 KJ9.AQ84.53.JT83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2NT     Db      3D
-3NT     Pass    Pass    Pass
+1N     2N     Db      3D
+3N     Pass    Pass    Pass
 
 
 
@@ -663,7 +663,7 @@ Pass    Pass    Pass
 [Deal "N:KJ5.82.K753.T764 A9.KQ74.Q986.KQ5 Q86..AJT42.AJ832 T7432.AJT9653..9"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -674,7 +674,7 @@ Pass    Pass
 [Deal "N:J54.KT65.J3.KJ32 AK3.AJ87.K75.864 .Q4.AQT642.AQT75 QT98762.932.98.9"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -685,7 +685,7 @@ Pass    Pass    Pass
 [Deal "N:A9754.AQ64.7654. QT.KJT52.AQ3.A86 K.3.KJT82.KQ9432 J8632.987.9.JT75"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -696,7 +696,7 @@ Pass    Pass    Pass
 [Deal "N:JT962.T543.9.T65 KQ853.KJ.Q54.A84 4.A8.AJ732.KJ732 A7.Q9762.KT86.Q9"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     Db      3C
+1N     2N     Db      3C
 Db      Pass    3H      Pass
 3S      Pass    4H      Pass
 Pass    Pass    
@@ -709,7 +709,7 @@ Pass    Pass
 [Deal "N:KJ97432.982.4.Q3 A5.AK76.QJT8.J72 86.5.AK752.AK984 QT.QJT43.963.T65"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -720,7 +720,7 @@ Pass    Pass    Pass
 [Deal "N:T6.J9865.743.542 AK3.KT74.AKT.973 8.2.QJ8652.AKQJT QJ97542.AQ3.9.86"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -731,7 +731,7 @@ Pass    Pass
 [Deal "N:985.AKJT84.963.9 AKT72.72.Q87.AQ7 .Q3.AKJT52.KJ853 QJ643.965.4.T642"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -742,7 +742,7 @@ Pass    Pass    Pass
 [Deal "N:86.KQ9762.J72.92 KJT9.AJ4.AT.K873 Q.T.KQ9853.AQJ64 A75432.853.64.T5"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -753,7 +753,7 @@ Pass    Pass    Pass
 [Deal "N:96542.QT75.Q62.9 A7.AK432.AT7.543 QJ.6.KJ983.AQJ86 KT83.J98.54.KT72"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -764,7 +764,7 @@ Pass    Pass    Pass
 [Deal "N:AJ842.984.9873.4 K93.KJ765.AT2.A9 5.Q.KJ654.KQJT62 QT76.AT32.Q.8753"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -775,7 +775,7 @@ Pass    Pass    Pass
 [Deal "N:AT654.QJ965..762 KQJ.A87.Q854.A43 93.K.AJT72.KQT98 872.T432.K963.J5"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -786,7 +786,7 @@ Pass    Pass    Pass
 [Deal "N:72.AKT653.T62.83 KQJ6.QJ8.A74.QJ6 54.4.KQJ93.AKT94 AT983.972.85.752"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -797,7 +797,7 @@ Pass    Pass    Pass
 [Deal "N:QT94.J53.985.T64 J85.AKQT.QJ6.K73 .874.AKT42.AJ982 AK7632.962.73.Q5"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -808,7 +808,7 @@ Pass    Pass
 [Deal "N:KQJ964.J972.86.8 AT73.Q53.AJ4.A96 .K8.KQT75.KQT742 852.AT64.932.J53"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -819,7 +819,7 @@ Pass    Pass    Pass
 [Deal "N:643.QJT762.53.64 AQT2.A543.JT6.A5 .K9.KQ9874.KJ982 KJ9875.8.A2.QT73"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -830,7 +830,7 @@ Pass    Pass
 [Deal "N:JT6.AK65.75.J852 AK874.QT3.AQ.T63 Q.2.KJ8643.AQ974 9532.J9874.T92.K"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -841,7 +841,7 @@ Pass    Pass    Pass
 [Deal "N:QT732.J964.74.Q9 A65.KQ8.Q65.AT82 .A52.KJT93.KJ764 KJ984.T73.A82.53"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -852,7 +852,7 @@ Pass    Pass
 [Deal "N:82.AJT8432.Q74.7 AJ765.Q65.A5.AT2 KQ.9.KJ863.KJ854 T943.K7.T92.Q963"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -863,7 +863,7 @@ Pass    Pass    Pass
 [Deal "N:A76.T974.54.8765 J2.AKQ86.AJ2.JT9 54.5.KQ976.AKQ32 KQT983.J32.T83.4"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -874,7 +874,7 @@ Pass    Pass    Pass
 [Deal "N:654.QJ97.K852.J3 AQT8.A643.Q96.A9 3.K8.AJT43.KQT65 KJ972.T52.7.8742"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -885,7 +885,7 @@ Pass    Pass    Pass
 [Deal "N:KJT754.765.T62.T AQ3.KJ94.A754.Q9 98.3.KQJ98.AK532 62.AQT82.3.J8764"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -896,7 +896,7 @@ Pass    Pass
 [Deal "N:AT9842.T985.53.K 75.AKJ64.KQT.Q84 6..AJ9842.AJ7652 KQJ3.Q732.76.T93"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -907,7 +907,7 @@ Pass    Pass    Pass
 [Deal "N:98432.Q942.5.853 QJT5.AJ83.A82.K7 6.5.KQT743.AQJ94 AK7.KT76.J96.T62"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Db      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
@@ -920,7 +920,7 @@ Pass    Pass
 [Deal "N:KJ652.984.86.876 AQ7.QT6.QJ53.KJ4 83.J.AKT97.AQT92 T94.AK7532.42.53"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -931,7 +931,7 @@ Pass    Pass
 [Deal "N:T.Q543.K432.J753 AKQJ4.987.JT.A42 53..AQ9875.KQT86 98762.AKJT62.6.9"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -942,7 +942,7 @@ Pass    Pass
 [Deal "N:T765432.KT4.97.5 AK.A832.J8.A9872 .J.AKT6542.KQT63 QJ98.Q9765.Q3.J4"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -953,7 +953,7 @@ Pass    Pass    Pass
 [Deal "N:J75.JT7.QT843.84 KQ3.Q93.A95.KJT9 A4.5.KJ762.AQ732 T9862.AK8642..65"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -964,7 +964,7 @@ Pass    Pass
 [Deal "N:JT64.632.QT.9872 AK952.A85.A52.T4 .KQJ.KJ984.KJ653 Q873.T974.763.AQ"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -975,7 +975,7 @@ Pass    Pass    Pass
 [Deal "N:KJT754.6.65.JT54 A3.AQJ85.AT8.983 2.K2.KQ943.KQ762 Q986.T9743.J72.A"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -986,7 +986,7 @@ Pass    Pass    Pass
 [Deal "N:9853.AQT4.T963.4 KQ6.K53.QJ8.AT92 T.87.AK742.KQJ63 AJ742.J962.5.875"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -997,7 +997,7 @@ Pass    Pass    Pass
 [Deal "N:63.AKQJT964.T5.Q AKJ5.83.K64.A987 T.7.AQJ987.KJ642 Q98742.52.32.T53"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -1008,7 +1008,7 @@ Pass    Pass    Pass
 [Deal "N:T7643.KJ7.96.932 Q8.A865.KJ4.KQ85 K5.3.AQ873.AJT76 AJ92.QT942.T52.4"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -1019,7 +1019,7 @@ Pass    Pass
 [Deal "N:A8765.KT7.98653. KT942.A54.A2.KQ2 Q.J6.KQJT4.AJT87 J3.Q9832.7.96543"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -1030,7 +1030,7 @@ Pass    Pass    Pass
 [Deal "N:5.QJT9865.QT4.85 QT74.AK42.K93.A3 A.3.AJ652.KQT642 KJ98632.7.87.J97"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -1041,7 +1041,7 @@ Pass    Pass    Pass
 [Deal "N:K973.QT6.964.T94 Q54.AJ97.AT8.AQ5 6.K2.KQJ52.KJ876 AJT82.8543.73.32"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -1052,7 +1052,7 @@ Pass    Pass    Pass
 [Deal "N:Q9876.AQ62.53.Q3 AK2.J94.AT76.K94 53..KQJ984.AJ876 JT4.KT8753.2.T52"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -1063,7 +1063,7 @@ Pass    Pass    Pass
 [Deal "N:742.J97632.K5.Q6 AK.AKT84.T73.JT5 T9.5.AQ842.AK984 QJ8653.Q.J96.732"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -1074,7 +1074,7 @@ Pass    Pass    Pass
 [Deal "N:KJT843.KT63.J.A2 AQ.QJ74.A53.Q854 96.A.KQ864.KJT63 752.9852.T972.97"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -1085,7 +1085,7 @@ Pass    Pass    Pass
 [Deal "N:JT42.AQ873.53.92 KQ5.KJ.Q9762.AQ6 96.9.AKJ84.KJT54 A873.T6542.T.873"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -1096,7 +1096,7 @@ Pass    Pass    Pass
 [Deal "N:AT9853.83.65.QT9 QJ76.AK64.AJT.76 .J9.KQ943.AKJ832 K42.QT752.872.54"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -1107,6 +1107,6 @@ Pass    Pass    Pass
 [Deal "N:95432.J943.J4.K8 AK87.AK7.QT9.T54 6.86.AK752.AQ762 QJT.QT52.863.J93"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 

--- a/GIB/Cappelletti-2C.pbn
+++ b/GIB/Cappelletti-2C.pbn
@@ -6,8 +6,8 @@
 [Deal "N:QT.AT52..QT87653 KJ54.KQJ4.Q96.K4 92.876.AKJ8743.2 A8763.93.T52.AJ9"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2C      2H      Pass
-2S      Pass    2NT     Pass
+1N     2C      2H      Pass
+2S      Pass    2N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -19,7 +19,7 @@
 [Deal "N:A983.A82.Q862.42 J75.K95.AK93.AT8 KQ.QJT743.T5.K65 T642.6.J74.QJ973"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      2S      3H
 Pass    Pass    Pass    
 
@@ -31,7 +31,7 @@ Pass    Pass    Pass
 [Deal "N:93.K7632.J4.KT76 AQJ86.J85.AT.QJ8 T4.A9.KQ9762.953 K752.QT4.853.A42"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2C      Db      Pass
+1N     2C      Db      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -43,7 +43,7 @@ Pass    Pass
 [Deal "N:K64.KJ8653.T42.7 9752.A97.AK73.KQ AT..J98.AJ986543 QJ83.QT42.Q65.T2"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2C      Pass    2H
+1N     2C      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -54,7 +54,7 @@ Pass    Pass    Pass
 [Deal "N:Q3.J5.J7532.T853 A98.A642.AK9.Q42 J64.98.T8.AKJ976 KT752.KQT73.Q64."]
 [Contract "4S"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -67,7 +67,7 @@ Pass    Pass
 [Deal "N:J952.Q96.J832.AT AK.42.AKQT5.6543 Q6.KJ8753.97.KQ9 T8743.AT.64.J872"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -79,7 +79,7 @@ Pass    Pass
 [Deal "N:952.AK97542.52.J KQ83.T3.AQ93.A72 J76.Q8.K7.KQ9653 AT4.J6.JT864.T84"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2C      Pass    2H
+1N     2C      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -90,7 +90,7 @@ Pass    Pass    Pass
 [Deal "N:J8542.AT92.Q82.J Q93.K863.AT.AK94 K7.J74.KJ7643.Q7 AT6.Q5.95.T86532"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -102,7 +102,7 @@ Pass    Pass    Pass
 [Deal "N:84.54.KJ9643.AJ4 AKJ96.KJ6.Q7.QT3 Q72.AQT832.AT5.7 T53.97.82.K98652"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -114,7 +114,7 @@ Pass    Pass    Pass
 [Deal "N:AQ8.76.642.K8762 64.AK5.AKT3.QT54 KJT532.Q2.98.AJ3 97.JT9843.QJ75.9"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -126,7 +126,7 @@ Pass    Pass    Pass
 [Deal "N:KJ9.86.J3.Q65432 AT.KJ54.Q742.AK8 862.A.AKT865.JT9 Q7543.QT9732.9.7"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2S      Pass    3D      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
@@ -139,7 +139,7 @@ Pass    Pass
 [Deal "N:964.432.AQ73.AT6 AJ.AQ76.962.KQJ7 KQT532.8.K84.954 87.KJT95.JT5.832"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2S      Pass    3D      Pass
 3H      Pass    Pass    Pass
 
@@ -152,7 +152,7 @@ Pass    Pass
 [Deal "N:K52.94.64.KT8653 AQ7.KT8.QJ97.QJ2 JT.AJ6532.K32.A9 98643.Q7.AT85.74"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -164,7 +164,7 @@ Pass    Pass
 [Deal "N:Q63.972.92.KQ764 AK42.A6.AQ83.953 85.KQ.KJT754.AT8 JT97.JT8543.6.J2"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -176,7 +176,7 @@ Pass    Pass
 [Deal "N:3.98.K8543.Q7643 KT62.KQ3.AT.KJT8 QJ9.AT7542.972.A A8754.J6.QJ6.952"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -188,7 +188,7 @@ Pass    Pass
 [Deal "N:T94.KQJ84.K9.T62 A7.93.AT42.AQJ85 KQJ86532.A.QJ8.3 .T7652.7653.K974"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -199,7 +199,7 @@ Pass    Pass    Pass
 [Deal "N:8.K9.KJT.QJT8764 QT.Q43.A762.AK95 KJ765432.AT.843. A9.J87652.Q95.32"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      2S      Pass    Pass
 Pass    
 
@@ -211,7 +211,7 @@ Pass
 [Deal "N:KT4.T432.JT8.764 A32.AKQ5.75.A932 75.J96.AKQ632.J8 QJ986.87.94.KQT5"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -223,7 +223,7 @@ Pass
 [Deal "N:Q9854.J94.J63.AK AK2.AQT5.A54.652 J.K82.K7.QJT8743 T763.763.QT982.9"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2C      Pass    2NT
+1N     2C      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -235,7 +235,7 @@ Pass
 [Deal "N:J98.A642.A976.95 AQ7.J753.T5.AKQ6 2.KQ9.KQ8432.843 KT6543.T8.J.JT72"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -247,7 +247,7 @@ Pass
 [Deal "N:AJT876.982.5.Q96 K54.KQ4.K62.AJT5 9.A3.AQT9843.K83 Q32.JT765.J7.742"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3D      Pass    3S
+1N     3D      Pass    3S
 Pass    Pass    Pass    
 
 
@@ -258,7 +258,7 @@ Pass    Pass    Pass
 [Deal "N:AQ93.T92.975.KJT 84.QJ.AKQJ2.Q982 JT2.A86543.T3.A7 K765.K7.864.6543"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Db      2H      3D      Pass
 Pass    Pass    
 
@@ -270,7 +270,7 @@ Pass    Pass
 [Deal "N:T4.975.KJ62.Q875 A5.KT3.AQT9.K942 KQJ973.A2.43.J63 862.QJ864.875.AT"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -282,7 +282,7 @@ Pass    Pass
 [Deal "N:KT7.Q63.JT87.953 J63.AK84.A652.KQ AQ4.T92.4.AJ7642 9852.J75.KQ93.T8"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -294,7 +294,7 @@ Pass
 [Deal "N:JT7.T743.KJ95.A3 A2.AQ2.Q864.K962 KQ9854.KJ5.A72.5 63.986.T3.QJT874"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -306,7 +306,7 @@ Pass
 [Deal "N:K9.93.QT862.QT74 AQJ6.76.A94.A853 53.KQJ852.K75.J2 T8742.AT4.J3.K96"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -318,7 +318,7 @@ Pass
 [Deal "N:T8.K7.T8532.Q642 K92.QT9.AQ9.AJ85 AJ.A86542.74.K73 Q76543.J3.KJ6.T9"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -330,7 +330,7 @@ Pass
 [Deal "N:AT93.Q32.T5.9872 QJ86.J4.A84.AK53 72.AKT875.K73.QT K54.96.QJ962.J64"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -342,7 +342,7 @@ Pass
 [Deal "N:T7542.2.52.AQJ84 AQ96.K53.KQ97.KT KJ.AQ8764.86.763 83.JT9.AJT43.952"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -354,7 +354,7 @@ Pass
 [Deal "N:KQ52.J76.87.T987 J94.KT5.AT6.AKQ3 AT7.AQ9432.93.42 863.8.KQJ542.J65"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2C      3C      Pass
+1N     2C      3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -366,7 +366,7 @@ Pass
 [Deal "N:8.Q982.QJT984.J5 AJ4.AT7.A76.A974 KQ9632.K.K32.K86 T75.J6543.5.QT32"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      2S      Pass    Pass
 Pass    
 
@@ -378,9 +378,9 @@ Pass
 [Deal "N:J43.KQ854.987.75 K75.AT9.J5.AKJ94 AQT9862.J63.43.6 .72.AKQT62.QT832"]
 [Contract "5D"]
 [Auction "E"]
-1NT     2C      2S      Pass
+1N     2C      2S      Pass
 3C      Pass    3S      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -391,7 +391,7 @@ Pass    Pass
 [Deal "N:KQJ752..T754.KJ5 AT6.T62.AKQ.QT87 9.AKJ87543.32.32 843.Q9.J986.A964"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      Pass    2S
+1N     2C      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -402,7 +402,7 @@ Pass    Pass    Pass
 [Deal "N:A6.A4.JT854.T742 Q7.QJT7.KQ2.AQ93 KJ98532.K3.73.K5 T4.98652.A96.J86"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      2S      Pass    Pass
 3H      Pass    Pass    Pass
 
@@ -415,7 +415,7 @@ Pass    Pass    Pass
 [Deal "N:KJ543.982.A63.K4 AQ7.AK65.Q84.T75 T.Q74.KJT972.AQ9 9862.JT3.5.J8632"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2C      Pass    2NT
+1N     2C      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -427,7 +427,7 @@ Pass
 [Deal "N:862.KJT96.T2.642 KT3.A3.Q875.KQJ3 AQJ975.54.K3.AT7 4.Q872.AJ964.985"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -439,7 +439,7 @@ Pass
 [Deal "N:KT543.653.K3.J65 A2.AQ9.J94.AQ842 J.K74.AT8652.K73 Q9876.JT82.Q7.T9"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -451,7 +451,7 @@ Pass
 [Deal "N:K9743.5.AT643.KT AQJ8.T86.KJ9.AQ3 65.AKJ972.872.98 T2.Q43.Q5.J76542"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -463,7 +463,7 @@ Pass
 [Deal "N:T962.A654.AT742. AK83.KQ3.95.K875 Q4.T97.KJ.AJT942 J75.J82.Q863.Q63"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -475,7 +475,7 @@ Pass
 [Deal "N:J96.AQ5.AJ7543.8 KQ4.KJ732.K8.KT9 82.94.Q62.AQJ652 AT753.T86.T9.743"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    3D
 Pass    Pass    Pass    
 
@@ -487,7 +487,7 @@ Pass    Pass    Pass
 [Deal "N:Q95.Q764.K762.QJ 42.KJT9.AJ8.AK93 AKT873.5.QT5.652 J6.A832.943.T874"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -499,7 +499,7 @@ Pass
 [Deal "N:QT9.42.T83.87432 A5.Q975.AJ76.KQ6 643.AKT863.9.JT9 KJ872.J.KQ542.A5"]
 [Contract "5D"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3D      Pass
 3H      Db      4C      Pass
 4S      Pass    5D      Pass
@@ -513,7 +513,7 @@ Pass    Pass
 [Deal "N:QT92.J832..Q7654 643.AK.AT86.AJ98 AJ.T54.KQJ754.K2 K875.Q976.932.T3"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    Pass    2H      Pass
 Pass    Pass    
 
@@ -525,7 +525,7 @@ Pass    Pass
 [Deal "N:KJ87.T2.Q975.983 AT54.QJ97.AJ.A72 Q3.AK8654.T86.JT 962.3.K432.KQ654"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -537,8 +537,8 @@ Pass
 [Deal "N:KQJ75.53..KQT974 942.AKT9.KQ9.AJ5 AT3.J4.AJ6542.63 86.Q8762.T873.82"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2C      2D      Pass
-2NT     Pass    3D      Pass
+1N     2C      2D      Pass
+2N     Pass    3D      Pass
 3H      Pass    Pass    Pass
 
 
@@ -550,7 +550,7 @@ Pass
 [Deal "N:AJ854.K65.K862.3 KQ2.Q732.A3.AQT7 T63.A.QJT754.K96 97.JT984.9.J8542"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 3D      Pass    3H      Pass
 Pass    Pass    
 
@@ -562,7 +562,7 @@ Pass    Pass
 [Deal "N:J87.J8752.A96.94 AQ53.AK64.K32.65 K4.QT3.QJT875.A2 T962.9.4.KQJT873"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -574,7 +574,7 @@ Pass    Pass
 [Deal "N:A93.9762.T96.Q74 KJT8.QT.KQ52.A62 6.AKJ853.J87.KJT Q7542.4.A43.9853"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -586,7 +586,7 @@ Pass    Pass
 [Deal "N:97.JT.Q9.AKT9873 AJ42.A642.A64.Q2 T63.K87.KJT7532. KQ85.Q953.8.J654"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2C      Db      Pass
+1N     2C      Db      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -598,7 +598,7 @@ Pass    Pass
 [Deal "N:A82.AJ875.JT98.Q KQT9.KQ2.A4.JT87 J7.T63.5.AK96543 6543.94.KQ7632.2"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2C      3C      Pass
+1N     2C      3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -610,7 +610,7 @@ Pass    Pass
 [Deal "N:KQJ93.9.K53.8752 A65.AQ84.87.AQT9 72.JT7.AQJ962.43 T84.K6532.T4.KJ6"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -622,7 +622,7 @@ Pass    Pass    Pass
 [Deal "N:.AJ86.JT432.7432 K7.97.AQ98.AQJ86 AQT983.KQ43.7.K5 J6542.T52.K65.T9"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -633,7 +633,7 @@ Pass    Pass    Pass
 [Deal "N:9653.98.QJT7654. 42.KT5.AK92.AQT4 AQT7.AQJ642..865 KJ8.73.83.KJ9732"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3H      Pass    3S
 Pass    Pass    Pass    
 
@@ -645,7 +645,7 @@ Pass    Pass    Pass
 [Deal "N:K843.J54.82.K853 J6.KT63.AKQ3.A97 AQ972.AQ97.J9.J6 T5.82.T7654.QT42"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -656,7 +656,7 @@ Pass    Pass    Pass
 [Deal "N:KT854.654.T74.K5 Q7.QJ9.AKQ2.JT93 AJ62.AK872.653.6 93.T3.J98.AQ8742"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3S
 Pass    Pass    Pass    
 
@@ -668,7 +668,7 @@ Pass    Pass    Pass
 [Deal "N:JT97.983.K.96532 A54.T4.AJ965.AQT KQ863.KQ62.83.84 2.AJ75.QT742.KJ7"]
 [Contract "5D"]
 [Auction "E"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 4D      Pass    5D      Pass
 Pass    Pass    
 
@@ -680,7 +680,7 @@ Pass    Pass
 [Deal "N:43.QT73.94.QT842 KJT.K54.KQT82.A6 AQ875.AJ982.5.J5 962.6.AJ763.K973"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -692,7 +692,7 @@ Pass    Pass
 [Deal "N:KQ63.854.9754.KQ T8.KQ62.AKT.AJ97 AJ97542.AJT3.3.8 .97.QJ862.T65432"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2D      2NT     3S
+1N     2D      2N     3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -704,7 +704,7 @@ Pass
 [Deal "N:J.AT2.AJ943.A973 A6.94.KQ76.KQJ42 KQ95.KQ863.82.T5 T87432.J75.T5.86"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2D      Pass    2NT
+1N     2D      Pass    2N
 Pass    3D      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -717,7 +717,7 @@ Pass
 [Deal "N:T84.986.AKT9.T75 A52.AJ753.Q6.A92 KQJ93.KQT4.842.Q 76.2.J753.KJ8643"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -729,7 +729,7 @@ Pass
 [Deal "N:T93.985.K9732.T6 K75.A3.AQT54.K74 AJ64.KQT762..A92 Q82.J4.J86.QJ853"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3H      Pass    Pass
 Pass    
 
@@ -741,7 +741,7 @@ Pass
 [Deal "N:7.T98.QJT.J98742 AT2.J7543.AK2.K5 KJ9853.AQ62..QT6 Q64.K.9876543.A3"]
 [Contract "4D"]
 [Auction "E"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 4D      Pass    Pass    Pass
 
 
@@ -753,7 +753,7 @@ Pass
 [Deal "N:JT3.8.98753.Q875 Q86.753.AJ2.AKJ3 AK97.KQ962.Q.964 542.AJT4.KT64.T2"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -764,7 +764,7 @@ Pass    Pass    Pass
 [Deal "N:Q7643.8.62.KJ752 A5.A7.JT874.AQ98 KJ982.KQJ432.A9. T.T965.KQ53.T643"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -774,10 +774,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:J94.T43.J87.J963 A53.Q72.53.AKQ72 KQ72.AK985.92.85 T86.J6.AKQT64.T4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2D      3D      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -788,7 +788,7 @@ Pass    Pass    Pass
 [Deal "N:93.8.96532.AQ865 KQ7.AT962.QJ.K92 AJ8654.KQJ753.K. T2.4.AT874.JT743"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3H      Pass    3S
 Pass    Pass    Pass    
 
@@ -800,7 +800,7 @@ Pass    Pass    Pass
 [Deal "N:T74.T54.K8.J9753 AQ3.K92.AT5.KT62 KJ986.AQJ7.J764. 52.863.Q932.AQ84"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -811,7 +811,7 @@ Pass    Pass    Pass
 [Deal "N:43.J62.AQT752.93 AQ.7543.KJ98.AJ7 KJT752.KQT98..T8 986.A.643.KQ6542"]
 [Contract "5C"]
 [Auction "E"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 3D      Pass    4C      Pass
 5C      Pass    Pass    Pass
 
@@ -824,7 +824,7 @@ Pass    Pass    Pass
 [Deal "N:K95.92.A86.JT952 732.K54.KQT.AK76 AQJ6.AQJ86.952.4 T84.T73.J743.Q83"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -835,7 +835,7 @@ Pass    Pass    Pass
 [Deal "N:T.AJ876.K74.JT95 AJ52.53.A853.AQ2 KQ963.KQ942.JT6. 874.T.Q92.K87643"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2D      2NT     3H
+1N     2D      2N     3H
 Pass    4H      Pass    Pass
 Pass    
 
@@ -847,7 +847,7 @@ Pass
 [Deal "N:KJ875.42.QJ9.543 93.Q9.A532.AKQJ7 AQT2.KJ863.K8.86 64.AT75.T764.T92"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -858,7 +858,7 @@ Pass    Pass    Pass
 [Deal "N:952.Q7.A9853.872 J4.KT2.QJT.AKQ93 AKQ763.AJ865.7.5 T8.943.K642.JT64"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    3S      Pass    Pass
 Pass    
 
@@ -870,7 +870,7 @@ Pass
 [Deal "N:T54.52.K953.QJT5 A82.K974.A876.A4 KQ97.AJT86.4.K32 J63.Q3.QJT2.9876"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -879,10 +879,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:JT63.7.T87.T9652 A85.86.AQJ4.KQ87 KQ94.KJT9432.52. 72.AQ5.K963.AJ43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2D      2H      Pass
-3NT     Pass    Pass    Pass
+1N     2D      2H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -893,7 +893,7 @@ Pass    Pass    Pass
 [Deal "N:94.T432.872.QJ54 72.J96.AKJT.AK63 AKT8.AK875.5.T72 QJ653.Q.Q9643.98"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    3D      Pass
 Pass    Db      Pass    3H
 Pass    Pass    Pass    
@@ -906,7 +906,7 @@ Pass    Pass    Pass
 [Deal "N:7543.T85.73.JT95 KJ.972.AJ95.AK43 AQT2.KQJ63.64.87 986.A4.KQT82.Q62"]
 [Contract "5D"]
 [Auction "E"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 4D      Pass    5D      Pass
 Pass    Pass    
 
@@ -918,7 +918,7 @@ Pass    Pass
 [Deal "N:982.9542.J73.K83 A43.87.AK95.AJ75 KJ765.AKJ63.Q4.9 QT.QT.T862.QT642"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3H
 Pass    Pass    Pass    
 
@@ -930,7 +930,7 @@ Pass    Pass    Pass
 [Deal "N:JT52.863.QT53.J3 K7.QT4.AK976.K95 AQ98.KJ975.42.Q8 643.A2.J8.AT7642"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3S
 Pass    Pass    Pass    
 
@@ -942,7 +942,7 @@ Pass    Pass    Pass
 [Deal "N:843.JT7.K82.A942 A65.943.AQ9.KQ63 KQ72.AKQ65.54.T7 JT9.82.JT763.J85"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    3H      Pass    4S
 Pass    Pass    Pass    
 
@@ -954,7 +954,7 @@ Pass    Pass    Pass
 [Deal "N:6.K765.KJT6.A873 AT9.92.AQ54.KQ64 KQ832.AJT83.972. J754.Q4.83.JT952"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2D      Pass    4H
+1N     2D      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -965,7 +965,7 @@ Pass    Pass    Pass
 [Deal "N:.Q865.QT5.987652 T3.93.AJ82.AKQJ3 KQ98642.AJ42.K.4 AJ75.KT7.97643.T"]
 [Contract "3SX"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3S      Db      Pass
 Pass    Pass    
 
@@ -977,8 +977,8 @@ Pass    Pass
 [Deal "N:Q642.T832.64.T92 AT75.KQ64.Q9.A74 KJ983.AJ95.T5.K3 .7.AKJ8732.QJ865"]
 [Contract "6D"]
 [Auction "E"]
-1NT     2D      3C      Pass
-3NT     Pass    6D      Pass
+1N     2D      3C      Pass
+3N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -989,7 +989,7 @@ Pass    Pass
 [Deal "N:JT876.T3.842.K82 A93.A87.AK976.63 KQ42.KJ642.QT3.5 5.Q95.J5.AQJT974"]
 [Contract "5C"]
 [Auction "E"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 3D      Pass    4C      Pass
 5C      Pass    Pass    Pass
 
@@ -1002,7 +1002,7 @@ Pass    Pass
 [Deal "N:K532.7.KJ32.JT94 Q8.Q63.A9654.AK7 AJT7.AKJ95.8.832 964.T842.QT7.Q65"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -1011,10 +1011,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:74.87652.QT8.QJ7 A2.A3.K6532.A985 KJ853.KQJT.J.T63 QT96.94.A974.K42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2D      Db      2H
-3NT     Pass    Pass    Pass
+1N     2D      Db      2H
+3N     Pass    Pass    Pass
 
 
 
@@ -1025,7 +1025,7 @@ Pass    Pass    Pass
 [Deal "N:T4.J98765.T96.Q6 A65.K3.KJ4.AJ973 KQ982.AQT4.Q52.4 J73.2.A873.KT852"]
 [Contract "4C"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3H
 4C      Pass    Pass    Pass
 
@@ -1038,7 +1038,7 @@ Pass    Pass    Pass
 [Deal "N:JT65.2.KQ8653.86 K8.AJ53.AT7.QJ53 AQ73.KQT9876.2.2 942.4.J94.AKT974"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3H      Pass    3S
 Pass    Pass    Pass    
 
@@ -1050,7 +1050,7 @@ Pass    Pass    Pass
 [Deal "N:82.8543.A862.AT4 QJ4.AQ97.KQ4.J65 AK95.KJT62.T9.93 T763..J753.KQ872"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3H
 Pass    Pass    Pass    
 
@@ -1062,7 +1062,7 @@ Pass    Pass    Pass
 [Deal "N:5.982.KJT63.T854 AKT4.743.985.AKQ QJ8632.AQ65.Q2.J 97.KJT.A74.97632"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1074,7 +1074,7 @@ Pass    Pass    Pass
 [Deal "N:J86.6.J8432.Q962 42.QJ84.AKQT.A75 AKT97.AK52.7.T83 Q53.T973.965.KJ4"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    3S      Pass    Pass
 Pass    
 
@@ -1086,7 +1086,7 @@ Pass
 [Deal "N:9.972.J85.KQ8653 AT65.KQ4.QT4.AJT KQJ842.AJ653.62. 73.T8.AK973.9742"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3S      Pass    4H
 Pass    Pass    Pass    
 
@@ -1098,7 +1098,7 @@ Pass    Pass    Pass
 [Deal "N:A4.J8642.J52.A87 976.K7.AKT.KQ532 KJT85.AQT53.93.4 Q32.9.Q8764.JT96"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      2NT     3H
+1N     2D      2N     3H
 Pass    Pass    Pass    
 
 
@@ -1109,7 +1109,7 @@ Pass    Pass    Pass
 [Deal "N:A86.5.KT943.J982 J2.A74.A86.AKT64 KQT93.KQJ92.52.3 754.T863.QJ7.Q75"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -1120,7 +1120,7 @@ Pass    Pass    Pass
 [Deal "N:T75.8.T98762.KQ7 J96.AJ76.AK3.A96 AKQ4.KQT43.54.54 832.952.QJ.JT832"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -1129,11 +1129,11 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:5.9.K7642.AQ9854 A86.AQ82.AQ3.632 KQJT7.KJT74.8.KJ 9432.653.JT95.T7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2D      Pass    2NT
+1N     2D      Pass    2N
 Pass    3C      Pass    3D
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1142,10 +1142,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:64.62.QJ876.KJ84 KT93.K8.K32.AQ63 AJ72.QJT7543.4.T Q85.A9.AT95.9752"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2D      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2D      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1156,7 +1156,7 @@ Pass    Pass
 [Deal "N:65.JT.QT65.J7643 K2.86.AJ82.AK982 AQ73.KQ972.K43.T JT984.A543.97.Q5"]
 [Contract "3HX"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    3H      Db      Pass
 Pass    Pass    
 
@@ -1168,7 +1168,7 @@ Pass    Pass
 [Deal "N:Q96.4.JT732.QJ74 53.J863.AK6.AKT6 AK74.AQT952.9.93 JT82.K7.Q854.852"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -1177,10 +1177,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:T2.J754.643.J876 63.A2.AQ752.KQ95 KJ874.KQT83.98.3 AQ95.96.KJT.AT42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2D      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2D      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1191,7 +1191,7 @@ Pass    Pass
 [Deal "N:97.2.AJ8543.Q932 KT84.AJ3.KQ62.A8 AQJ65.KQT854.T.T 32.976.97.KJ7654"]
 [Contract "2D"]
 [Auction "E"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -1202,7 +1202,7 @@ Pass
 [Deal "N:J942..QJT7.AJ852 KT5.K6.AK864.K64 AQ76.AQT74.2.973 83.J98532.953.QT"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2D      Pass    3S
+1N     2D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -1214,7 +1214,7 @@ Pass
 [Deal "N:J654.96.74.A8753 KT83.Q42.KQ62.KQ AQ92.AKJT8.T8.96 7.753.AJ953.JT42"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 

--- a/GIB/Cappelletti-2D.pbn
+++ b/GIB/Cappelletti-2D.pbn
@@ -4,10 +4,10 @@
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:KT.T62.Q87543.93 Q962.Q75.AK9.AT2 AJ853.AJ843..J65 74.K9.JT62.KQ874"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2D      Db      2H
-3NT     Pass    Pass    Pass
+1N     2D      Db      2H
+3N     Pass    Pass    Pass
 
 
 
@@ -18,7 +18,7 @@
 [Deal "N:873.6.82.AQJ9532 AQ.KQ85.KT75.KT7 KJ964.AJT94.63.4 T52.732.AQJ94.86"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      2NT     3S
+1N     2D      2N     3S
 Pass    Pass    Pass    
 
 
@@ -29,7 +29,7 @@ Pass    Pass    Pass
 [Deal "N:872.872.AK5.KT64 KQ63.AJ.T84.AQ75 AJT4.KQT63.Q6.92 95.954.J9732.J83"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -40,7 +40,7 @@ Pass    Pass    Pass
 [Deal "N:Q84.32.JT75.AJ96 72.Q8.AKQ9.KQ843 AJT63.AJ74.42.52 K95.KT965.863.T7"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -51,7 +51,7 @@ Pass    Pass    Pass
 [Deal "N:Q976.86.942.9875 42.K5.AQT7.AQJ43 AJT53.AQT942.8.2 K8.J73.KJ653.KT6"]
 [Contract "5D"]
 [Auction "E"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 3S      Pass    4D      Pass
 5D      Pass    Pass    Pass
 
@@ -64,7 +64,7 @@ Pass    Pass    Pass
 [Deal "N:Q8543.Q6.KQ8.T64 AT7.K75.AT764.A5 KJ962.AJT9.J5.Q7 .8432.932.KJ9832"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3S
 Pass    Pass    Pass    
 
@@ -76,7 +76,7 @@ Pass    Pass    Pass
 [Deal "N:T96.JT72.K876.A3 K32.K3.AQ952.K64 AQ87.AQ9654.3.75 J54.8.JT4.QJT982"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3H      Pass    Pass
 Pass    
 
@@ -88,7 +88,7 @@ Pass
 [Deal "N:J853.842.932.KQ7 A2.T97.AKJ74.AJ3 KQT976.AKQ63.5.8 4.J5.QT86.T96542"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    3S      Pass    Pass
 Pass    
 
@@ -98,10 +98,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:8.J9732.T96.KJ52 J74.A84.AQJ4.A86 KQT953.KQT5.7.93 A62.6.K8532.QT74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2D      Db      2H
-3NT     Pass    Pass    Pass
+1N     2D      Db      2H
+3N     Pass    Pass    Pass
 
 
 
@@ -112,7 +112,7 @@ Pass
 [Deal "N:T752.2.94.AQJT74 KJ4.K653.AKQ5.96 AQ63.QJT874.JT.2 98.A9.87632.K853"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      2NT     3S
+1N     2D      2N     3S
 Pass    Pass    Pass    
 
 
@@ -123,7 +123,7 @@ Pass    Pass    Pass
 [Deal "N:43.KJ532.K874.QJ A75.97.AQT52.AK5 KJ962.AQT64.6.63 QT8.8.J93.T98742"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      Pass    3H
+1N     2D      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -134,7 +134,7 @@ Pass    Pass    Pass
 [Deal "N:J865.9.AKJ54.K85 A93.AQT53.T62.AJ KQ42.KJ872.Q.T96 T7.64.9873.Q7432"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2D      Pass    4S
+1N     2D      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -145,7 +145,7 @@ Pass    Pass    Pass
 [Deal "N:653.74.KJT762.K3 KT2.AQ5.Q93.AQ72 AJ74.KJT92.8.854 Q98.863.A54.JT96"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -154,10 +154,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:864.873.93.QJ942 J5.J642.AKQJ7.K7 AQT93.AQ95.T4.65 K72.KT.8652.AT83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2D      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2D      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -168,7 +168,7 @@ Pass    Pass
 [Deal "N:J43.Q654.QJ8.T83 98.K82.AKT6.KQ42 AQ762.AJ973.3.J9 KT5.T.97542.A765"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -180,7 +180,7 @@ Pass    Pass
 [Deal "N:65.K52.QJ85.8752 KT42.Q3.AK72.AJT AJ73.AJ876.4.Q93 Q98.T94.T963.K64"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -191,8 +191,8 @@ Pass    Pass    Pass
 [Deal "N:T2.T98743.T4.984 Q95.K2.AJ75.AQJ6 KJ643.AQJ5.3.T53 A87.6.KQ9862.K72"]
 [Contract "6D"]
 [Auction "E"]
-1NT     2D      3D      Pass
-3S      Pass    4NT     Pass
+1N     2D      3D      Pass
+3S      Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -204,7 +204,7 @@ Pass    Pass
 [Deal "N:Q76.965.KJ52.Q84 K4.AJT2.T764.AK2 AJT98.KQ43.83.T3 532.87.AQ9.J9765"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -216,7 +216,7 @@ Pass    Pass
 [Deal "N:5.J64.Q86.AKJ874 AQ7.Q3.AK54.QT95 KJ964.AK875.J7.2 T832.T92.T932.63"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2D      Pass    4H
+1N     2D      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -225,10 +225,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:T5..KJT9432.8643 AJ8.A972.Q765.AQ KQ74.KJT84..J972 9632.Q653.A8.KT5"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "E"]
-1NT     2D      Db      Pass
-2NT     Pass    Pass    Pass
+1N     2D      Db      Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -239,7 +239,7 @@ Pass    Pass    Pass
 [Deal "N:JT8.764.QT86.A65 976.K83.AKJ.KQ32 KQ43.AQJ52.74.T8 A52.T9.9532.J974"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -250,7 +250,7 @@ Pass    Pass    Pass
 [Deal "N:97543.852.Q2.A86 J6.KQT.AKJ93.J32 AKQT8.AJ43.T875. 2.976.64.KQT9754"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3S
 Pass    Pass    Pass    
 
@@ -262,7 +262,7 @@ Pass    Pass    Pass
 [Deal "N:JT5.987.KJT82.T8 A63.Q53.65.AKQ73 KQ98.AKT42.Q.942 742.J6.A9743.J65"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -274,7 +274,7 @@ Pass    Pass
 [Deal "N:52.6.KT987.AQJ63 AJT6.Q74.AJ6.K85 KQ943.AKJ82.52.7 87.T953.Q43.T942"]
 [Contract "5S"]
 [Auction "E"]
-1NT     2D      Pass    2NT
+1N     2D      Pass    2N
 Pass    3D      Pass    4S
 Pass    5H      Pass    5S
 Pass    Pass    Pass    
@@ -287,7 +287,7 @@ Pass    Pass    Pass
 [Deal "N:Q43.62.J7.QJT976 98.A75.AKQT.A854 AKT75.KQJ94.98.2 J62.T83.65432.K3"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    3S      Pass    Pass
 Pass    
 
@@ -299,7 +299,7 @@ Pass
 [Deal "N:Q32.4.9852.AQT92 A54.A953.AKQ.863 KJT97.KQJ8.T.KJ4 86.T762.J7643.75"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -311,7 +311,7 @@ Pass    Pass    Pass
 [Deal "N:.T752.KJ742.K983 AK87.Q43.AQ85.QT QJT965.AK98.T96. 432.J6.3.AJ76542"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      2NT     3H
+1N     2D      2N     3H
 Pass    Pass    Pass    
 
 
@@ -322,7 +322,7 @@ Pass    Pass    Pass
 [Deal "N:KT.532.9865.Q732 Q5.96.AKJT3.AJ64 AJ873.AQT8.Q2.T5 9642.KJ74.74.K98"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -333,7 +333,7 @@ Pass    Pass    Pass
 [Deal "N:7.AT42.A8762.973 AT4.J93.Q3.AKJ52 KQ9832.KQ85.4.Q8 J65.76.KJT95.T64"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -342,10 +342,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:94.532.Q4.Q96532 A85.A97.A9873.A8 KJT7632.KQ84..T7 Q.JT6.KJT652.KJ4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2D      3D      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -356,7 +356,7 @@ Pass    Pass    Pass
 [Deal "N:6.JT8.J983.T8742 T74.K75.AKQ.KQ63 AK82.AQ643.652.9 QJ953.92.T74.AJ5"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -367,7 +367,7 @@ Pass    Pass    Pass
 [Deal "N:JT4.732.76.K9875 Q63.QJ.KQJ92.AQ2 AK75.AKT965.T.63 982.84.A8543.JT4"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    3H      Pass    Pass
 Pass    
 
@@ -379,7 +379,7 @@ Pass
 [Deal "N:T982.7643.J6.JT5 73.KJ8.AQ3.AQ987 AQ654.AQT95.84.3 KJ.2.KT9752.K642"]
 [Contract "5D"]
 [Auction "E"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 3S      Pass    5D      Pass
 Pass    Pass    
 
@@ -391,7 +391,7 @@ Pass    Pass
 [Deal "N:J8.53.KJT63.A852 Q2.QJT.A95.KQJT4 AK543.AK97.842.7 T976.8642.Q7.963"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -402,7 +402,7 @@ Pass    Pass    Pass
 [Deal "N:T32.A75.764.Q973 Q874.QT8.AKJ3.KJ AKJ6.KJ943.T9.T4 95.62.Q852.A8652"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -414,7 +414,7 @@ Pass    Pass    Pass
 [Deal "N:532..986542.K982 KJ4.A63.AQJT7.53 AQT86.KQJT954..J 97.872.K3.AQT764"]
 [Contract "5C"]
 [Auction "E"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 3D      Pass    4C      Pass
 5C      Pass    Pass    Pass
 
@@ -427,7 +427,7 @@ Pass    Pass    Pass
 [Deal "N:T4.AT6.K963.QJ74 K32.92.AQ84.AK96 AQ86.KJ875.JT.52 J975.Q43.752.T83"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      Pass    3H
+1N     2D      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -438,7 +438,7 @@ Pass    Pass    Pass
 [Deal "N:T..A9876.AT97643 A72.K54.KJT4.KQ2 KQJ3.QJT9762.Q3. 98654.A83.52.J85"]
 [Contract "5H"]
 [Auction "E"]
-1NT     2D      Pass    2NT
+1N     2D      Pass    2N
 Pass    3D      Pass    4C
 Pass    4H      Pass    5D
 Pass    5H      Pass    Pass
@@ -452,7 +452,7 @@ Pass
 [Deal "N:T98.54.AJ9762.42 KQ.KT96.83.AKJ83 AJ543.AQ87.Q.765 762.J32.KT54.QT9"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -463,7 +463,7 @@ Pass    Pass    Pass
 [Deal "N:852.T9.KT9732.95 KJ.J873.A5.AKT62 AQ974.AQ54.J.873 T63.K62.Q864.QJ4"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -474,7 +474,7 @@ Pass    Pass    Pass
 [Deal "N:JT82.T943.K9.JT4 Q7.QJ7.AQT7.AQ95 AK64.AK652.42.87 953.8.J8653.K632"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    3H      Pass    Pass
 Pass    
 
@@ -486,7 +486,7 @@ Pass
 [Deal "N:62.J42.KJT85.QJ2 AT5.98.A64.AK865 KJ9874.AKT653.3. Q3.Q7.Q972.T9743"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3H      Pass    Pass
 Pass    
 
@@ -498,7 +498,7 @@ Pass
 [Deal "N:84.J9.KJ32.J6532 AT3.642.QT.AKQT9 KJ9652.KQ53.A86. Q7.AT87.9754.874"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -509,7 +509,7 @@ Pass    Pass    Pass
 [Deal "N:64.KT7653.532.52 KT8.Q4.AK98.A763 AQ95.AJ982.Q.J94 J732..JT764.KQT8"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    3D      4H
 Pass    Pass    Pass    
 
@@ -521,7 +521,7 @@ Pass    Pass    Pass
 [Deal "N:863.JT7.KQ52.AQ7 AT.K52.AJ63.K986 KJ542.AQ43.4.J52 Q97.986.T987.T43"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      Pass    3S
+1N     2D      Pass    3S
 Pass    Pass    Pass    
 
 
@@ -532,7 +532,7 @@ Pass    Pass    Pass
 [Deal "N:53.A762.T842.752 J62.K5.AQJ96.KQT AKQ84.QJT984..93 T97.3.K753.AJ864"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3H      Pass    Pass
 Pass    
 
@@ -544,7 +544,7 @@ Pass
 [Deal "N:54.K732.T94.KJ73 K92.T4.AKQ83.A84 AQJT73.AQ98.6.52 86.J65.J752.QT96"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -555,7 +555,7 @@ Pass    Pass    Pass
 [Deal "N:Q83.J7.Q865.QJ87 752.AT8.A94.AKT3 AKJ6.KQ543.J73.2 T94.962.KT2.9654"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -564,9 +564,9 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:K3.T85.Q9762.J74 742.63.AKJT8.AK9 AJ965.AJ92.3.862 QT8.KQ74.54.QT53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -577,7 +577,7 @@ Pass    Pass
 [Deal "N:T8.T42.864.KJ943 K965.A97.Q9.AQ87 AQJ732.KQJ8.2.T2 4.653.AKJT753.65"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3S      Pass    Pass
 Pass    
 
@@ -589,7 +589,7 @@ Pass
 [Deal "N:93.QJ54.T953.942 Q8.82.AKQ84.KJ76 AJT764.AK73.2.QT K52.T96.J76.A853"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -600,7 +600,7 @@ Pass    Pass    Pass
 [Deal "N:K85.642.KQ876.QJ J9.K9.AJ54.AK742 AQ62.AQJT853.9.8 T743.7.T32.T9653"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2D      Pass    3S
+1N     2D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 

--- a/GIB/Cappelletti-2H.pbn
+++ b/GIB/Cappelletti-2H.pbn
@@ -6,7 +6,7 @@
 [Deal "N:A984.AJ8.J3.T965 KJ.T97.AKQ95.A74 T6.KQ43.64.KQJ32 Q7532.652.T872.8"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2H      Pass    2S
+1N     2H      Pass    2S
 Pass    3C      Pass    Pass
 Pass    
 
@@ -18,7 +18,7 @@ Pass
 [Deal "N:QJT32.J42.32.A97 AK965.Q96.K76.KJ 84.AK73.AQ954.T5 7.T85.JT8.Q86432"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -29,7 +29,7 @@ Pass
 [Deal "N:Q874.6.QT74.8652 KJ953.KQ8.AJ9.Q9 .AJT953.83.AJT73 AT62.742.K652.K4"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -41,7 +41,7 @@ Pass    Pass
 [Deal "N:J2.K97.AJT42.QT2 AK7.6542.KQ97.A8 Q86.AQJ3..KJ9763 T9543.T8.8653.54"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2H      Pass    2NT
+1N     2H      Pass    2N
 Pass    3C      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -54,7 +54,7 @@ Pass
 [Deal "N:Q42.T53.T843.K72 K87.AQ6.Q7.AJT43 95.KJ982.AKJ5.86 AJT63.74.962.Q95"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -63,9 +63,9 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:Q97.743.8.JT9843 AKJ63.AT6.JT2.K6 82.KJ985.AQ763.2 T54.Q2.K954.AQ75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -76,7 +76,7 @@ Pass    Pass
 [Deal "N:KT62.Q4.J63.9543 A97.A96.Q942.AJ7 5.KJT72.AK75.K86 QJ843.853.T8.QT2"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Db      Pass    3C
 Pass    Pass    Pass    
 
@@ -88,7 +88,7 @@ Pass    Pass    Pass
 [Deal "N:Q75.943.932.Q762 AK6.T2.KT6.AJ854 T9.AQJ86.AQJ74.3 J8432.K75.85.KT9"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Db      Pass    3C
 Pass    Pass    Pass    
 
@@ -100,7 +100,7 @@ Pass    Pass    Pass
 [Deal "N:A953.65.AT985.T2 K4.AT97.KJ63.A64 QJ86.KQ84..KQ753 T72.J32.Q742.J98"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -111,7 +111,7 @@ Pass
 [Deal "N:KJ86..9832.QJ953 AQ7.KJ82.KQ4.T62 93.AQ7643.AJT5.8 T542.T95.76.AK74"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2H      Pass    2NT
+1N     2H      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -123,7 +123,7 @@ Pass
 [Deal "N:72.K53.T842.K972 AK84.QT2.A93.Q64 Q.AJ96.Q65.AJT53 JT9653.874.KJ7.8"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Db      Pass    3C
 Pass    Pass    Pass    
 
@@ -133,10 +133,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:K98.432.Q952.954 AQJ.AJT5.AJ86.63 T4.KQ876.73.AJT7 76532.9.KT4.KQ82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2H      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -145,10 +145,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:KQ8.A5.T64.AQ842 AJ92.K2.QJ98.KJT 63.QJT743.AK53.5 T754.986.72.9763"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2H      Pass    3C
-Pass    3D      Pass    3NT
+1N     2H      Pass    3C
+Pass    3D      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -159,7 +159,7 @@ Pass    Pass    Pass
 [Deal "N:QJT862.K65.A3.95 AK7.94.KQ2.KJ843 .AJT7.J54.AQT762 9543.Q832.T9876."]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -170,7 +170,7 @@ Pass
 [Deal "N:Q8542.K3.T94.T84 AJ93.QT.AKJ5.Q96 T.AJ7652.6.AK752 K76.984.Q8732.J3"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Db      3D      Pass
 Pass    3H      Pass    Pass
 Pass    
@@ -183,7 +183,7 @@ Pass
 [Deal "N:JT6.8743.J964.32 A842.AJ9.AQT2.T8 Q9.KQ52.85.AQJ65 K753.T6.K73.K974"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2H      Db      Pass
+1N     2H      Db      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -195,7 +195,7 @@ Pass    Pass
 [Deal "N:KQ97.T9.AKJT7.52 A4.AQ52.Q94.A976 T63.KJ873.6.KQJT J852.64.8532.843"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2H      Pass    3D
+1N     2H      Pass    3D
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
 
@@ -205,11 +205,11 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:975.7643.2.J8632 AK2.JT.AT975.KT5 J86.KQ852.KQ63.Q QT43.A9.J84.A974"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -220,7 +220,7 @@ Pass    Pass    Pass
 [Deal "N:AQJ8.7632.8.9763 K965.KQT.KQ9.KT2 42.AJ95.AJ532.QJ T73.84.T764.A854"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -231,7 +231,7 @@ Pass
 [Deal "N:KT985.QT6.J9.KQ3 AJ3.K32.AK85.T54 64.AJ954.72.AJ98 Q72.87.QT643.762"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -242,7 +242,7 @@ Pass
 [Deal "N:KQ9864.K987.K.62 AJ.Q53.Q52.AQJ54 3.AJ64.AJ9874.T9 T752.T2.T63.K873"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2H      Pass    3H
+1N     2H      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
 
@@ -254,7 +254,7 @@ Pass
 [Deal "N:KQ84.J95.JT987.2 A652.K72.AKQ5.T3 T3.AQ843..KQ8764 J97.T6.6432.AJ95"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -265,7 +265,7 @@ Pass
 [Deal "N:J96.54.A8653.T93 AK2.QT3.KQJ7.852 .AJ9862.42.KQ764 QT87543.K7.T9.AJ"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -277,7 +277,7 @@ Pass
 [Deal "N:JT8542.82.Q64.83 A96.K54.A952.A92 Q.AQJ973.T3.KQT7 K73.T6.KJ87.J654"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -288,7 +288,7 @@ Pass
 [Deal "N:Q94.76.QJT93.A65 KJT2.AT93.AK5.42 75.KQ85.74.KQJT9 A863.J42.862.873"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -297,10 +297,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:JT93.J965.J53.T4 AQ4.A843.K986.Q8 652.KQT7.2.AJ762 K87.2.AQT74.K953"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2H      3D      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -311,7 +311,7 @@ Pass
 [Deal "N:Q8764.T43.AJ9.J4 AK3.QJ85.KQT.973 J.AK972.832.AQ82 T952.6.7654.KT65"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -322,7 +322,7 @@ Pass
 [Deal "N:T432.K742.AJ3.Q6 AKJ8.A6.K98.8742 5.QJT983.7.AJT93 Q976.5.QT6542.K5"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2H      2NT     3H
+1N     2H      2N     3H
 Pass    Pass    Pass    
 
 
@@ -331,10 +331,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:T9632.9432.93.A6 AKJ54.65.AQ4.J93 7.KQT8.J72.KQ742 Q8.AJ7.KT865.T85"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2H      3D      Pass
-3S      Pass    3NT     Pass
+1N     2H      3D      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -345,7 +345,7 @@ Pass    Pass
 [Deal "N:AJT.J7643.A82.92 KQ832.AT.T95.AQ5 6.KQ85.3.KJT8763 9754.92.KQJ764.4"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2H      2NT     3H
+1N     2H      2N     3H
 Pass    Pass    Pass    
 
 
@@ -356,7 +356,7 @@ Pass    Pass    Pass
 [Deal "N:A6532.87.T6.A843 KT4.KQ2.Q43.KQ75 J87.AJ94.AK872.6 Q9.T653.J95.JT92"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -367,7 +367,7 @@ Pass
 [Deal "N:K82.Q2.J9654.T42 A653.K74.AQT8.K7 7.AJ865.2.AQJ965 QJT94.T93.K73.83"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    3C      Pass    Pass
 3S      Pass    Pass    Pass
 
@@ -380,7 +380,7 @@ Pass    3C      Pass    Pass
 [Deal "N:AQT982.T9.T963.9 KJ5.K3.KQ75.A653 .AQ8542.J2.KJT72 7643.J76.A84.Q84"]
 [Contract "2HX"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Db      Pass    Pass    Pass
 
 
@@ -392,7 +392,7 @@ Db      Pass    Pass    Pass
 [Deal "N:Q52.8752.KJ73.K5 A8.AJT3.AQ95.T83 .KQ96.42.AQJ7642 KJT97643.4.T86.9"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    3C      3S      Pass
 Pass    Pass    
 
@@ -404,7 +404,7 @@ Pass    Pass
 [Deal "N:KQ72.T75.Q.QJ743 A43.A6432.A4.A82 J96.KQ98.KJ987.6 T85.J.T6532.KT95"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -415,7 +415,7 @@ Pass
 [Deal "N:KQJ97.KJT.T83.T3 32.98542.AKQ.AQ7 A84.AQ73.4.KJ865 T65.6.J97652.942"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -426,7 +426,7 @@ Pass
 [Deal "N:T75432.7543.Q7.2 AK.KT8.AT543.K63 J9.AQJ6.92.AJ874 Q86.92.KJ86.QT95"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -437,7 +437,7 @@ Pass
 [Deal "N:J7.K9632.QJT96.5 AQ85.Q5.A84.K986 932.AJT4.K.AQT43 KT64.87.7532.J72"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -448,7 +448,7 @@ Pass
 [Deal "N:T4.984.AQ97.9865 K2.AQT.K832.QJ32 QJ8.KJ732.5.AK74 A97653.65.JT64.T"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -459,7 +459,7 @@ Pass    Pass
 [Deal "N:AK85.863.4.QJT97 Q74.KQ7.J532.AK2 93.AJ542.AKQT.54 JT62.T9.9876.863"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2H      Pass    2S
+1N     2H      Pass    2S
 Pass    3D      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -472,7 +472,7 @@ Pass
 [Deal "N:K9732..QJT875.74 QJ6.A542.AK2.JT3 T84.KQ976.4.AK62 A5.JT83.963.Q985"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -483,7 +483,7 @@ Pass
 [Deal "N:KQJT87652..972.J A9.KQ97.AJ65.K94 4.AJT542.T.AQT63 3.863.KQ843.8752"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Db      3D      Pass
 Pass    3H      Pass    4S
 Pass    Pass    Pass    
@@ -496,7 +496,7 @@ Pass    Pass    Pass
 [Deal "N:J75.T7.JT843.KT6 AKT42.K4.KQ9.543 8.AQ532.2.AQJ987 Q963.J986.A765.2"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -508,7 +508,7 @@ Pass    Pass
 [Deal "N:T8542.T743.Q74.J AKQ3.A8.JT96.Q94 J7.KQJ62.53.AK62 96.95.AK82.T8753"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -520,7 +520,7 @@ Pass    Pass
 [Deal "N:KT64.T83.T94.965 AQ7.K6.KQ5.KT742 832.AQ754.AJ863. J95.J92.72.AQJ83"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -531,7 +531,7 @@ Pass
 [Deal "N:K9763..KT63.Q973 AQ.K964.AQ952.84 52.AQT53.J.AKT52 JT84.J872.874.J6"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2H      Pass    2NT
+1N     2H      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -543,7 +543,7 @@ Pass
 [Deal "N:AJ8654.63.K754.3 KQ.KJT72.AJ9.Q54 93.AQ94.Q2.KJ972 T72.85.T863.AT86"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -554,7 +554,7 @@ Pass
 [Deal "N:K6.652.QJ942.986 A842.KT3.AK75.J7 T.AQ874.T8.KQT43 QJ9753.J9.63.A52"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    3S      Pass
 Pass    Pass    
 
@@ -566,7 +566,7 @@ Pass    Pass
 [Deal "N:AK9.72.J9632.J85 Q54.Q63.AKQT8.A3 876.AJT4.5.KQ976 JT32.K985.74.T42"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -577,7 +577,7 @@ Pass
 [Deal "N:KJ65.J94.9542.T8 AQT.A732.T76.AQ2 43.KQ65.QJ.KJ965 9872.T8.AK83.743"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -588,6 +588,6 @@ Pass
 [Deal "N:QT86.8.54.T76542 73.AJ.K862.AQJ98 KJ9.KQ976.AJ73.3 A542.T5432.QT9.K"]
 [Contract "2H"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 

--- a/GIB/Cappelletti-2N.pbn
+++ b/GIB/Cappelletti-2N.pbn
@@ -6,7 +6,7 @@
 [Deal "N:54.AKQ8764.J4.53 AQ3.J93.AT63.AJ7 K..KQ9852.KQ8642 JT98762.T52.7.T9"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -15,10 +15,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:K97.A9872.754.T8 AQJT5.KJT.A32.73 3..KQJT86.AKJ954 8642.Q6543.9.Q62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     Db      2D      2H
-Db      3C      Pass    3NT
+1N     Db      2D      2H
+Db      3C      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -29,7 +29,7 @@ Pass    Pass    Pass
 [Deal "N:987653.87.62.J73 QJ.AJ952.A98.A54 A..KJT753.KQT962 KT42.KQT643.Q4.8"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -40,7 +40,7 @@ Pass    Pass
 [Deal "N:Q76542.KT982..J6 AJ.A754.AK32.874 8..QJ8654.AKQ932 KT93.QJ63.T97.T5"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -51,7 +51,7 @@ Pass    Pass    Pass
 [Deal "N:T643.T54.JT952.9 KJ98.AQJ2.Q3.K87 .9.AK8764.AQJT32 AQ752.K8763..654"]
 [Contract "4S"]
 [Auction "E"]
-1NT     Db      Pass    2D
+1N     Db      Pass    2D
 Pass    Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -64,7 +64,7 @@ Pass    Pass    3S      Pass
 [Deal "N:JT98752.763.J.73 AQ.KJ8.AT975.QJ4 .T.KQ8432.AKT962 K643.AQ9542.6.85"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -75,7 +75,7 @@ Pass    Pass
 [Deal "N:9854.T642.Q9.T63 AKQJT.Q75.K42.J8 .K.AJT763.KQ9752 7632.AJ983.85.A4"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -86,7 +86,7 @@ Pass    Pass
 [Deal "N:Q987.863.43.T652 AJ54.AK2.JT65.A3 T..AK9872.KQJ987 K632.QJT9754.Q.4"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -97,7 +97,7 @@ Pass    Pass
 [Deal "N:K4.987653.QT72.2 AQ.K42.A93.KT965 8..KJ8654.AQ8743 JT976532.AQJT..J"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -108,7 +108,7 @@ Pass    Pass
 [Deal "N:QT763.J973.Q8.K7 AKJ8.K86.632.A96 .2.AKT974.QJT854 9542.AQT54.J5.32"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -119,7 +119,7 @@ Pass    Pass    Pass
 [Deal "N:9753.J9642.32.83 AQ.QT873.A85.AT7 ..KJT764.KQ96542 KJT8642.AK5.Q9.J"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -130,7 +130,7 @@ Pass    Pass
 [Deal "N:AJT632.Q9543.2.6 KQ95.K6.K96.AJT4 4..AJ8753.KQ8752 87.AJT872.QT4.93"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -141,7 +141,7 @@ Pass    Pass
 [Deal "N:AT86.T932.953.54 QJ94.AK6.K8.Q982 7..AJT764.AKT763 K532.QJ8754.Q2.J"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -152,7 +152,7 @@ Pass    Pass
 [Deal "N:J53.AJ754.K9.876 AKQ96.K83.75.K32 .2.AJ8432.AQJT54 T8742.QT96.QT6.9"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -163,7 +163,7 @@ Pass    Pass    Pass
 [Deal "N:AT97432.8643.T.8 865.AKQJ.AJ43.T2 .T.KQ9752.AKJ954 KQJ.9752.86.Q763"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -174,7 +174,7 @@ Pass    Pass    Pass
 [Deal "N:KJ74.Q654.92.763 AT865.KJT.KQ.Q95 .9.AJT865.AKJT82 Q932.A8732.743.4"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -185,7 +185,7 @@ Pass    Pass    Pass
 [Deal "N:Q83.AQ8542.9.975 AK72.J3.KT86.AT4 5..AQ7532.KQ8632 JT964.KT976.J4.J"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -196,7 +196,7 @@ Pass    Pass    Pass
 [Deal "N:J7643.JT7.Q84.96 AKQ9.Q95.AT3.853 8..KJ9762.AKQJ42 T52.AK86432.5.T7"]
 [Contract "5H"]
 [Auction "E"]
-1NT     Db      4D      Pass
+1N     Db      4D      Pass
 4H      5C      5H      Pass
 Pass    Pass    
 
@@ -208,7 +208,7 @@ Pass    Pass
 [Deal "N:A642.K7654.J65.2 J85.AQJ3.K87.AQ3 7..AQT942.KJ9864 KQT93.T982.3.T75"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -219,7 +219,7 @@ Pass    Pass    Pass
 [Deal "N:QT984.K863.T7.A6 AK3.QJT94.K3.Q98 .2.AQ9854.KJT532 J7652.A75.J62.74"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -230,7 +230,7 @@ Pass    Pass    Pass
 [Deal "N:QT54.K.J74.J8754 AK92.Q85.K982.A9 J..AQT653.KQT632 8763.AJT976432.."]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -241,7 +241,7 @@ Pass    Pass
 [Deal "N:KJ975.KQT83..732 AT82.AJ6.A93.Q86 .9.QJT762.AKT954 Q643.7542.K854.J"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -252,7 +252,7 @@ Pass    Pass    Pass
 [Deal "N:JT987532.QJ62.8. A6.A743.AK53.953 .T.QJT642.AK7642 KQ4.K985.97.QJT8"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     Db      3D
+1N     2N     Db      3D
 Db      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -265,7 +265,7 @@ Db      Pass    3H      Pass
 [Deal "N:T643.Q7432.4.J72 AKJ8.K985.K73.K6 9..AQJ962.AQT843 Q752.AJT6.T85.95"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -276,7 +276,7 @@ Pass    Pass    Pass
 [Deal "N:QT8432.K73.74.93 AK9.QJT85.AT8.Q2 7..KQJ953.AJT854 J65.A9642.62.K76"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -287,7 +287,7 @@ Pass    Pass
 [Deal "N:KT752.QT752.5.T7 AQ83.A98.AT8.Q64 .6.KQ9632.AJ9832 J964.KJ43.J74.K5"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -298,7 +298,7 @@ Pass    Pass    Pass
 [Deal "N:KQ7642.QT954.3.5 AJ8.AK82.A92.T84 .7.KJT754.AKQ972 T953.J63.Q86.J63"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -309,7 +309,7 @@ Pass    Pass    Pass
 [Deal "N:KJ3.A875.KT5.J54 AQ.K632.Q432.A92 9..AJ9876.KQT876 T876542.QJT94..3"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -320,7 +320,7 @@ Pass    Pass    Pass
 [Deal "N:T7542.QT843..T64 AKJ3.AJ96.KT3.98 Q..AQ9862.KQJ532 986.K752.J754.A7"]
 [Contract "2H"]
 [Auction "E"]
-1NT     Db      Pass    2H
+1N     Db      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -331,7 +331,7 @@ Pass    Pass    Pass
 [Deal "N:A98.QJ632.T74.JT QJ62.AT85.AQ9.Q4 .7.KJ8532.AK9865 KT7543.K94.6.732"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -342,7 +342,7 @@ Pass    Pass    Pass
 [Deal "N:AQT42.Q7532.76.6 KJ6.J986.AQ42.A5 3..KJT953.KQJ972 9875.AKT4.8.T843"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -353,7 +353,7 @@ Pass    Pass    Pass
 [Deal "N:AT8765.A753..943 943.KQJT.QT74.AK K..AJ9652.QJT762 QJ2.98642.K83.85"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -364,7 +364,7 @@ Pass    Pass    Pass
 [Deal "N:QT653.A9.542.T65 AK72.KJ64.J7.AJ4 9..AQT863.KQ9873 J84.QT87532.K9.2"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -375,7 +375,7 @@ Pass    Pass    Pass
 [Deal "N:KJ9762.KT87.K8.6 AQT3.A964.T5.AJT 5..AQJ632.KQ8752 84.QJ532.974.943"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -386,7 +386,7 @@ Pass    Pass    Pass
 [Deal "N:T87532.T8.J5.QJ6 AQ96.AJ9.AT4.742 .2.KQ9762.AKT953 KJ4.KQ76543.83.8"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -397,7 +397,7 @@ Pass    Pass
 [Deal "N:T654.AQJ75.62.J4 KQ87.K84.AJ53.Q3 J..KQT874.AK9872 A932.T9632.9.T65"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -408,7 +408,7 @@ Pass    Pass    Pass
 [Deal "N:4.AT98542.864.J7 AQ987.KJ3.AJ7.65 K..KQT952.AQ9432 JT6532.Q76.3.KT8"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      2H      Db
+1N     Db      2H      Db
 2S      Pass    Pass    Pass
 
 
@@ -420,7 +420,7 @@ Pass    Pass    Pass
 [Deal "N:KT542.92.KJ32.96 AJ.AKT83.T54.QJ8 .6.AQ9876.AKT754 Q98763.QJ754..32"]
 [Contract "4SX"]
 [Auction "E"]
-1NT     2NT     4S      Db
+1N     2N     4S      Db
 Pass    Pass    Pass    
 
 
@@ -431,7 +431,7 @@ Pass    Pass    Pass
 [Deal "N:AK74.T743.63.T97 QT95.AKQ5.Q52.Q6 .2.AKJT94.AJ8432 J8632.J986.87.K5"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2NT     Pass    3C
+1N     2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -442,7 +442,7 @@ Pass    Pass    Pass
 [Deal "N:KJT9.KQJ93.64.A3 AQ.A8752.A85.J65 .T.KQJT32.KQT987 8765432.64.97.42"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -453,7 +453,7 @@ Pass    Pass    Pass
 [Deal "N:KJ3.QT98753.J4.A A865.AKJ.Q6.KT64 2..AKT532.QJ8752 QT974.642.987.93"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -464,7 +464,7 @@ Pass    Pass    Pass
 [Deal "N:QJ975.JT2.2.J832 A63.AKQ84.Q76.T4 .5.AJ9843.AKQ965 KT842.9763.KT5.7"]
 [Contract "3D"]
 [Auction "E"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      3D      Pass    Pass
 Pass    
 
@@ -474,11 +474,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:KT53.K632.75.J98 A976.QJ5.AKT2.Q3 .A.QJ9864.AKT754 QJ842.T9874.3.62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     Db      2D      2H
+1N     Db      2D      2H
 Db      3C      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -489,7 +489,7 @@ Pass
 [Deal "N:K974.K742.8763.J AQT3.A965.KQ4.95 8..AJT952.AKQ762 J652.QJT83..T843"]
 [Contract "5D"]
 [Auction "E"]
-1NT     Db      2D      2H
+1N     Db      2D      2H
 Db      3C      Pass    3S
 Pass    4C      Pass    4D
 Pass    5D      Pass    Pass
@@ -503,7 +503,7 @@ Pass
 [Deal "N:976542.AQT8.87.7 KJT3.J4.A63.AK85 A..KQJT94.QJT963 Q8.K976532.52.42"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -514,7 +514,7 @@ Pass    Pass    Pass
 [Deal "N:AKQ752.Q654.73.3 T8.AKT.KJ85.AJ75 3..AQT962.KQT964 J964.J98732.4.82"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -525,7 +525,7 @@ Pass    Pass    Pass
 [Deal "N:Q542.KT93.75.852 KJT9.AJ4.J93.AQ4 8..AK8642.KJT763 A763.Q87652.QT.9"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -536,7 +536,7 @@ Pass    Pass
 [Deal "N:94.KJ7642.T82.83 KQ862.95.AQ3.KJ6 .8.KJ9764.AQT942 AJT753.AQT3.5.75"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2NT     4S      Pass
+1N     2N     4S      Pass
 Pass    Pass    
 
 
@@ -547,7 +547,7 @@ Pass    Pass
 [Deal "N:Q9432.KQJ2.94.Q9 AKJT.765.K62.A63 8..AQT875.KJT752 765.AT9843.J3.84"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -558,7 +558,7 @@ Pass    Pass    Pass
 [Deal "N:T87643.KQT7.32.T QJ9.J95.KJT.AK83 K..AQ8754.QJ9762 A52.A86432.96.54"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -569,6 +569,6 @@ Pass    Pass
 [Deal "N:QT8542.832.3.J83 AKJ7.QJ74.AJ8.T5 .9.KQ9652.AK9762 963.AKT65.T74.Q4"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 

--- a/GIB/Cappelletti-2S.pbn
+++ b/GIB/Cappelletti-2S.pbn
@@ -6,7 +6,7 @@
 [Deal "N:J932.93.T6.QT843 Q8.T642.AQ5.AKJ7 AKT4.K8.KJ872.92 765.AQJ75.943.65"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -18,7 +18,7 @@ Pass    Pass
 [Deal "N:T62.Q943.742.K62 A95.AJ6.Q5.AQT83 KQJ3..AK986.J754 874.KT8752.JT3.9"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -29,7 +29,7 @@ Pass
 [Deal "N:T8.AT8.962.KJ942 953.KJ42.AQ4.AQT KQ64.Q5.KJT83.87 AJ72.9763.75.653"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -38,10 +38,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:73.KJT8643.Q762. Q854.A5.AK8.QT42 AJT9.9.954.KJ863 K62.Q72.JT3.A975"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2S      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2S      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -52,7 +52,7 @@ Pass    Pass
 [Deal "N:4.K86432.J5.T873 T976.AQJ.AT93.KQ AQ532..Q74.AJ642 KJ8.T975.K862.95"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -63,7 +63,7 @@ Pass
 [Deal "N:K8732.K3.AT7.T86 Q9.A865.Q93.AK75 AJ64.94.KJ654.QJ T5.QJT72.82.9432"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -74,7 +74,7 @@ Pass
 [Deal "N:Q6543.763.97.J97 92.KJT4.KQ84.AK2 KJT87.A52.AJT5.T A.Q98.632.Q86543"]
 [Contract "3S"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    Pass    3S
 Pass    Pass    Pass    
 
@@ -86,7 +86,7 @@ Pass    Pass    Pass
 [Deal "N:J6.QJ87532.T765. T92.KT6.AQ.AQT86 AK74..J943.KJ972 Q853.A94.K82.543"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -97,7 +97,7 @@ Pass
 [Deal "N:84.KJ972.A87.K75 AKT7.AT85.T6.AJ4 QJ9653..KQJ532.9 2.Q643.94.QT8632"]
 [Contract "5D"]
 [Auction "E"]
-1NT     2S      2NT     3H
+1N     2S      2N     3H
 Pass    4D      Pass    5D
 Pass    Pass    Pass    
 
@@ -109,7 +109,7 @@ Pass    Pass    Pass
 [Deal "N:92.8653.A42.K987 A8.AQ2.K865.Q643 KQT65.T7.93.AJT5 J743.KJ94.QJT7.2"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -120,7 +120,7 @@ Pass
 [Deal "N:32.Q7432.62.AJ92 AK6.AK96.J85.T63 QJ9754.5.AKQT3.Q T8.JT8.974.K8754"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -131,7 +131,7 @@ Pass
 [Deal "N:3.AT9753.T863.T5 T84.KJ86.AQJ7.A2 AKJ96.2.942.KQ96 Q752.Q4.K5.J8743"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -143,7 +143,7 @@ Pass
 [Deal "N:A7.KJ832.985.963 QT82.AT4.A3.KQ85 KJ643.7.JT2.AJ72 95.Q965.KQ764.T4"]
 [Contract "3D"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -155,8 +155,8 @@ Pass    Pass
 [Deal "N:T85.6.T864.J8732 KJ2.52.Q95.AKQ54 AQ9764.K3.AJ32.6 3.AQJT9874.K7.T9"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2S      3H      Pass
-3NT     Pass    4H      Pass
+1N     2S      3H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -167,7 +167,7 @@ Pass    Pass
 [Deal "N:Q4.K984.A94.K965 A7.AJ52.KJ732.Q3 KJT982.73.6.AJ42 653.QT6.QT85.T87"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -178,7 +178,7 @@ Pass
 [Deal "N:6532.KJ75.AJ93.J J97.AQT9.KQ5.K75 AQT4.82.86.AQ862 K8.643.T742.T943"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -190,7 +190,7 @@ Pass
 [Deal "N:T2.KJ95.J.Q98762 KQ87.A864.73.AK5 AJ95.T73.AK964.J 643.Q2.QT852.T43"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -201,7 +201,7 @@ Pass
 [Deal "N:T73.J7.5.KJ76542 J62.Q42.AQ862.AQ AK854.986.KJT43. Q9.AKT53.97.T983"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -213,7 +213,7 @@ Pass
 [Deal "N:J95432.A52.5.Q85 AT8.Q98.K86.AK63 KQ76.74.AQT73.T9 .KJT63.J942.J742"]
 [Contract "4SX"]
 [Auction "E"]
-1NT     2S      4H      4S
+1N     2S      4H      4S
 Db      Pass    Pass    Pass
 
 
@@ -223,10 +223,10 @@ Db      Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:973.T9543.95.874 T42.AK2.AJ83.A63 KQJ6.Q8.KQ742.J9 A85.J76.T6.KQT52"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2S      3C      Pass
-3D      Pass    3NT     Pass
+1N     2S      3C      Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -237,7 +237,7 @@ Pass    Pass
 [Deal "N:9.AT84.3.AKJ7643 A53.K975.AQ86.Q2 KQJT62.2.KJ972.8 874.QJ63.T54.T95"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2S      Pass    3C
+1N     2S      Pass    3C
 Pass    3D      Pass    4C
 Pass    4S      Pass    Pass
 Pass    
@@ -250,7 +250,7 @@ Pass
 [Deal "N:2.J954.J9652.J65 J976.AT.AK83.A74 AQT53.K32.4.KQ92 K84.Q876.QT7.T83"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2S      Pass    2NT
+1N     2S      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -262,7 +262,7 @@ Pass
 [Deal "N:QT32.83.QJ76.Q42 A9.AKJ5.842.A985 KJ654.T94..KJT76 87.Q762.AKT953.3"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -274,7 +274,7 @@ Pass    Pass
 [Deal "N:32.QT983.K98.653 A86.AK5.Q3.AT942 KQ54.7.AJT762.K7 JT97.J642.54.QJ8"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -285,7 +285,7 @@ Pass
 [Deal "N:Q2.J6.8642.AJT74 K976.AQT.AQT3.53 AJ83.K54..KQ9862 T54.98732.KJ975."]
 [Contract "3H"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -297,7 +297,7 @@ Pass    Pass
 [Deal "N:Q962.J763.72.J76 A5.A42.KT983.KQ3 KJ843.K8.AQ64.94 T7.QT95.J5.AT852"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -309,7 +309,7 @@ Pass    Pass
 [Deal "N:63.Q986.QJ52.643 KQ5.AK43.K974.Q5 AJT97.2.T63.AKT9 842.JT75.A8.J872"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -320,7 +320,7 @@ Pass
 [Deal "N:J75.AT83.7.KT643 A2.QJ76.KJ964.A7 KQT6.52.AQT32.Q9 9843.K94.85.J852"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -331,7 +331,7 @@ Pass
 [Deal "N:8.KQ9853.98.KJ75 AJT6.J764.K4.AQ3 KQ974.T.AQ753.82 532.A2.JT62.T964"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2S      Pass    3H
+1N     2S      Pass    3H
 Pass    4D      Pass    4H
 Pass    Pass    Pass    
 
@@ -343,7 +343,7 @@ Pass    Pass    Pass
 [Deal "N:T8.T9532.7.KQ654 Q642.AJ8.KQ6.AJT AJ93.64.AJ932.82 K75.KQ7.T854.973"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -354,7 +354,7 @@ Pass
 [Deal "N:K2.J962.T87.JT84 J76.AQ53.A3.KQ92 AQT94.4.KQJ962.6 853.KT87.54.A753"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -365,7 +365,7 @@ Pass
 [Deal "N:A763.T952.T43.53 QT.KJ4.AKQ8.QT98 KJ854.Q8.95.AK74 92.A763.J762.J62"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Db      Pass    3H      Pass
 Pass    Pass    
 
@@ -377,7 +377,7 @@ Pass    Pass
 [Deal "N:84.A85.743.KQJT4 KQ6.KT732.K9.A75 AJ975.J94.AQ62.8 T32.Q6.JT85.9632"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -388,7 +388,7 @@ Pass
 [Deal "N:T53.AKT932.AQ63. K87.QJ74.74.AKQT AQJ2.8.KJT82.762 964.65.95.J98543"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -399,7 +399,7 @@ Pass
 [Deal "N:97.AT.A963.98532 KQ6.QJ843.J75.AQ AJT543..KQT42.76 82.K97652.8.KJT4"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -411,7 +411,7 @@ Pass
 [Deal "N:J54.AT62.94.J876 T73.K84.QJ6.AKQ2 AQ86.J7.AKT73.53 K92.Q953.852.T94"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -420,10 +420,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:J964.9643.76.874 AT3.QJ87.KT2.AQ6 KQ872.52.8.KJ953 5.AKT.AQJ9543.T2"]
-[Contract "4NT"]
+[Contract "4N"]
 [Auction "E"]
-1NT     2S      3D      Pass
-3NT     Pass    4NT     Pass
+1N     2S      3D      Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -434,7 +434,7 @@ Pass    Pass
 [Deal "N:985.85.KJ43.T973 KT42.AK3.A75.K82 AQ63.94.82.AJ654 J7.QJT762.QT96.Q"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -446,7 +446,7 @@ Pass    Pass
 [Deal "N:Q632.KJT854.6.54 K874.AQ.A754.Q63 AJ95..QJT982.KJ2 T.97632.K3.AT987"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -458,7 +458,7 @@ Pass    Pass
 [Deal "N:QT9.KJ983.Q863.7 J7.A75.AK9.KJT63 AK52.6.74.AQ8542 8643.QT42.JT52.9"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -469,7 +469,7 @@ Pass
 [Deal "N:K74.QT864.Q3.T85 Q82.KJ95.AJ6.A42 AJ963..T752.KQ73 T5.A732.K984.J96"]
 [Contract "4H"]
 [Auction "E"]
-1NT     2S      Db      Pass
+1N     2S      Db      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -481,7 +481,7 @@ Pass    Pass
 [Deal "N:A73.K43.QJ9863.4 94.AJT5.A542.AK8 KQJ82.8.K.QJ9652 T65.Q9762.T7.T73"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2S      Pass    2NT
+1N     2S      Pass    2N
 Pass    3C      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -494,7 +494,7 @@ Pass
 [Deal "N:942.AQ2.96.JT862 AQ6.8643.A7.AK74 KJ873.5.KQ543.95 T5.KJT97.JT82.Q3"]
 [Contract "3H"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -506,7 +506,7 @@ Pass    Pass
 [Deal "N:Q73.84.QJ74.J984 T8.KJ92.AKT83.A7 AJ96.653.6.KQT65 K542.AQT7.952.32"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -517,7 +517,7 @@ Pass
 [Deal "N:Q973.653.AQJ3.T5 T8.AKQT7.KT2.A42 AJ654.98.4.KQ763 K2.J42.98765.J98"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -528,7 +528,7 @@ Pass
 [Deal "N:64.KT74.QJ763.J3 Q532.AQ86.A98.K7 AKJT8.92.T4.AQ84 97.J53.K52.T9652"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -539,7 +539,7 @@ Pass
 [Deal "N:985.J9853.K986.J AJ4.A64.AQJ53.82 KQT73.K2.72.AQ95 62.QT7.T4.KT7643"]
 [Contract "3C"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -549,11 +549,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:Q4.J87643.87.863 62.KT2.QT3.AKQJ4 AJ753..AK952.952 KT98.AQ95.J64.T7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -564,7 +564,7 @@ Pass
 [Deal "N:853.T853.964.973 92.KJ.KQJ3.AJ842 AJT64.92.52.KQ65 KQ7.AQ764.AT87.T"]
 [Contract "6D"]
 [Auction "E"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 4C      Pass    4D      Pass
 5D      Pass    6D      Pass
 Pass    Pass    
@@ -577,7 +577,7 @@ Pass    Pass
 [Deal "N:5.JT8752.T4.JT87 J86.AQ93.K83.AK4 AK93.64.AJ972.53 QT742.K.Q65.Q962"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -588,6 +588,6 @@ Pass
 [Deal "N:2.KQ76543.J96.Q9 KQ5.AJT8.K2.A654 AJ963.9.AQT4.JT8 T874.2.8753.K732"]
 [Contract "2S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 

--- a/GIB/Cappelletti-3C.pbn
+++ b/GIB/Cappelletti-3C.pbn
@@ -6,7 +6,7 @@
 [Deal "N:A7432.752.9652.7 KQJ9.K863.KQ.Q42 T8.QJ.A83.AKJT63 65.AT94.JT74.985"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -17,7 +17,7 @@ Pass
 [Deal "N:Q4.9865.T65.T654 AJ.AJ72.KQJ32.92 K8.QT.987.AKQJ73 T976532.K43.A4.8"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3C      4S      Pass
+1N     3C      4S      Pass
 Pass    Pass    
 
 
@@ -28,7 +28,7 @@ Pass    Pass
 [Deal "N:952.J32.J9852.95 AKJ6.A94.AT74.T3 74.Q85.K3.AKQJ62 QT83.KT76.Q6.874"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -39,7 +39,7 @@ Pass
 [Deal "N:AT82.43.9765.982 K97.KT976.KQ2.A4 J6.A8.A43.KQJT65 Q543.QJ52.JT8.73"]
 [Contract "4C"]
 [Auction "E"]
-1NT     3C      Pass    4C
+1N     3C      Pass    4C
 Pass    Pass    Pass    
 
 
@@ -50,7 +50,7 @@ Pass    Pass    Pass
 [Deal "N:632.9853.KT76.83 AKJ.762.A95.A975 98.AKT.Q2.KQJT42 QT754.QJ4.J843.6"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -61,7 +61,7 @@ Pass
 [Deal "N:8762.98.KT764.62 KQJ3.AKJ3.952.J3 A94.T6.Q3.AKQT75 T5.Q7542.AJ8.984"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -72,7 +72,7 @@ Pass
 [Deal "N:QT2.KT6532.J2.52 863.AQ.AKQ53.J84 AJ.J98.94.AKQT76 K9754.74.T876.93"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -83,7 +83,7 @@ Pass
 [Deal "N:763.Q85.T943.J85 AKT4.A42.KQ8.743 Q5.97.A76.AKQT62 J982.KJT63.J52.9"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -94,7 +94,7 @@ Pass
 [Deal "N:Q7643.QT32.J7.65 J98.AK6.AKQ43.92 A5.J8.982.AKQJ73 KT2.9754.T65.T84"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -105,7 +105,7 @@ Pass
 [Deal "N:QT974.J842.Q97.7 AK2.AT93.AT83.Q3 J65.K.K52.AKJT54 83.Q765.J64.9862"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -116,7 +116,7 @@ Pass
 [Deal "N:742.Q9872.A63.76 AQ85.AJT4.KJ8.Q8 KJ.K5.974.AKJT52 T963.63.QT52.943"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -127,7 +127,7 @@ Pass
 [Deal "N:843.K98.A84.J876 AKT9.AQ3.QJ75.52 Q5.J54.K9.AKQT93 J762.T762.T632.4"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -138,7 +138,7 @@ Pass
 [Deal "N:32.T32.AJ97632.6 QJ95.AQ.K85.A983 A64.K76.Q.KQJT72 KT87.J9854.T4.54"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -149,7 +149,7 @@ Pass
 [Deal "N:QT97.J9764.AJ82. A653.AQ3.K43.Q85 KJ.K2.975.AKJT63 842.T85.QT6.9742"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -160,7 +160,7 @@ Pass
 [Deal "N:JT98.T9.KQ875.42 A543.AKQJ.JT4.J7 Q2.652.A3.AKQT86 K76.8743.962.953"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -171,7 +171,7 @@ Pass
 [Deal "N:43.KJ84.KJT62.73 AQ65.AT53.AQ.852 K2.Q9.943.AKQJ64 JT987.762.875.T9"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -182,7 +182,7 @@ Pass
 [Deal "N:J972.KJT743.T96. A5.Q65.AQJ7.A763 Q86.A8.K8.KQJT94 KT43.92.5432.852"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -193,7 +193,7 @@ Pass
 [Deal "N:T987.KQ95.9762.3 Q653.A74.AK54.A9 AK2.T2.QT.KQJT72 J4.J863.J83.8654"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -204,7 +204,7 @@ Pass
 [Deal "N:QT43.J6432.76.82 K652.AK87.AJ3.73 AJ9.QT.T5.AKJT94 87.95.KQ9842.Q65"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -215,7 +215,7 @@ Pass
 [Deal "N:QJ8.Q874.92.9832 AK96.A9.A873.T54 73.K53.Q6.AKQJ76 T542.JT62.KJT54."]
 [Contract "4C"]
 [Auction "E"]
-1NT     3C      Pass    4C
+1N     3C      Pass    4C
 Pass    Pass    Pass    
 
 
@@ -226,7 +226,7 @@ Pass    Pass    Pass
 [Deal "N:AT32.T74.85.T974 K9.KQJ3.KQJ74.83 J7.92.A96.AKQJ52 Q8654.A865.T32.6"]
 [Contract "4D"]
 [Auction "E"]
-1NT     3C      Pass    4C
+1N     3C      Pass    4C
 4D      Pass    Pass    Pass
 
 
@@ -238,7 +238,7 @@ Pass    Pass    Pass
 [Deal "N:T72.9.KQ632.8763 AJ983.A53.AT8.K5 K5.KJT.J4.AQJT42 Q64.Q87642.975.9"]
 [Contract "5C"]
 [Auction "E"]
-1NT     3C      Pass    5C
+1N     3C      Pass    5C
 Pass    Pass    Pass    
 
 
@@ -249,7 +249,7 @@ Pass    Pass    Pass
 [Deal "N:J98.AT982.T7.974 AT73.K64.KQJ8.A3 Q6.QJ.A65.KQJT62 K542.753.9432.85"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3C      Pass    4C
+1N     3C      Pass    4C
 Db      Pass    4S      Pass
 Pass    Pass    
 
@@ -261,7 +261,7 @@ Pass    Pass
 [Deal "N:J9542.5.Q9653.J7 A3.AJ932.AK7.653 K8.K8.42.AKQT984 QT76.QT764.JT8.2"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -272,7 +272,7 @@ Pass
 [Deal "N:62.A74.97653.J62 AJT3.T5.AKQJ.543 K8.K82.84.AKQT97 Q9754.QJ963.T2.8"]
 [Contract "4C"]
 [Auction "E"]
-1NT     3C      Pass    4C
+1N     3C      Pass    4C
 Pass    Pass    Pass    
 
 
@@ -283,7 +283,7 @@ Pass    Pass    Pass
 [Deal "N:Q742.KT987.A72.9 AJT8.AJ4.KT64.Q2 K96.Q.Q83.AKJT83 53.6532.J95.7654"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -294,7 +294,7 @@ Pass
 [Deal "N:AJ854.JT7.T432.5 QT.KQ964.KQ9.K92 976.A32.A.AQJT63 K32.85.J8765.874"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -305,7 +305,7 @@ Pass
 [Deal "N:9732.Q64.AQT65.2 AKJ.KJ97.J83.Q97 84.A32.K2.AKJT85 QT65.T85.974.643"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -316,7 +316,7 @@ Pass
 [Deal "N:9873.JT973.A82.Q AKJT.A65.QJ96.93 Q2.KQ2.T5.AKJT82 654.84.K743.7654"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -327,7 +327,7 @@ Pass
 [Deal "N:865.A98752.T7.54 KQJ43.KQT.A52.82 A2.64.Q64.AKQT76 T97.J3.KJ983.J93"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -338,7 +338,7 @@ Pass
 [Deal "N:QT3.J864.73.9532 K96.AK7.AK985.87 J7.Q32.QT.AKQJ64 A8542.T95.J642.T"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3C      Pass    4C
+1N     3C      Pass    4C
 Db      Pass    4S      Pass
 Pass    Pass    
 
@@ -348,10 +348,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:52.QT9.KQT864.76 KQ8.AJ65.AJ95.Q2 AT.K42.32.AKJT83 J97643.873.7.954"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     3C      Pass    3D
-Pass    3NT     Pass    Pass
+1N     3C      Pass    3D
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -362,7 +362,7 @@ Pass
 [Deal "N:76.QJT5.JT932.62 AJT92.K97.AQ.Q97 K4.A86.85.AKJT84 Q853.432.K764.53"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -373,7 +373,7 @@ Pass
 [Deal "N:982.Q54.J987.J82 AKJ5.K86.AQ5.973 Q64.A7.43.AKQT64 T73.JT932.KT62.5"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -384,7 +384,7 @@ Pass
 [Deal "N:97432.J92.T53.76 AQ6.QT73.AQ4.Q53 KJ5.K.876.AKJT98 T8.A8654.KJ92.42"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3C      3H      Pass
+1N     3C      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -396,7 +396,7 @@ Pass
 [Deal "N:432.KJ863.KT8.74 AK97.Q752.AQ5.65 J8.A94.32.AKQJ93 QT65.T.J9764.T82"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -407,7 +407,7 @@ Pass
 [Deal "N:J97643.A65.QT97. AK8.QJT7.J85.A95 QT.K84.A2.KQJT82 52.932.K643.7643"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3C      Pass    3S
+1N     3C      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -419,7 +419,7 @@ Pass
 [Deal "N:QT32.KJT98.8743. AK75.A53.A2.J987 J9.Q76.K.AKQT632 864.42.QJT965.54"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -430,7 +430,7 @@ Pass
 [Deal "N:72.AJT962.73.842 AKJ94.Q73.A94.J5 Q.K85.JT6.AKQT76 T8653.4.KQ852.93"]
 [Contract "4C"]
 [Auction "E"]
-1NT     3C      Pass    4C
+1N     3C      Pass    4C
 Pass    Pass    Pass    
 
 
@@ -441,7 +441,7 @@ Pass    Pass    Pass
 [Deal "N:J76.9753.T6.Q862 AK5.AT84.KQ42.74 983.Q6.AJ.AKJT95 QT42.KJ2.98753.3"]
 [Contract "4D"]
 [Auction "E"]
-1NT     3C      Pass    4C
+1N     3C      Pass    4C
 Db      Pass    4D      Pass
 Pass    Pass    
 
@@ -453,7 +453,7 @@ Pass    Pass
 [Deal "N:QJ9876.5432.A7.3 A4.KT97.KJ982.A2 K2.A8.Q53.KQJT74 T53.QJ6.T64.9865"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3C      Pass    3S
+1N     3C      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -465,7 +465,7 @@ Pass
 [Deal "N:J73.K8765.832.74 K6.QJ3.AQJ4.Q862 84.AT4.KT.AKJT53 AQT952.92.9765.9"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3C      4S      Pass
+1N     3C      4S      Pass
 Pass    Pass    
 
 
@@ -476,7 +476,7 @@ Pass    Pass
 [Deal "N:QT93.97.QJT75.84 A65.AKJ6.A32.J95 J2.Q85.K9.AKQT32 K874.T432.864.76"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -487,7 +487,7 @@ Pass
 [Deal "N:J874.J43.QT972.4 K65.AT96.AKJ.976 AQT.Q8.43.AQJT83 932.K752.865.K52"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -498,7 +498,7 @@ Pass
 [Deal "N:765.QJ82.T83.762 AQJ32.AT.Q65.Q94 KT.643.A7.AKJT53 984.K975.KJ942.8"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -509,7 +509,7 @@ Pass
 [Deal "N:9632.864.A542.62 KQJ4.A72.K7.A875 A5.KT5.Q6.KQJT93 T87.QJ93.JT983.4"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -520,7 +520,7 @@ Pass
 [Deal "N:QT972.Q95.J6.864 KJ.AJT7.A842.Q52 A63.K2.T9.AKJT97 854.8643.KQ753.3"]
 [Contract "4C"]
 [Auction "E"]
-1NT     3C      Pass    4C
+1N     3C      Pass    4C
 Pass    Pass    Pass    
 
 
@@ -531,7 +531,7 @@ Pass    Pass    Pass
 [Deal "N:T984.T643.Q652.3 AQ76.AQ2.K973.84 J2.K.JT8.AKQJ952 K53.J9875.A4.T76"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -542,7 +542,7 @@ Pass
 [Deal "N:QT9876.J742.5.Q8 AK42.AT8.AQ82.62 J5.Q9.KJT.AKJT75 3.K653.97643.943"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -553,7 +553,7 @@ Pass
 [Deal "N:JT862.A98.K95.J7 AQ7.KQT.AJT43.98 K5.J6.Q82.AKQT42 943.75432.76.653"]
 [Contract "3C"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -564,7 +564,7 @@ Pass
 [Deal "N:Q7.QJT9872.K9.82 KJT9.AK.J742.K93 A8.54.AT5.AQJT64 65432.63.Q863.75"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3C      Pass    3H
+1N     3C      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
 

--- a/GIB/Cappelletti-3D.pbn
+++ b/GIB/Cappelletti-3D.pbn
@@ -6,7 +6,7 @@
 [Deal "N:98753.93.874.T43 A642.KQJ6.Q93.A2 QJ.874.AKJT52.KJ KT.AT52.6.Q98765"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3D      Pass    4D
+1N     3D      Pass    4D
 Db      Pass    4H      Pass
 Pass    Pass    
 
@@ -18,7 +18,7 @@ Pass    Pass
 [Deal "N:53.J72.9842.6432 A9764.KQ5.A6.K75 K8.4.KQJT753.AT9 QJT2.AT9863..QJ8"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3D      4H      Pass
+1N     3D      4H      Pass
 Pass    Pass    
 
 
@@ -29,7 +29,7 @@ Pass    Pass
 [Deal "N:T.AJT9432.Q.T975 K83.K865.82.AKQ2 A95.Q.AKJT53.J63 QJ7642.7.9764.84"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3D      Pass    3H
+1N     3D      Pass    3H
 Pass    4D      Pass    4H
 Pass    Pass    Pass    
 
@@ -41,7 +41,7 @@ Pass    Pass    Pass
 [Deal "N:JT986.873.J7.T94 732.AK52.96.AKQ5 A4.6.AKQT542.862 KQ5.QJT94.83.J73"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3D      3H      Pass
+1N     3D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -53,7 +53,7 @@ Pass    Pass    Pass
 [Deal "N:A62.J2.J52.JT874 K75.AQ985.98.AQ9 843.K3.AKQT743.6 QJT9.T764.6.K532"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3D      Pass    4D
+1N     3D      Pass    4D
 4H      Pass    Pass    Pass
 
 
@@ -65,7 +65,7 @@ Pass    Pass    Pass
 [Deal "N:9862.QJ98.8.A975 K43.AKT7.953.KQ3 A7.54.AKQJ76.862 QJT5.632.T42.JT4"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -76,7 +76,7 @@ Pass
 [Deal "N:53.JT876.Q8.9875 AJ764.AK4.95.K32 KT9.95.AKJT432.J Q82.Q32.76.AQT64"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -85,9 +85,9 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:9653.K432.7.T943 AT84.QJ9.95.AKJ2 Q2.A7.AKJT42.865 KJ7.T865.Q863.Q7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     3D      3NT     Pass
+1N     3D      3N     Pass
 Pass    Pass    
 
 
@@ -98,7 +98,7 @@ Pass    Pass
 [Deal "N:T53.T643.762.843 QJ96.KQJ.Q5.AT75 72.A7.AKJT98.QJ9 AK84.9852.43.K62"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3D      Db      Pass
+1N     3D      Db      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -110,7 +110,7 @@ Pass    Pass
 [Deal "N:KJ32.5.5.JT97652 A964.KQ97.J97.KQ 5.AJ3.AKQT43.843 QT87.T8642.862.A"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -121,7 +121,7 @@ Pass
 [Deal "N:AJT8754..853.J87 KQ.AQ54.76.KQT92 632.972.AKQJ92.A 9.KJT863.T4.6543"]
 [Contract "4D"]
 [Auction "E"]
-1NT     3D      Pass    4D
+1N     3D      Pass    4D
 Pass    Pass    Pass    
 
 
@@ -132,7 +132,7 @@ Pass    Pass    Pass
 [Deal "N:T763.Q5.6.KT9854 AQ9.KJT62.84.AJ2 K54..KQJT932.Q63 J82.A98743.A75.7"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3D      4H      Pass
+1N     3D      4H      Pass
 Pass    Pass    
 
 
@@ -143,7 +143,7 @@ Pass    Pass
 [Deal "N:T64.T85.6.AK8643 KQ8.AJ932.A75.JT J9.KQ.KQJT98.Q92 A7532.764.432.75"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -154,7 +154,7 @@ Pass
 [Deal "N:52.AT643.32.J762 AQ97.985.A8.AQT3 63.KQ.KQJT965.K5 KJT84.J72.74.984"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -165,7 +165,7 @@ Pass
 [Deal "N:KQT872.9874.8.72 AJ4.KQ5.A96.J985 96.AJ.KQJT54.A43 53.T632.732.KQT6"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -176,7 +176,7 @@ Pass
 [Deal "N:J74.765.93.K9843 A653.AQ83.87.AJ2 K82.J94.AKJT65.Q QT9.KT2.Q42.T765"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -187,7 +187,7 @@ Pass
 [Deal "N:KQ98.Q5.6.Q98763 A63.AK63.954.AJ4 J5.J74.AKQJ83.KT T742.T982.T72.52"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -198,7 +198,7 @@ Pass
 [Deal "N:Q54.K742.T3.K943 AK92.AQT.754.QJT 76.J83.AKQJ86.A8 JT83.965.92.7652"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -209,7 +209,7 @@ Pass
 [Deal "N:Q87652.T63.4.J94 AKJT.QJ95.A98.QT .A72.KQJT7632.K8 943.K84.5.A76532"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -220,7 +220,7 @@ Pass
 [Deal "N:7.QT864.T863.KJ2 AQ65.AK5.52.AT74 KT8.9.AKQJ97.986 J9432.J732.4.Q53"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3D      Pass    4D
+1N     3D      Pass    4D
 Db      Pass    4S      Pass
 Pass    Pass    
 
@@ -232,7 +232,7 @@ Pass    Pass
 [Deal "N:QJ.QJ9842.76.K98 AK4.AK5.J3.T7542 T8.T.AKQT984.Q63 976532.763.52.AJ"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3D      Pass    3H
+1N     3D      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -243,7 +243,7 @@ Pass    Pass    Pass
 [Deal "N:QJ52.KT9.Q7.K873 AK87.Q64.43.AQT9 T9.AJ3.AKJT52.52 643.8752.986.J64"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -254,7 +254,7 @@ Pass
 [Deal "N:AT642.QT8.32.J84 QJ5.K7.K984.AKT5 K7.A42.AQJT75.73 983.J9653.6.Q962"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -265,7 +265,7 @@ Pass
 [Deal "N:AQ8763.J76..K982 K95.AKQ.Q32.QT54 2.942.AKJT964.AJ JT4.T853.875.763"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3D      Pass    3S
+1N     3D      Pass    3S
 Pass    Pass    Pass    
 
 
@@ -276,7 +276,7 @@ Pass    Pass    Pass
 [Deal "N:42.KQ543.9.AQ943 AK7.A9762.J74.K2 QJT.J.AKQT86.J75 98653.T8.532.T86"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -287,7 +287,7 @@ Pass
 [Deal "N:QT3.AT962.96.942 AK9.743.53.AKJ73 J76.K.AKJT874.86 8542.QJ85.Q2.QT5"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -298,7 +298,7 @@ Pass
 [Deal "N:T93.AT873.Q3.Q64 AQ76.KQ92.97.A73 KJ8..AKJT654.T85 542.J654.82.KJ92"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -309,7 +309,7 @@ Pass
 [Deal "N:J6.K876543..AJ74 AK875.J2.A82.K65 94.A.KQJT974.Q32 QT32.QT9.653.T98"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3D      Pass    3H
+1N     3D      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -320,7 +320,7 @@ Pass    Pass    Pass
 [Deal "N:73.KQT54.3.QT765 AQ95.862.J4.AKJ2 KJ2.J9.AKQT86.84 T864.A73.9752.93"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -331,7 +331,7 @@ Pass
 [Deal "N:Q532.QT763.62.43 AK4.K82.Q94.KQT8 T.AJ.AKJT8753.J6 J9876.954..A9752"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -342,7 +342,7 @@ Pass
 [Deal "N:T932.53.86.KQJ76 AKQ.KQ84.Q94.T85 J87.T9.AKJT75.A3 654.AJ762.32.942"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -353,7 +353,7 @@ Pass
 [Deal "N:KJ2.KJ54..T98765 A97.AT2.A865.K42 QT.9.KQJT932.AJ3 86543.Q8763.74.Q"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -364,7 +364,7 @@ Pass
 [Deal "N:KJT73.J64.5.KT85 AQ.A87.T9873.AJ6 92.Q9.AKQJ42.Q93 8654.KT532.6.742"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -375,7 +375,7 @@ Pass
 [Deal "N:942.T8432.52.972 QT75.AQ9.98.AK64 KJ6.7.AKJT763.J3 A83.KJ65.Q4.QT85"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -386,7 +386,7 @@ Pass
 [Deal "N:7542.87.93.AK943 AKQJ.AJ2.J84.T62 63.95.AKQT75.QJ7 T98.KQT643.62.85"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -397,7 +397,7 @@ Pass
 [Deal "N:QT84.873.752.J76 A953.A6.T64.AKT3 J2.Q95.AKQJ98.82 K76.KJT42.3.Q954"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3D      3H      Pass
+1N     3D      3H      Pass
 3S      Pass    4H      Pass
 Pass    Pass    
 
@@ -409,7 +409,7 @@ Pass    Pass
 [Deal "N:A8765.J2.865.K32 KQ2.AK84.J9.AT84 4.Q65.AKQT743.J9 JT93.T973.2.Q765"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -420,7 +420,7 @@ Pass
 [Deal "N:QJ64.Q.76.QJT654 KT83.A763.K9.AK7 A95.KT5.AQJT83.2 72.J9842.542.983"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -431,7 +431,7 @@ Pass
 [Deal "N:J94.T75.J74.9654 AKT.AQ982.53.K32 Q73.3.AKQT986.J8 8652.KJ64.2.AQT7"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3D      Db      Pass
+1N     3D      Db      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -443,7 +443,7 @@ Pass    Pass
 [Deal "N:A752.AQ82.74.T82 KT83.K53.T62.AKQ QJ6.94.AKQJ98.75 94.JT76.53.J9643"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -454,7 +454,7 @@ Pass
 [Deal "N:QJ8.73.873.KQ852 A973.AQJ5.T65.A6 4.K84.AKQJ42.T93 KT652.T962.9.J74"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -465,7 +465,7 @@ Pass
 [Deal "N:QJ8763.97.6.Q652 K92.AJ62.A32.A94 T.KT8.KQJT875.KJ A54.Q543.94.T873"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -476,7 +476,7 @@ Pass
 [Deal "N:QT8.QJ832.9.KJT4 A63.AKT.732.A872 K54.54.AKQT865.6 J972.976.J4.Q953"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -487,7 +487,7 @@ Pass
 [Deal "N:Q73.T8.953.KQJ87 AT64.A962.K8.AT4 K8.KJ.AQJT62.952 J952.Q7543.74.63"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -498,7 +498,7 @@ Pass
 [Deal "N:653.JT932.8.K832 Q82.AKQ5.K54.JT7 AJ7.84.AQJT76.95 KT94.76.932.AQ64"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -509,7 +509,7 @@ Pass
 [Deal "N:J962.75.92.76542 AQ87.AQ86.A54.83 5.T3.KQJT763.AK9 KT43.KJ942.8.QJT"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3D      Db      Pass
+1N     3D      Db      Pass
 4D      Pass    4S      Pass
 Pass    Pass    
 
@@ -521,7 +521,7 @@ Pass    Pass
 [Deal "N:9864.Q843.8654.3 AJ5.AK95.T7.K984 KT.72.AKQJ93.J76 Q732.JT6.2.AQT52"]
 [Contract "5DX"]
 [Auction "E"]
-1NT     3D      Pass    5D
+1N     3D      Pass    5D
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -533,7 +533,7 @@ Pass    Pass
 [Deal "N:T653.53.2.QJT954 K742.AKJ.987.A86 98.97.AKQJ543.K3 AQJ.QT8642.T6.72"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3D      4H      Pass
+1N     3D      4H      Pass
 Pass    Pass    
 
 
@@ -544,7 +544,7 @@ Pass    Pass
 [Deal "N:J8.87.42.KQJ8642 AQ9.KQJ95.73.A73 KT.A2.KQJT986.95 765432.T643.A5.T"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -555,7 +555,7 @@ Pass
 [Deal "N:Q753.AT54.32.QT7 AKJ84.J82.A87.K5 62.K73.KQJT64.AJ T9.Q96.95.986432"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -566,6 +566,6 @@ Pass
 [Deal "N:T82.J932.4.K9643 AQ97.KQ85.93.AQT 64.A6.AKJT876.J2 KJ53.T74.Q52.875"]
 [Contract "3D"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 

--- a/GIB/Cappelletti-3H.pbn
+++ b/GIB/Cappelletti-3H.pbn
@@ -6,7 +6,7 @@
 [Deal "N:J632.4.7432.AQT3 AKT5.83.KQ96.K54 84.AQJT9752.A5.7 Q97.K6.JT8.J9862"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -17,7 +17,7 @@ Pass
 [Deal "N:Q2.J75.T87654.43 K4.964.QJ9.AKQ98 JT5.AKQT32.K2.76 A98763.8.A3.JT52"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3H      4S      Pass
+1N     3H      4S      Pass
 Pass    Pass    
 
 
@@ -28,7 +28,7 @@ Pass    Pass
 [Deal "N:KT764.2.KQJ2.T83 Q852.T9.A85.AKQ4 93.AKQJ8654.6.62 AJ.73.T9743.J975"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -39,7 +39,7 @@ Pass
 [Deal "N:974.82.T42.AQT86 AJ63.A43.A86.K92 KQ5.KQJT96.K3.73 T82.75.QJ975.J54"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -50,7 +50,7 @@ Pass
 [Deal "N:AT86.2.J873.J986 K42.K5.A952.AQ74 73.AQJT764.KQ.K5 QJ95.983.T64.T32"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -61,7 +61,7 @@ Pass
 [Deal "N:8.42.JT53.KQ8654 KT53.K93.A86.AJ9 J7.AQJT85.KQ9.T3 AQ9642.76.742.72"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -72,7 +72,7 @@ Pass
 [Deal "N:QT642.A4.Q543.Q3 AK3.97.A92.AJ975 87.KQJT532.KT8.K J95.86.J76.T8642"]
 [Contract "5H"]
 [Auction "E"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Db      Pass    5C      Db
 Pass    5H      Pass    Pass
 Pass    
@@ -85,7 +85,7 @@ Pass
 [Deal "N:Q5.62.Q8762.K754 A73.Q5.KJ94.AJT2 T62.AKJT84.AT3.Q KJ984.973.5.9863"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -96,7 +96,7 @@ Pass
 [Deal "N:7642.9.K875.J762 A8.J86.AJ96.KQ83 K53.AKQT53.T32.5 QJT9.742.Q4.AT94"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -107,7 +107,7 @@ Pass
 [Deal "N:QJT43..A54.QT852 AK.Q65.T83.AK963 985.AKJT973.QJ6. 762.842.K972.J74"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -118,7 +118,7 @@ Pass
 [Deal "N:T3..AJT9743.K875 AK74.73.K85.AJT9 82.AKQT9842..Q62 QJ965.J65.Q62.43"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -129,7 +129,7 @@ Pass
 [Deal "N:Q95.K42.973.T652 AKT64.763.KQ.K43 J82.AQJT95.A2.Q8 73.8.JT8654.AJ97"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -140,7 +140,7 @@ Pass
 [Deal "N:8642..KQJ852.QJ4 AK.Q975.A9.K8765 T93.AKJT832.6.A3 QJ75.64.T743.T92"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -151,7 +151,7 @@ Pass
 [Deal "N:T9.J43.QJ542.Q95 K86.75.AKT6.AK32 QJ7.AKQT82.73.76 A5432.96.98.JT84"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Db      Pass    4S      Pass
 Pass    Pass    
 
@@ -163,7 +163,7 @@ Pass    Pass
 [Deal "N:K3.3.KJ854.JT743 A62.K75.Q9.AK862 QJ8.AQJT942.6.Q5 T9754.86.AT732.9"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -174,7 +174,7 @@ Pass
 [Deal "N:KQJ982.7..JT8543 A73.Q852.QJ7.AQ9 T.AKJT94.KT8532. 654.63.A964.K762"]
 [Contract "4S"]
 [Auction "E"]
-1NT     2H      Pass    2S
+1N     2H      Pass    2S
 Pass    3D      Db      3S
 Pass    4H      Pass    4S
 Pass    Pass    Pass    
@@ -187,7 +187,7 @@ Pass    Pass    Pass
 [Deal "N:7.7654.986.AJ743 AQ3.32.KJ53.KQ82 J4.AKQJ98.A4.T65 KT98652.T.QT72.9"]
 [Contract "5HX"]
 [Auction "E"]
-1NT     3H      4S      5H
+1N     3H      4S      5H
 Db      Pass    Pass    Pass
 
 
@@ -199,7 +199,7 @@ Db      Pass    Pass    Pass
 [Deal "N:75.4.JT54.987543 Q8.T765.AK6.AKJ2 T43.AKQJ83.9.QT6 AKJ962.92.Q8732."]
 [Contract "4S"]
 [Auction "E"]
-1NT     3H      4S      Pass
+1N     3H      4S      Pass
 Pass    Pass    
 
 
@@ -210,7 +210,7 @@ Pass    Pass
 [Deal "N:5.J8.KQ8543.K875 AKJ3.32.AJ9.QJ63 64.AKQT54.762.A9 QT9872.976.T.T42"]
 [Contract "4SX"]
 [Auction "E"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Db      Pass    4S      Db
 Pass    Pass    Pass    
 
@@ -222,7 +222,7 @@ Pass    Pass    Pass
 [Deal "N:JT9764..532.9732 A5.T43.AK74.KQT6 83.AKQJ986.QJ.J8 KQ2.752.T986.A54"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -233,7 +233,7 @@ Pass
 [Deal "N:KT642.4.54.A9862 J87.A5.AKQT2.K73 AQ5.KQJT63.J93.J 93.9872.876.QT54"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -244,7 +244,7 @@ Pass
 [Deal "N:A764.8.642.QT653 KT98.K6.AKJ8.K98 .AQJT9742.95.A42 QJ532.53.QT73.J7"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -255,7 +255,7 @@ Pass
 [Deal "N:Q932.A63.7542.A4 AJT4.9874.AQ.KQ3 K5.KQJT52.KJ6.92 876..T983.JT8765"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -266,7 +266,7 @@ Pass    Pass    Pass
 [Deal "N:QT98643.64.83.K3 K7.Q98.AT65.AQJ6 A52.AKJT53.J4.54 J.72.KQ972.T9872"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -277,7 +277,7 @@ Pass
 [Deal "N:9832.83.AQT94.QT AJ6.97.KJ3.AK872 Q.AKQT642.72.J63 KT754.J5.865.954"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -288,7 +288,7 @@ Pass
 [Deal "N:KQJ3.T72.64.6543 54.986.KQJ82.AKQ AT8.AKQJ53.75.JT 9762.4.AT93.9872"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -299,7 +299,7 @@ Pass    Pass    Pass
 [Deal "N:Q8642.95.J9876.4 AJ97.J3.AK54.QT6 K3.AKQT86.Q3.J87 T5.742.T2.AK9532"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -310,7 +310,7 @@ Pass
 [Deal "N:A876.J4.T8643.97 KQ2.85.AKJ.AT854 J93.AKQT762.52.Q T54.93.Q97.KJ632"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -321,7 +321,7 @@ Pass
 [Deal "N:T73.764.QT6.JT62 QJ65.Q52.AK54.K3 K4.AKJT98.82.Q75 A982.3.J973.A984"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -332,7 +332,7 @@ Pass
 [Deal "N:Q872.32.KQJ82.K7 AKJ5.J4.A96.Q654 T3.AKQT65.T4.AJ3 964.987.753.T982"]
 [Contract "4SX"]
 [Auction "E"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Db      Pass    4S      Db
 Pass    Pass    Pass    
 
@@ -344,7 +344,7 @@ Pass    Pass    Pass
 [Deal "N:J852.93.T7642.84 T763.A62.KJ.AKQ6 9.KQJT85.AQ5.JT5 AKQ4.74.983.9732"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -355,7 +355,7 @@ Pass
 [Deal "N:T832.4.QT43.8642 A75.J8.K872.AKT5 K9.AKQT9762.9.Q9 QJ64.53.AJ65.J73"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -366,7 +366,7 @@ Pass
 [Deal "N:AT98743.3.52.T62 KJ65.64.AQ4.AQ98 2.AQJT985.K3.K75 Q.K72.JT9876.J43"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -377,7 +377,7 @@ Pass
 [Deal "N:K98.72.T6.JT7642 Q65.A983.AK53.A9 A4.KQJT54.Q82.Q3 JT732.6.J974.K85"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -388,7 +388,7 @@ Pass
 [Deal "N:J2.K.KJ9865.QT76 AK97.82.A43.AJ52 Q65.AQJT7654.Q.K T843.93.T72.9843"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -399,7 +399,7 @@ Pass
 [Deal "N:J9876.83.T8.T752 A2.Q96.KQJ75.K43 Q4.AKJT752.A4.96 KT53.4.9632.AQJ8"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -410,7 +410,7 @@ Pass
 [Deal "N:KT97.32.97632.T5 A432.K97.AK5.K83 Q86.AQJT854..A96 J5.6.QJT84.QJ742"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -421,7 +421,7 @@ Pass
 [Deal "N:Q83..KJ764.A9742 KT97.K84.AQ5.KJ6 AJ.AQJT97632.T.5 6542.5.9832.QT83"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -432,7 +432,7 @@ Pass
 [Deal "N:763.76.72.QJT975 AQT98.A95.AJT.82 KJ2.KQJT42.K6.64 54.83.Q98543.AK3"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -443,7 +443,7 @@ Pass
 [Deal "N:K653.986.T97.JT2 8742.J3.AKQ.AK86 A.AKQT75.832.975 QJT9.42.J654.Q43"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -454,7 +454,7 @@ Pass
 [Deal "N:T7652.5.J943.965 A94.K86.KQ5.KJ83 KQ3.AQJT9432.T.T J8.7.A8762.AQ742"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -465,7 +465,7 @@ Pass
 [Deal "N:87653.84.J2.KT72 AK.J6.T8743.AQJ8 Q4.AKQT32.A6.965 JT92.975.KQ95.43"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -476,7 +476,7 @@ Pass
 [Deal "N:764.63.T965.9754 T83.Q9.AKQ32.AQ3 KQ9.AKJT42.J4.J2 AJ52.875.87.KT86"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -487,7 +487,7 @@ Pass
 [Deal "N:AQT83.5.6.J86543 K972.Q9.AT8.AKT9 6.AKJT8764.Q9.Q2 J54.32.KJ75432.7"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -498,7 +498,7 @@ Pass
 [Deal "N:KT94.T8.5.AJ9853 A6.954.AQ962.KQ4 QJ2.AKQJ762.T8.2 8753.3.KJ743.T76"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -509,7 +509,7 @@ Pass    Pass    Pass
 [Deal "N:A954.762.T84.T84 KQT8.Q54.KQ3.K73 J2.AKJT83.52.A92 763.9.AJ976.QJ65"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -520,7 +520,7 @@ Pass
 [Deal "N:AJ74.65.AJ987.Q5 KQ2.T94.K5.AK864 3.AKQJ873.T2.J92 T9865.2.Q643.T73"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -531,7 +531,7 @@ Pass    Pass    Pass
 [Deal "N:854.2.QJ632.KJ95 AQT62.73.KT4.AQ4 K9.AKJT85.A85.32 J73.Q964.97.T876"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -542,7 +542,7 @@ Pass
 [Deal "N:94.632.Q76.JT854 762.J4.AJT83.AKQ K3.AKQT97.K52.72 AQJT85.85.94.963"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3H      4S      Pass
+1N     3H      4S      Pass
 Pass    Pass    
 
 
@@ -553,7 +553,7 @@ Pass    Pass
 [Deal "N:QJ872..KJ987.943 A43.Q4.A652.AJ76 95.AKJT873.Q4.K2 KT6.9652.T3.QT85"]
 [Contract "3H"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -564,7 +564,7 @@ Pass
 [Deal "N:QJ2.97.KQJ86.854 K83.J6.A942.AKQ3 7.AKQT8532.7.J97 AT9654.4.T53.T62"]
 [Contract "5H"]
 [Auction "E"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Db      Pass    4S      Db
 Pass    5H      Pass    Pass
 Pass    

--- a/GIB/Cappelletti-3S.pbn
+++ b/GIB/Cappelletti-3S.pbn
@@ -6,7 +6,7 @@
 [Deal "N:J.AK9642.64.T954 92.87.AKQ75.AQ86 AKQT764.Q.92.K32 853.JT53.JT83.J7"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -17,7 +17,7 @@ Pass
 [Deal "N:864.K9432.Q7.JT7 K93.QT5.AK43.A95 AQJT72.AJ6.T92.6 5.87.J865.KQ8432"]
 [Contract "4SX"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -29,7 +29,7 @@ Pass    Pass
 [Deal "N:52.JT65.J2.JT762 A7.K93.K9643.AK8 KQJT964.8.A8.Q93 83.AQ742.QT75.54"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3S      4H      Pass
+1N     3S      4H      Pass
 Pass    Pass    
 
 
@@ -40,7 +40,7 @@ Pass    Pass
 [Deal "N:9.QJ754.873.T853 Q5.A862.AT96.KQJ AKJT832.KT9.J4.9 764.3.KQ52.A7642"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -51,7 +51,7 @@ Pass
 [Deal "N:752.973.Q862.J94 A8.J86.A75.AQ753 KQJT643.KT5.K43. 9.AQ42.JT9.KT862"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -62,7 +62,7 @@ Pass
 [Deal "N:982.9.T7532.Q953 64.AK743.AKQ.642 AKQJ73.J65.84.K8 T5.QT82.J96.AJT7"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -73,7 +73,7 @@ Pass    Pass    Pass
 [Deal "N:T85.QT7432.Q75.K 643.KJ9.AK3.AJ85 AKQJ72.A.942.762 9.865.JT86.QT943"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -84,7 +84,7 @@ Pass    Pass    Pass
 [Deal "N:954.J9.KT.QJT865 72.AQ863.AQJ.K74 AKQT63.KT2.972.9 J8.754.86543.A32"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -95,7 +95,7 @@ Pass    Pass    Pass
 [Deal "N:T5.Q642.KQ72.AQ3 97.AK7.A54.KJ976 AKQJ8642.T5.T9.T 3.J983.J863.8542"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -106,7 +106,7 @@ Pass    Pass    Pass
 [Deal "N:72.KJ87.8763.764 T9.Q43.AQJ.AQJT9 AKQJ86.T62.K9.52 543.A95.T542.K83"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -117,7 +117,7 @@ Pass
 [Deal "N:T83.653.J863.Q72 97.AT4.AQ72.AK65 AKQJ642.Q92.T.T8 5.KJ87.K954.J943"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -128,7 +128,7 @@ Pass
 [Deal "N:T6.QJT93.43.T943 872.A742.AK96.AJ AKQJ53.8.JT8.Q82 94.K65.Q752.K765"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -139,7 +139,7 @@ Pass
 [Deal "N:72.98752.Q95.963 984.KJ4.AK764.AQ AKQJ65.A3.T82.T7 T3.QT6.J3.KJ8542"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -150,7 +150,7 @@ Pass
 [Deal "N:7.T963.QT63.9872 T84.KQ872.A4.AK5 AKQJ953.J5.7.QT3 62.A4.KJ9852.J64"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -161,7 +161,7 @@ Pass
 [Deal "N:98.J.AT952.AQJ63 K73.A875.KQJ.K75 AQJT42.KQ4.63.82 65.T9632.874.T94"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -172,7 +172,7 @@ Pass    Pass    Pass
 [Deal "N:J7.J82.AT9742.65 92.AKQ5.K853.KQ9 AKQT843.T7.6.A42 65.9643.QJ.JT873"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -183,7 +183,7 @@ Pass
 [Deal "N:86.98764.T32.973 T7.AJ52.KQ84.KQ8 AKQJ532.3.976.A2 94.KQT.AJ5.JT654"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -194,7 +194,7 @@ Pass
 [Deal "N:J652.T752.63.J96 43.AKQ3.K94.AT43 AKQT987.8.QT7.Q5 .J964.AJ852.K872"]
 [Contract "4SX"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -206,7 +206,7 @@ Pass    Pass
 [Deal "N:43.J853.Q86.T852 K9.Q7.KJT9.AQJ93 AQJT876.92.A43.4 52.AKT64.752.K76"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3S      4H      Pass
+1N     3S      4H      Pass
 Pass    Pass    
 
 
@@ -217,7 +217,7 @@ Pass    Pass
 [Deal "N:2.653.T74.AQ8732 Q43.KQT97.AQ5.K9 AKJT876.A2.632.5 95.J84.KJ98.JT64"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -228,7 +228,7 @@ Pass
 [Deal "N:74.KQ4.95.Q98763 A6.AT963.A73.AT4 KQJT82.J87.KQT.K 953.52.J8642.J52"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -239,7 +239,7 @@ Pass
 [Deal "N:Q94.T876.Q92.T84 65.KQ92.KJ4.KQJ3 AKJT72.54.AT5.72 83.AJ3.8763.A965"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -250,7 +250,7 @@ Pass
 [Deal "N:T62.KJ5.84.J8732 87.A432.AT95.AK5 AKQJ93.QT9.3.964 54.876.KQJ762.QT"]
 [Contract "4SX"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -262,7 +262,7 @@ Pass    Pass
 [Deal "N:876.AT75.T86.J64 T54.KQJ2.AJ.A975 AKQJ93.86.Q43.T8 2.943.K9752.KQ32"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -273,7 +273,7 @@ Pass
 [Deal "N:3.94.Q972.QT9652 A2.AQJ52.J54.K43 KQJT94.T76.AK6.7 8765.K83.T83.AJ8"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -284,7 +284,7 @@ Pass
 [Deal "N:854.K2.973.AT642 Q32.AQ85.AK86.97 AKJT97.6.QJ4.QJ3 6.JT9743.T52.K85"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -295,7 +295,7 @@ Pass    Pass    Pass
 [Deal "N:6.KJ984.Q654.952 T9.QT3.A92.AKQT7 AKQJ753.65.JT8.3 842.A72.K73.J864"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -306,7 +306,7 @@ Pass
 [Deal "N:984.54.AQ2.JT872 A72.AKT7.JT5.A63 KQJT63.Q32.K8.K5 5.J986.97643.Q94"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -317,7 +317,7 @@ Pass    Pass    Pass
 [Deal "N:52.85.QJ9643.T93 83.AQ6.KT2.KQJ42 AKJT94.T97432.A. Q76.KJ.875.A8765"]
 [Contract "4C"]
 [Auction "E"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 4C      Pass    Pass    Pass
 
 
@@ -329,7 +329,7 @@ Pass    Pass    Pass
 [Deal "N:843.AJT987.Q7.97 92.K42.KT43.AKQT AKQT75.Q6.A92.62 J6.53.J865.J8543"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -340,7 +340,7 @@ Pass    Pass    Pass
 [Deal "N:65.T5.AQ543.QT74 972.A43.KJT.AKJ6 AKJT843.K72..982 Q.QJ986.98762.53"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -351,7 +351,7 @@ Pass    Pass    Pass
 [Deal "N:542.8753.T984.Q5 J96.AKT2.AKQ7.T2 AKQT83.94.65.K74 7.QJ6.J32.AJ9863"]
 [Contract "4SX"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -363,7 +363,7 @@ Pass    Pass
 [Deal "N:J72.JT9.974.QJT4 98.AKQ.QJ653.A75 AKQT54.64.AT8.86 63.87532.K2.K932"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -374,7 +374,7 @@ Pass
 [Deal "N:2.Q.QJ8543.QJ963 Q73.AKT75.72.AK8 AKJT84.J92.A96.5 965.8643.KT.T742"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -385,7 +385,7 @@ Pass
 [Deal "N:65.KT63.J854.K85 82.AJ5.AK32.AT62 AKJT743.Q.97.Q73 Q9.98742.QT6.J94"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -396,7 +396,7 @@ Pass
 [Deal "N:83.T73.T832.9872 Q6.A986.AK964.Q5 AKJT72.K54.Q.643 954.QJ2.J75.AKJT"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -407,7 +407,7 @@ Pass
 [Deal "N:8.KT842.AJ95.T65 J752.AJ6.KQ3.KQ2 AKQT94.5.876.A43 63.Q973.T42.J987"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -418,7 +418,7 @@ Pass
 [Deal "N:853.J82.83.K9864 T9.K643.AJ97.AQJ AKQJ72.7.KT4.T72 64.AQT95.Q652.53"]
 [Contract "5H"]
 [Auction "E"]
-1NT     3S      4H      4S
+1N     3S      4H      4S
 5H      Pass    Pass    Pass
 
 
@@ -430,7 +430,7 @@ Pass
 [Deal "N:5.AQT3.AT9754.84 K4.KJ4.KJ63.AQT2 AQJT983.75.Q.KJ3 762.9862.82.9765"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -441,7 +441,7 @@ Pass
 [Deal "N:K.Q96.QT98743.JT 87.J843.AKJ2.AK9 AQJT542.K52..Q52 963.AT7.65.87643"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -452,7 +452,7 @@ Pass
 [Deal "N:A98.K6.AT73.9732 63.AJ93.KQJ4.KQ5 KQJT752.Q4.8.AT8 4.T8752.9652.J64"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -463,7 +463,7 @@ Pass    Pass    Pass
 [Deal "N:543.T9862.Q5.K83 96.AK5.A76.AJT65 AKQJ87.J7.K92.42 T2.Q43.JT843.Q97"]
 [Contract "4S"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -474,7 +474,7 @@ Pass    Pass    Pass
 [Deal "N:6.K3.AQ6542.T754 852.AJ86.J8.AKQ6 AKQJ743.9.K73.83 T9.QT7542.T9.J92"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -485,7 +485,7 @@ Pass
 [Deal "N:8.J9.QJ9732.Q842 A42.AQ852.64.AJ9 KQJT765.KT6.T8.K 93.743.AK5.T7653"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -496,7 +496,7 @@ Pass
 [Deal "N:5.Q8432.KQT4.763 T3.KT.AJ853.AK52 AKQJ8762.6.2.JT4 94.AJ975.976.Q98"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -507,7 +507,7 @@ Pass
 [Deal "N:8.985.97.KQJ9876 K74.A62.KQ4.A432 AQJT962.KJ.J32.T 53.QT743.AT865.5"]
 [Contract "4H"]
 [Auction "E"]
-1NT     3S      4H      Pass
+1N     3S      4H      Pass
 Pass    Pass    
 
 
@@ -518,7 +518,7 @@ Pass    Pass
 [Deal "N:T62.74.9753.Q865 9543.AQJ6.Q42.AK AKQJ87.9.AT6.742 .KT8532.KJ8.JT93"]
 [Contract "4SX"]
 [Auction "E"]
-1NT     3S      4H      4S
+1N     3S      4H      4S
 Db      Pass    Pass    Pass
 
 
@@ -530,7 +530,7 @@ Db      Pass    Pass    Pass
 [Deal "N:8653.532.J94.K72 K4.QJT.AKQ63.J94 AQJT972.A74.T5.5 .K986.872.AQT863"]
 [Contract "4SX"]
 [Auction "E"]
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -542,7 +542,7 @@ Pass    Pass
 [Deal "N:3.KT84.T8.AJT982 K92.A95.AKQ73.74 AQJT64.J76.94.KQ 875.Q32.J652.653"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -553,7 +553,7 @@ Pass
 [Deal "N:72.QT9543.632.T7 J86.AJ8.AJ7.AQ42 AKQT93.76.Q5.K63 54.K2.KT984.J985"]
 [Contract "3S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -562,8 +562,8 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:.543.J9765.KT864 82.AKQ62.KT2.QJ7 KQJT654.97.AQ4.2 A973.JT8.83.A953"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     3S      3NT     Pass
+1N     3S      3N     Pass
 Pass    Pass    
 

--- a/GIB/Cappelletti-X.pbn
+++ b/GIB/Cappelletti-X.pbn
@@ -6,7 +6,7 @@
 [Deal "N:QT63.852.Q52.T73 J752.AK64.K86.KQ AK9.QJT73.A7.A42 84.9.JT943.J9865"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      Rd      Pass
+1N     Db      Rd      Pass
 2C      Pass    2D      Pass
 Pass    2H      Pass    2S
 Pass    Pass    Pass    
@@ -19,7 +19,7 @@ Pass    Pass    Pass
 [Deal "N:A9765.T3.T983.T5 Q83.A85.AKQ.Q942 K.KQJ9.J764.AKJ3 JT42.7642.52.876"]
 [Contract "3D"]
 [Auction "E"]
-1NT     Db      Pass    2S
+1N     Db      Pass    2S
 Pass    3C      Pass    3D
 Pass    Pass    Pass    
 
@@ -29,9 +29,9 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:9742.K83.8762.T7 KJ6.AQ.KJ953.Q53 AQ5.T742.A.AK942 T83.J965.QT4.J86"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -42,7 +42,7 @@ Pass
 [Deal "N:86532.Q.Q85.T432 J9.AK32.KJT9.K96 AQ.J9875.A762.AJ KT74.T64.43.Q875"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      Pass    2S
+1N     Db      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -51,9 +51,9 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:752.JT74.9873.T2 KJ.Q985.AK54.QJ7 AQ964.AK2.Q.K543 T83.63.JT62.A986"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -62,9 +62,9 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:JT6.J965.65.Q652 KQ873.KQ.J97.AT4 4.AT4.AKQ2.K9873 A952.8732.T843.J"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -75,7 +75,7 @@ Pass
 [Deal "N:K8.T.J9654.KT874 AQT94.K9.QT8.A65 7.AQJ753.AK.QJ92 J6532.8642.732.3"]
 [Contract "5H"]
 [Auction "E"]
-1NT     Db      2H      2S
+1N     Db      2H      2S
 Db      3H      Pass    4H
 4S      5H      Pass    Pass
 Pass    
@@ -88,7 +88,7 @@ Pass
 [Deal "N:J974.54.J852.T83 A862.AK9.64.A942 KQ53.J3.KQ73.KQJ T.QT8762.AT9.765"]
 [Contract "2H"]
 [Auction "E"]
-1NT     Db      2D      Pass
+1N     Db      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -100,7 +100,7 @@ Pass
 [Deal "N:T9632.985.853.94 QJ.AQ3.AT72.KT73 K85.KJT76.KJ.AJ8 A74.42.Q964.Q652"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      Pass    2S
+1N     Db      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -109,9 +109,9 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:T7.QT842.Q642.A8 QJ854.A53.AK.J65 AK.KJ6.T87.KQT73 9632.97.J953.942"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -122,7 +122,7 @@ Pass
 [Deal "N:Q98732.9.Q64.743 KT.KJ62.KJ52.AJ6 A654.A8.AT8.KQT8 J.QT7543.973.952"]
 [Contract "2H"]
 [Auction "E"]
-1NT     Db      2D      Pass
+1N     Db      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -134,7 +134,7 @@ Pass
 [Deal "N:T874.42.Q843.764 Q63.KQ95.AKJ2.T8 AKJ95.A7.T7.AQ32 2.JT863.965.KJ95"]
 [Contract "3S"]
 [Auction "E"]
-1NT     Db      2D      Pass
+1N     Db      2D      Pass
 2H      2S      Pass    Pass
 3H      3S      Pass    Pass
 Pass    
@@ -147,7 +147,7 @@ Pass
 [Deal "N:KT62.J9.87.JT865 875.KQ32.Q6.AKQ3 AJ93.A6.AKJ43.74 Q4.T8754.T952.92"]
 [Contract "2H"]
 [Auction "E"]
-1NT     Db      2D      Pass
+1N     Db      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -159,7 +159,7 @@ Pass
 [Deal "N:Q6.96542.T6.J842 KT4.AKQ.J92.KT65 A9873.8.AK843.AQ J52.JT73.Q75.973"]
 [Contract "3H"]
 [Auction "E"]
-1NT     Db      Pass    2H
+1N     Db      Pass    2H
 Pass    2S      Pass    3C
 Pass    3D      Pass    3H
 Pass    Pass    Pass    
@@ -170,9 +170,9 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:T862.65.T953.873 A4.QT743.AK6.Q96 KQJ53.AKJ9.Q87.2 97.82.J42.AKJT54"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -183,7 +183,7 @@ Pass
 [Deal "N:T65.T6.87652.965 KJ42.AQJ2.AT3.QT Q7.K953.K.AKJ872 A983.874.QJ94.43"]
 [Contract "2D"]
 [Auction "E"]
-1NT     Db      Pass    2D
+1N     Db      Pass    2D
 Pass    Pass    Pass    
 
 
@@ -192,9 +192,9 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:976.J98532.A2.Q9 AQ4.AKT.QJ98.732 K52.Q6.K75.AKJ85 JT83.74.T643.T64"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -203,9 +203,9 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:J987.842.Q74.874 AK6.K53.93.AQJ93 Q5.AQJ7.AT865.K5 T432.T96.KJ2.T62"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -216,7 +216,7 @@ Pass
 [Deal "N:952.87654.52.QJ8 73.A9.AKQT.K9432 AQT8.KQJ3.984.A5 KJ64.T2.J763.T76"]
 [Contract "3H"]
 [Auction "E"]
-1NT     Db      Pass    2H
+1N     Db      Pass    2H
 Pass    Pass    2S      Pass
 3C      Pass    3D      Pass
 Pass    3H      Pass    Pass
@@ -230,7 +230,7 @@ Pass
 [Deal "N:K8654.T3.Q975.76 QJ.AKQ4.KT432.92 A932.J.A8.AKQJ53 T7.987652.J6.T84"]
 [Contract "4S"]
 [Auction "E"]
-1NT     Db      2D      Pass
+1N     Db      2D      Pass
 2H      3C      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -241,9 +241,9 @@ Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:8763.T986.K4.872 JT.A72.QJ75.AK64 AKQ5.54.A63.QJT9 942.KQJ3.T982.53"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -254,7 +254,7 @@ Pass
 [Deal "N:T4.854.T98.T9764 AK72.QJ93.A4.K53 Q98.AKT2.QJ6.A82 J653.76.K7532.QJ"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      Pass    2C
+1N     Db      Pass    2C
 Pass    Pass    2D      Pass
 2H      Pass    2S      Pass
 Pass    Pass    
@@ -267,7 +267,7 @@ Pass    Pass
 [Deal "N:632.K965.Q9432.6 AKJ7.74.K876.KJ4 Q.AQJ3.AJ.QT9832 T9854.T82.T5.A75"]
 [Contract "4H"]
 [Auction "E"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      3C      Pass    3D
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
@@ -278,9 +278,9 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:JT53.863.983.T64 A74.AQ94.KQT.J53 KQ82.KJ2.A42.AK9 96.T75.J765.Q872"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -291,7 +291,7 @@ Pass
 [Deal "N:9.QJT85.J93.9863 KJ82.A4.Q75.KQJ7 AQ6.K93.AKT864.2 T7543.762.2.AT54"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -303,7 +303,7 @@ Pass
 [Deal "N:QJ986.J32.T83.75 43.AQ54.AKQ.T964 AK752.K76.J9.AJ3 T.T98.76542.KQ82"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      Rd      2S
+1N     Db      Rd      2S
 Pass    Pass    Pass    
 
 
@@ -314,7 +314,7 @@ Pass    Pass    Pass
 [Deal "N:K742.Q7654.98.74 J965.A9.AQT2.A82 AT8.K832.K76.KQJ Q3.JT.J543.T9653"]
 [Contract "2H"]
 [Auction "E"]
-1NT     Db      Rd      Pass
+1N     Db      Rd      Pass
 2C      Pass    Pass    2H
 Pass    Pass    Pass    
 
@@ -326,7 +326,7 @@ Pass    Pass    Pass
 [Deal "N:764.T62.J65.J975 KT85.Q53.AK2.K83 AQJ93.AJ4.Q3.AT2 2.K987.T9874.Q64"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      Rd      Pass
+1N     Db      Rd      Pass
 2C      Pass    2D      Pass
 Pass    2S      Pass    Pass
 Pass    
@@ -339,7 +339,7 @@ Pass
 [Deal "N:Q62.T853.65.T543 K97.J94.AT4.AK72 AT.AK62.KQ732.Q9 J8543.Q7.J98.J86"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -349,9 +349,9 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:76.J5.J9874.AT82 AJ43.KQT4.K3.Q53 KQT85.A86.AQ.J97 92.9732.T652.K64"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -362,7 +362,7 @@ Pass
 [Deal "N:753.52.932.QT962 KQT9.J43.AKT8.K3 AJ86.AK97.65.A85 42.QT86.QJ74.J74"]
 [Contract "2D"]
 [Auction "E"]
-1NT     Db      Pass    2C
+1N     Db      Pass    2C
 Pass    Pass    2D      Pass
 Pass    Pass    
 
@@ -374,7 +374,7 @@ Pass    Pass
 [Deal "N:T43.854.96532.94 J765.K92.AK.A862 AK98.A6.QJT4.KQ7 Q2.QJT73.87.JT53"]
 [Contract "3D"]
 [Auction "E"]
-1NT     Db      2D      Pass
+1N     Db      2D      Pass
 2H      3D      Pass    Pass
 Pass    
 
@@ -386,7 +386,7 @@ Pass
 [Deal "N:9542.Q84.83.T762 AJ7.T963.K9.AKQ8 KT63.AK.AQ.J9543 Q8.J752.JT76542."]
 [Contract "2D"]
 [Auction "E"]
-1NT     Db      Rd      Pass
+1N     Db      Rd      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -396,9 +396,9 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:Q542.T432.QJ963. AKJ.A87.K872.987 T3.KQ9.AT.AKQJ32 9876.J65.54.T654"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -407,11 +407,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:Q865.Q7654.5.962 AKT72.A2.T73.KJ4 J.K9.AKQ9.AQT873 943.JT83.J8642.5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     Db      Rd      2H
+1N     Db      Rd      2H
 Pass    3C      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -422,7 +422,7 @@ Pass
 [Deal "N:7.T9752.Q9432.97 T6.AJ86.KJ.AQT83 AKQ3.KQ43.A6.K52 J98542..T875.J64"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -434,7 +434,7 @@ Pass
 [Deal "N:92.K652.JT2.9863 K653.A87.A76.A75 AQ4.Q.KQ984.KT42 JT87.JT943.53.QJ"]
 [Contract "2H"]
 [Auction "E"]
-1NT     Db      2D      Pass
+1N     Db      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -446,7 +446,7 @@ Pass
 [Deal "N:T3.JT543.J73.973 K754.AK9.AQ5.T42 AQJ98.Q87.K.KQJ8 62.62.T98642.A65"]
 [Contract "2H"]
 [Auction "E"]
-1NT     Db      Rd      2H
+1N     Db      Rd      2H
 Pass    Pass    Pass    
 
 
@@ -457,7 +457,7 @@ Pass    Pass    Pass
 [Deal "N:T8542.9876.T.875 AK6.AT54.9752.A6 QJ7.K.AKQ43.KQJ3 93.QJ32.J86.T942"]
 [Contract "4S"]
 [Auction "E"]
-1NT     Db      Pass    2S
+1N     Db      Pass    2S
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -469,7 +469,7 @@ Pass    Pass    Pass
 [Deal "N:J932.9543.T63.Q4 AK.J87.942.AK985 4.AKT62.AKQ8.T72 QT8765.Q.J75.J63"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -479,11 +479,11 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:92.A432.J76543.8 J73.KT75.AQ.AJ93 AQ4.QJ98.KT9.KQ2 KT865.6.82.T7654"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "E"]
-1NT     Db      2H      2S
-Db      2NT     Pass    3D
-Pass    3NT     Pass    Pass
+1N     Db      2H      2S
+Db      2N     Pass    3D
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -492,9 +492,9 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:42.K8654.KT43.J9 KJ6.A972.QJ.KQT5 AQ985.QT.A65.A72 T73.J3.9872.8643"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -505,7 +505,7 @@ Pass
 [Deal "N:T54.Q83.KJT92.T5 AQJ3.K72.764.AQ9 K76.A64.AQ85.K87 982.JT95.3.J6432"]
 [Contract "2D"]
 [Auction "E"]
-1NT     Db      Rd      Pass
+1N     Db      Rd      Pass
 2C      Pass    Pass    2D
 Pass    Pass    Pass    
 
@@ -517,7 +517,7 @@ Pass    Pass    Pass
 [Deal "N:753.872.KJ94.762 KJ6.AQ95.76.AJ95 A.KJ6.AT53.KQ843 QT9842.T43.Q82.T"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -529,7 +529,7 @@ Pass    Pass    Pass
 [Deal "N:83.Q97432.972.KJ AQ7.A6.KT4.Q8432 KT5.KJ8.AQJ653.A J9642.T5.8.T9765"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -541,7 +541,7 @@ Pass    Pass    Pass
 [Deal "N:98.AT3.97652.875 AJ.Q62.KQJ84.Q43 KQ63.KJ97.3.AKJ9 T7542.854.AT.T62"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -553,7 +553,7 @@ Pass    Pass    Pass
 [Deal "N:764.8762.QT985.7 Q8.AQ43.A4.QJ532 AKJT5.KJ.J763.A8 932.T95.K2.KT964"]
 [Contract "2D"]
 [Auction "E"]
-1NT     Db      Pass    2D
+1N     Db      Pass    2D
 Pass    Pass    Pass    
 
 
@@ -564,7 +564,7 @@ Pass    Pass    Pass
 [Deal "N:JT542.9854.QJT.T K876.Q6.A97.AQJ5 AQ9.KJT2.K865.K4 3.A73.432.987632"]
 [Contract "2S"]
 [Auction "E"]
-1NT     Db      Rd      2S
+1N     Db      Rd      2S
 Pass    Pass    Pass    
 
 
@@ -573,9 +573,9 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:AQT974.J853.92.J K82.Q4.JT643.AKQ 6.AK97.AKQ.T8432 J53.T62.875.9765"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -584,9 +584,9 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:5.7632.T753.9832 Q7.AKT8.K982.KQ6 AKJT98.QJ95.AQ.T 6432.4.J64.AJ754"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "E"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -597,7 +597,7 @@ Pass
 [Deal "N:Q432.T72.T63.952 A96.KQ84.AKJ4.83 KT.A9653.Q.AKQJT J875.J.98752.764"]
 [Contract "4C"]
 [Auction "E"]
-1NT     Db      Rd      Pass
+1N     Db      Rd      Pass
 2C      Db      2D      Pass
 Pass    3H      Pass    4C
 Pass    Pass    Pass    

--- a/GIB/Cappelletti.pbn
+++ b/GIB/Cappelletti.pbn
@@ -11,7 +11,7 @@
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -28,7 +28,7 @@
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      2NT     3H
+1N     2H      2N     3H
 Pass    Pass    Pass    
 
 
@@ -44,7 +44,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      Pass    2H
+1N     2C      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -60,7 +60,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -74,11 +74,11 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:T864..AT87652.32 J7.AQ84.K3.KQ765 532.KJT532.4.A98 AKQ9.976.QJ9.JT4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       2D
-2H      Pass    3NT     Pass
+1N     2C      X       2D
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -94,7 +94,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -110,7 +110,7 @@ Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2S      Pass    3C
+1N     2S      Pass    3C
 Pass    3D      Pass    4C
 Pass    5C      Pass    Pass
 Pass    
@@ -128,7 +128,7 @@ Pass
 [Contract "5C"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 3S      Pass    4C      Pass
 5C      Pass    Pass    Pass
 
@@ -146,7 +146,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -163,7 +163,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -181,7 +181,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -198,7 +198,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      2S      Pass    Pass
 Pass    
 
@@ -212,10 +212,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:T983.9532.93.T96 Q65.QJ.AT62.AQJ3 AKJ42.AK7.QJ75.2 7.T864.K84.K8754"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -228,11 +228,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:T942.T94.972.984 AJ.Q765.AQ63.KJ7 876.AJ8.KJT854.A KQ53.K32..QT6532"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2H      Pass    3NT     Pass
+1N     2C      X       Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -248,7 +248,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -265,7 +265,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      3D      3H      Pass
 Pass    Pass    
 
@@ -282,7 +282,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3H
 Pass    Pass    Pass    
 
@@ -296,10 +296,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:JT43.Q764.T65.73 62.AK82.Q43.AKJ4 AQ5.T.AKJ82.Q652 K987.J953.97.T98"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -315,7 +315,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    2NT
+1N     2S      Pass    2N
 Pass    3D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -333,7 +333,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      X       Pass
+1N     2H      X       Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -350,7 +350,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -367,7 +367,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -384,7 +384,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -400,7 +400,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       Pass    2H
+1N     X       Pass    2H
 Pass    Pass    Pass    
 
 
@@ -416,7 +416,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -433,7 +433,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -449,7 +449,7 @@ Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -465,7 +465,7 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     3H      3S      Pass
+1N     3H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -482,7 +482,7 @@ Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    Pass    Pass    
 
 
@@ -498,7 +498,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -514,7 +514,7 @@ Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -531,7 +531,7 @@ Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3C      Pass
+1N     2C      3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -548,7 +548,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -565,7 +565,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -581,7 +581,7 @@ Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      3H      Pass    Pass
 3S      Pass    Pass    Pass
 
@@ -596,11 +596,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:73.JT96.QT973.J9 JT.Q32.AK642.AKT KQ942.A874.85.72 A865.K5.J.Q86543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2D      3C      Pass
-3S      Pass    3NT     Pass
+1N     2D      3C      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -616,7 +616,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -632,7 +632,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      2S      Pass
 Pass    Pass    
 
@@ -649,7 +649,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       Pass    2H
+1N     X       Pass    2H
 Pass    3C      Pass    Pass
 Pass    
 
@@ -666,7 +666,7 @@ Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       Pass    2C
+1N     X       Pass    2C
 Pass    2H      Pass    3H
 Pass    Pass    Pass    
 
@@ -683,7 +683,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -699,7 +699,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -715,7 +715,7 @@ Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -731,7 +731,7 @@ Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -747,7 +747,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -764,7 +764,7 @@ Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -778,12 +778,12 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:Q86.987.KQ952.62 K43.A53.A3.KQ875 A5.KQJ4.JT8.AJ94 JT972.T62.764.T3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       2H      2S
-X       2NT     Pass    3D
-Pass    3H      Pass    3NT
+1N     X       2H      2S
+X       2N     Pass    3D
+Pass    3H      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -796,11 +796,11 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:62.T643.98.KQ943 KT9.KJ.KJ3.AJ852 AQJ875.985.QT5.6 43.AQ72.A7642.T7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2D      Pass    3NT     Pass
+1N     2C      X       Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -816,9 +816,9 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      Pass    2S
-Pass    2NT     Pass    3D
+Pass    2N     Pass    3D
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -835,7 +835,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -852,7 +852,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -866,10 +866,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:954.Q862.QJT.942 AQ87.95.AK2.QT86 K3.AKJ43.7543.AK JT62.T7.986.J753"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -885,7 +885,7 @@ Pass
 [Contract "2SX"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 X       Pass    Pass    Pass
 
 
@@ -899,11 +899,11 @@ X       Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:T.T986.63.QJ9432 92.AQ7.KQJ2.K865 A7653.K32.A974.7 KQJ84.J54.T85.AT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2S      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -919,7 +919,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3D      Pass
 4S      Pass    Pass    Pass
 
@@ -937,7 +937,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -951,11 +951,11 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:987.K764.864.953 AT6.Q95.KQ.AQT84 K52.AT832.AT932. QJ43.J.J75.KJ762"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      X       Pass
-3NT     Pass    Pass    Pass
+1N     2H      X       Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -968,10 +968,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:KT73.AT872.T87.3 QJ2.QJ4.AK543.Q6 954.953.6.AKJ542 A86.K6.QJ92.T987"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -987,7 +987,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     3C      Pass    3H
+1N     3C      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -1000,10 +1000,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:853.Q87.9874.Q65 QT.KJT4.AQT5.A43 KJ7642.962.J.KJ2 A9.A53.K632.T987"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -1019,7 +1019,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2H      Pass    3S
+1N     2H      Pass    3S
 Pass    4D      Pass    4S
 Pass    Pass    Pass    
 
@@ -1033,10 +1033,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:4.AT532.QJ976.75 AK.97.K5432.AQ43 QJT987652.J86.A. 3.KQ4.T8.KJT9862"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -1052,7 +1052,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       Pass    2S
+1N     X       Pass    2S
 Pass    Pass    Pass    
 
 
@@ -1068,7 +1068,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -1085,7 +1085,7 @@ Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1102,7 +1102,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      2S      Pass
 Pass    Pass    
 
@@ -1119,7 +1119,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -1135,7 +1135,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 4C      Pass    5C      Pass
 Pass    Pass    
 
@@ -1152,7 +1152,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     3D      Pass    4D
+1N     3D      Pass    4D
 X       Pass    4H      Pass
 Pass    Pass    
 
@@ -1169,7 +1169,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -1187,7 +1187,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -1201,11 +1201,11 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:AT53.K6.J5.KQJ52 KQ742.Q9.AT2.A93 J6.AJT74.KQ876.6 98.8532.943.T874"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2H      Pass    3C
-Pass    3D      Pass    3NT
+1N     2H      Pass    3C
+Pass    3D      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -1221,7 +1221,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -1234,11 +1234,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:8542.JT.K98.Q764 AK9.952.AJT.KT52 63.AQ8763.Q52.J9 QJT7.K4.7643.A83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2D      Pass    3NT     Pass
+1N     2C      X       Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1254,7 +1254,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
 4D      Pass    Pass    Pass
 
@@ -1272,7 +1272,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1288,7 +1288,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3C      Pass
 4S      Pass    Pass    Pass
 
@@ -1306,7 +1306,7 @@ Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1323,7 +1323,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -1340,7 +1340,7 @@ Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2NT
+1N     2C      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -1357,7 +1357,7 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -1375,7 +1375,7 @@ Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      3S      Pass    Pass
 Pass    
 
@@ -1392,7 +1392,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
 Pass    3C      Pass    3H
 Pass    4H      Pass    Pass
@@ -1411,7 +1411,7 @@ Pass
 [Contract "6H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 3S      Pass    4D      Pass
 4S      Pass    6H      Pass
 Pass    Pass    
@@ -1429,7 +1429,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1446,7 +1446,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -1463,7 +1463,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    2S      Pass
 4H      Pass    Pass    Pass
 
@@ -1481,7 +1481,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1498,7 +1498,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 3H      Pass    4C      Pass
 5C      Pass    Pass    Pass
 
@@ -1513,13 +1513,13 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:JT8542.7.Q9765.2 AQ63.K9.A83.QJ73 .AQT8.KJ2.AKT985 K97.J65432.T4.64"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    2S
 Pass    3C      Pass    3D
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1532,10 +1532,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:A97543.92.74.J87 KQ.JT754.K53.AQ6 T.AQ3.AQJT82.KT2 J862.K86.96.9543"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1551,7 +1551,7 @@ Pass
 [Contract "2HX"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 X       Pass    Pass    Pass
 
 
@@ -1565,10 +1565,10 @@ X       Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:T853.98643..J985 QJ9.AQ7.Q942.AQ7 A62.J52.AK8763.T K74.KT.JT5.K6432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -1584,7 +1584,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    2NT
+1N     2H      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -1601,7 +1601,7 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     3D      4S      Pass
+1N     3D      4S      Pass
 Pass    Pass    
 
 
@@ -1617,7 +1617,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -1634,7 +1634,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -1651,7 +1651,7 @@ Pass
 [Contract "3S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      3H      3S      Pass
 Pass    Pass    
 
@@ -1668,7 +1668,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      4D      Pass
+1N     2C      4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -1685,7 +1685,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3C      Pass
+1N     2C      3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1699,11 +1699,11 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:98742.852.J7.J83 KQT.Q4.KQ2.KT642 A53.AT9763.94.AQ J6.KJ.AT8653.975"]
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2D      2H      2NT     Pass
+1N     2C      X       Pass
+2D      2H      2N     Pass
 Pass    Pass    
 
 
@@ -1719,7 +1719,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1736,7 +1736,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1753,7 +1753,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1770,7 +1770,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      2NT     3S
+1N     2S      2N     3S
 Pass    Pass    Pass    
 
 
@@ -1786,7 +1786,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1802,7 +1802,7 @@ Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1816,12 +1816,12 @@ Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:J2.T2.987643.864 843.K97.AKQJ.K53 A9765.AQ63.5.972 KQT.J854.T2.AQJT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1837,7 +1837,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1854,7 +1854,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -1871,7 +1871,7 @@ Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -1885,11 +1885,11 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:4.J763.A642.K874 KJT9.K2.Q853.AQ3 AQ7653.QT9.97.52 82.A854.KJT.JT96"]
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2S      Pass    2NT     Pass
+1N     2C      X       Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1905,7 +1905,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    3H
+1N     2H      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -1918,11 +1918,11 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:542.T.Q87.QT7653 QJ7.KQ3.AT53.K42 AT6.AJ9754.J42.J K983.862.K96.A98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2D      Pass    3NT     Pass
+1N     2C      X       Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1938,7 +1938,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -1951,10 +1951,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:53.K853.765.T853 AQJ.QT.QJT42.A74 KT762.A76.AK9.Q6 984.J942.83.KJ92"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1970,7 +1970,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -1984,10 +1984,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:63.Q98632.T3.T64 KJT.AKJ7.J74.A97 AQ8742.5.852.KQ5 95.T4.AKQ96.J832"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -2000,11 +2000,11 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:K8762.72.Q4.9875 A953.Q94.AJ5.A43 J4.AKT853.T96.QJ QT.J6.K8732.KT62"]
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2S      Pass    2NT     Pass
+1N     2C      X       Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2017,10 +2017,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:932.753.K6.QT853 KQJ.KQ82.J952.K9 AT74.A9.AQT8.AJ6 865.JT64.743.742"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -2036,7 +2036,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -2052,7 +2052,7 @@ Pass
 [Contract "5D"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 3D      Pass    4D      Pass
 5D      Pass    Pass    Pass
 
@@ -2070,8 +2070,8 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
-2S      Pass    3NT     Pass
+1N     2C      2H      Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -2088,7 +2088,7 @@ Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2H
 Pass    2S      Pass    3H
 Pass    Pass    Pass    
@@ -2106,7 +2106,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3S
 Pass    Pass    Pass    
 
@@ -2120,10 +2120,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:AT96432.7.65.853 K7.KQ3.KQJT8.QT6 8.AJ9864.73.AJ74 QJ5.T52.A942.K92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -2139,7 +2139,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -2155,7 +2155,7 @@ Pass
 [Contract "4C"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 4C      Pass    Pass    Pass
 
 
@@ -2172,7 +2172,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2190,7 +2190,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -2206,7 +2206,7 @@ Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -2222,9 +2222,9 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    3D      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -2237,10 +2237,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:65.K972.98.QT876 AJ7.AQ6.7432.KJ4 KQT943.853.J6.A9 82.JT4.AKQT5.532"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -2256,7 +2256,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -2273,7 +2273,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -2287,12 +2287,12 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:A8763.J2.852.843 T54.Q7.AJT6.AKQ2 KQJ92.AT54.94.T7 .K9863.KQ73.J965"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2D      X       2S
-2NT     Pass    3C      Pass
-3NT     Pass    Pass    Pass
+1N     2D      X       2S
+2N     Pass    3C      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2308,7 +2308,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2D      Pass    3C
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
@@ -2326,7 +2326,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    Pass
 Pass    
 
@@ -2343,7 +2343,7 @@ Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -2359,7 +2359,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    3D      Pass
 4H      Pass    Pass    Pass
 
@@ -2377,7 +2377,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    Pass    2H      Pass
 Pass    Pass    
 
@@ -2394,7 +2394,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -2411,7 +2411,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -2428,7 +2428,7 @@ Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2445,7 +2445,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 X       Pass    2S      Pass
 Pass    Pass    
 
@@ -2462,7 +2462,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      3C      Pass
+1N     2C      3C      Pass
 3D      Pass    Pass    3S
 Pass    Pass    Pass    
 
@@ -2479,7 +2479,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -2496,7 +2496,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    2S
+1N     2H      Pass    2S
 Pass    3C      Pass    Pass
 Pass    
 
@@ -2513,7 +2513,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -2527,10 +2527,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:2.T76.AJT52.J943 KJ5.KQ82.76.AQT7 AT983.A3.KQ94.K8 Q764.J954.83.652"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -2546,7 +2546,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -2560,10 +2560,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:J8.J754.9765.852 QT94.AKQ.AJ3.J93 AK7.92.KQT8.KQ64 6532.T863.42.AT7"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -2579,7 +2579,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 3C      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -2597,7 +2597,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       Pass    2S
+1N     X       Pass    2S
 Pass    Pass    Pass    
 
 
@@ -2613,7 +2613,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4C      Pass    4S      Pass
 Pass    Pass    
 
@@ -2630,7 +2630,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -2644,10 +2644,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:T3.JT54.T652.T97 AJ62.972.AK94.A2 KQ7.Q6.QJ8.KQJ54 9854.AK83.73.863"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -2663,7 +2663,7 @@ Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2680,7 +2680,7 @@ Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3C      Pass
+1N     2C      3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2697,7 +2697,7 @@ Pass
 [Contract "2SX"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 X       Pass    Pass    Pass
 
 
@@ -2714,7 +2714,7 @@ X       Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       Pass    2H
+1N     X       Pass    2H
 Pass    Pass    Pass    
 
 
@@ -2730,7 +2730,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      4H      Pass
+1N     2S      4H      Pass
 Pass    Pass    
 
 
@@ -2746,7 +2746,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3S
 Pass    Pass    Pass    
 
@@ -2763,7 +2763,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -2777,10 +2777,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:86.T9762.Q987.72 AT2.AQ8.AJT3.J63 KQ9743.KJ.652.KT J5.543.K4.AQ9854"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -2796,7 +2796,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -2812,7 +2812,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    4H
+1N     2D      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -2828,7 +2828,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    4C      Pass
 4H      Pass    Pass    Pass
 
@@ -2846,7 +2846,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3H      Pass    Pass
 Pass    
 
@@ -2863,7 +2863,7 @@ Pass
 [Contract "5DX"]
 [Declarer "W"]
 [Auction "E"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 X       Pass    5D      X
 Pass    Pass    Pass    
 
@@ -2880,7 +2880,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -2896,7 +2896,7 @@ Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -2913,7 +2913,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -2930,7 +2930,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    2S
+1N     2H      Pass    2S
 Pass    3H      Pass    Pass
 Pass    
 
@@ -2947,7 +2947,7 @@ Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3C      Pass
+1N     2C      3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2964,7 +2964,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 X       2H      Pass    Pass
 Pass    
 
@@ -2981,7 +2981,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      2H      X
+1N     2C      2H      X
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -2998,7 +2998,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -3015,7 +3015,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -3028,11 +3028,11 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:J9872.J875.73.97 KT.K2.KJT5.AJT83 AQ6543.Q64.A94.Q .AT93.Q862.K6542"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2C      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3048,7 +3048,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -3065,8 +3065,8 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
-2S      Pass    3NT     Pass
+1N     2C      2H      Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -3080,10 +3080,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:9763.6532.T74.J8 A542.AJT.A95.Q93 Q.KQ7.QJ63.AK754 KJT8.984.K82.T62"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -3099,7 +3099,7 @@ Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
 Pass    3C      Pass    4C
 Pass    5C      Pass    Pass
@@ -3118,7 +3118,7 @@ Pass
 [Contract "5D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 3S      Pass    5D      Pass
 Pass    Pass    
 
@@ -3135,7 +3135,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3151,7 +3151,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3168,7 +3168,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -3184,7 +3184,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -3201,7 +3201,7 @@ Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    3S
 Pass    Pass    Pass    
 
@@ -3218,7 +3218,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    Pass    Pass    
 
 
@@ -3234,7 +3234,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2H
+1N     2C      Pass    2H
 Pass    Pass    2S      Pass
 Pass    3H      Pass    Pass
 3S      Pass    Pass    Pass
@@ -3250,10 +3250,10 @@ Pass    3H      Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:64.864.J943.J543 85.QJT53.AK8.KQT AKQJT32.A.Q52.76 97.K972.T76.A982"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -3269,7 +3269,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3286,7 +3286,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2D
 Pass    3S      Pass    4D
 Pass    4S      Pass    Pass
@@ -3305,7 +3305,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -3322,7 +3322,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -3336,10 +3336,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:T8.9854.KQT2.432 A4.AQJ3.A9764.J9 KQJ63.K.J3.AKQ87 9752.T762.85.T65"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -3355,7 +3355,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -3369,10 +3369,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:7.JT74.T975.Q964 KQT9.A32.Q83.KJ3 AJ43.K65.AK4.A52 8652.Q98.J62.T87"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -3385,10 +3385,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:953.98764.J643.5 JT.KJ.AKT85.K987 AQ8642.Q53.Q97.A K7.AT2.2.QJT6432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -3404,7 +3404,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -3420,7 +3420,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    Pass    Pass    
 
 
@@ -3436,7 +3436,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -3452,7 +3452,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -3466,11 +3466,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:A98432.Q954.4.Q2 Q65.AJT2.KJ.KJT3 T7.K3.AQ9732.654 KJ.876.T865.A987"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       2S
-Pass    Pass    3NT     Pass
+1N     2C      X       2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3483,10 +3483,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:J97.654.763.JT97 AK8.973.KJT.KQ42 QT62.AKQJT.A94.6 543.82.Q852.A853"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -3502,7 +3502,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       Pass    2C
+1N     X       Pass    2C
 Pass    Pass    2D      Pass
 2H      Pass    2S      Pass
 Pass    Pass    
@@ -3520,7 +3520,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3537,7 +3537,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      Pass    2H
+1N     2C      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -3553,7 +3553,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2D      Pass    2NT
+1N     2D      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -3570,7 +3570,7 @@ Pass
 [Contract "5D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 4D      Pass    5D      Pass
 Pass    Pass    
 
@@ -3587,7 +3587,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      2S      Pass    Pass
 Pass    
 
@@ -3604,7 +3604,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      2S      Pass
 Pass    Pass    
 
@@ -3621,7 +3621,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    3D
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
@@ -3639,7 +3639,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    3H
 Pass    Pass    Pass    
 
@@ -3656,7 +3656,7 @@ Pass    Pass    Pass
 [Contract "4C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      X       XX
+1N     2C      X       XX
 2S      3C      3S      4C
 Pass    Pass    Pass    
 
@@ -3670,10 +3670,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:9762.932.75.8643 AQJ54.QJT.T3.AJT KT.AK7.QJ96.K972 83.8654.AK842.Q5"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -3689,7 +3689,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    3S
+1N     2D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -3706,7 +3706,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -3722,7 +3722,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    2S
+1N     2H      Pass    2S
 Pass    3D      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -3740,7 +3740,7 @@ Pass
 [Contract "2DX"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 X       Pass    Pass    Pass
 
 
@@ -3757,7 +3757,7 @@ X       Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3773,7 +3773,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3790,7 +3790,7 @@ Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      2S      3D
+1N     2H      2S      3D
 Pass    4C      Pass    4D
 Pass    5C      Pass    Pass
 Pass    
@@ -3808,7 +3808,7 @@ Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -3822,10 +3822,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:Q62.T42.AKQ5.A93 A97.AKQJ7.JT.864 KJ843.9.83.KJT72 T5.8653.97642.Q5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2S      Pass    3NT
+1N     2S      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -3841,7 +3841,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -3858,7 +3858,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      X       2D      3C
 4D      Pass    Pass    Pass
 
@@ -3876,7 +3876,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      3D      Pass    Pass
 3H      3S      Pass    4S
 Pass    Pass    Pass    
@@ -3891,10 +3891,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:2.J954.743.KJ653 Q96.AKQ8.AQ5.T87 AT87543.T73.2.A9 KJ.62.KJT986.Q42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -3910,7 +3910,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3927,7 +3927,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -3945,7 +3945,7 @@ Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -3959,11 +3959,11 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:74.652.T9432.753 QT.AJ9.K87.KQT84 AJ9863.T87.QJ.A6 K52.KQ43.A65.J92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2D      Pass    3NT     Pass
+1N     2C      X       Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3976,11 +3976,11 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:4.KJT64.KT987.J9 KJ9.Q87.AQ53.K82 AT8762.952.2.AT6 Q53.A3.J64.Q7543"]
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2D      Pass    2NT     Pass
+1N     2C      X       Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3996,7 +3996,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      X       3D      Pass
 Pass    Pass    
 
@@ -4013,7 +4013,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    3H      Pass    4C
 Pass    4H      Pass    5C
 Pass    Pass    Pass    
@@ -4028,10 +4028,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:J9632.KJ853.4.95 KT4.AQ4.A8763.Q4 A7.92.KQ95.AK832 Q85.T76.JT2.JT76"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -4047,8 +4047,8 @@ Pass
 [Contract "3C"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      X       Pass
-2NT     Pass    3C      Pass
+1N     2H      X       Pass
+2N     Pass    3C      Pass
 Pass    Pass    
 
 
@@ -4064,7 +4064,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3D      3NT     4D
+1N     3D      3N     4D
 Pass    Pass    Pass    
 
 
@@ -4077,11 +4077,11 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:9653.QT5.72.J753 QT4.K8.AQT8.A942 A872.J73.KJ954.K KJ.A9642.63.QT86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4097,7 +4097,7 @@ Pass    Pass    Pass
 [Contract "2DX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2D      X       Pass    Pass
 Pass    
 
@@ -4114,7 +4114,7 @@ Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      3C      Pass    Pass
 Pass    
 
@@ -4128,12 +4128,12 @@ Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:QJ532.KJ8.QT83.8 A7.A963.J6.AQ764 K86.4.AK9754.K93 T94.QT752.2.JT52"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    2S
-Pass    3D      Pass    3NT
+Pass    3D      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -4149,7 +4149,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4166,7 +4166,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4183,7 +4183,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -4200,7 +4200,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -4217,9 +4217,9 @@ Pass
 [Contract "5C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    3D      Pass
-3NT     Pass    5C      Pass
+3N     Pass    5C      Pass
 Pass    Pass    
 
 
@@ -4235,7 +4235,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       XX      2C
+1N     X       XX      2C
 Pass    3H      Pass    4C
 Pass    4H      Pass    Pass
 Pass    
@@ -4253,7 +4253,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       Pass    2D
+1N     X       Pass    2D
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -4270,7 +4270,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4287,7 +4287,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      2S      Pass
 Pass    Pass    
 
@@ -4304,7 +4304,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -4320,7 +4320,7 @@ Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      3H      Pass    Pass
 Pass    
 
@@ -4337,7 +4337,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    2NT
+1N     2S      Pass    2N
 Pass    3D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -4355,7 +4355,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -4371,7 +4371,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2S      Pass    3H
+1N     2S      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
 
@@ -4388,7 +4388,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -4401,10 +4401,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:T75.KT9.Q8754.32 KQ83.J6.AKT9.K95 A942.AQ53..AQT86 J6.8742.J632.J74"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -4417,12 +4417,12 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:963..J983.K98543 AK72.Q98.Q5.AQT2 J85.AJT654.K74.J QT4.K732.AT62.76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2C      X       Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4435,11 +4435,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:JT8764.32.T9.953 K3.Q976.KQ5.AQJ4 Q2.K85.A76432.76 A95.AJT4.J8.KT82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       2S
-Pass    Pass    3NT     Pass
+1N     2C      X       2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4452,10 +4452,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:T65.J862.72.KQ65 KQ74.AKT9.K94.43 J98.Q73.QJT853.A A32.54.A6.JT9872"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -4468,10 +4468,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:Q9.JT32.984.J984 J64.KQ94.QJ73.AQ AK872.6.AK62.K63 T53.A875.T5.T752"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -4487,7 +4487,7 @@ Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       Pass    2D
+1N     X       Pass    2D
 Pass    Pass    Pass    
 
 
@@ -4503,7 +4503,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    2NT
+1N     2S      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -4520,7 +4520,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      3S
 Pass    4S      Pass    Pass
 Pass    
@@ -4538,7 +4538,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    2S
+1N     2H      Pass    2S
 Pass    3C      Pass    3H
 Pass    4D      Pass    4H
 Pass    Pass    Pass    
@@ -4553,10 +4553,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:632.T532.7642.T8 QT4.AQJ6.AT5.Q72 K75.987.KQ8.AKJ4 AJ98.K4.J93.9653"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -4572,7 +4572,7 @@ Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      X       2D      3D
 X       3H      Pass    3S
 Pass    5C      Pass    Pass
@@ -4591,7 +4591,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    4H
+1N     2D      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -4607,7 +4607,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 3C      Pass    3H      Pass
 3S      Pass    Pass    Pass
 
@@ -4625,7 +4625,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      2S      Pass
 Pass    Pass    
 
@@ -4642,7 +4642,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       4D      Pass
+1N     X       4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4656,11 +4656,11 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:T2.QJ652.KT65.KT A964.A94.A73.QJ5 KJ8753.T73.8.A63 Q.K8.QJ942.98742"]
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2S      Pass    2NT     Pass
+1N     2C      X       Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4676,7 +4676,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4693,7 +4693,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      2D      X
+1N     2C      2D      X
 Pass    Pass    2H      Pass
 Pass    Pass    
 
@@ -4710,7 +4710,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
 Pass    4S      Pass    Pass
 Pass    
@@ -4728,7 +4728,7 @@ Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -4744,7 +4744,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    2NT
+1N     2H      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -4761,7 +4761,7 @@ Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -4778,7 +4778,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4795,7 +4795,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -4811,7 +4811,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      2S      Pass    Pass
 Pass    
 
@@ -4828,7 +4828,7 @@ Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -4844,7 +4844,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -4860,7 +4860,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -4876,7 +4876,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -4892,7 +4892,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -4909,7 +4909,7 @@ Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -4925,7 +4925,7 @@ Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    3H
+1N     2D      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -4941,7 +4941,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -4957,7 +4957,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    Pass    2H      Pass
 Pass    Pass    
 
@@ -4974,7 +4974,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -4991,7 +4991,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5007,8 +5007,8 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      3H      Pass
-3NT     Pass    4H      Pass
+1N     2S      3H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -5024,7 +5024,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -5038,10 +5038,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:J98.K9832.J5.972 A532.AQ7.T96.AJ8 KQT.T5.AKQ87.Q64 764.J64.432.KT53"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -5057,7 +5057,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2D      Pass    3D
+1N     2D      Pass    3D
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
 
@@ -5074,7 +5074,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      4D      Pass
+1N     2C      4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5091,7 +5091,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -5107,7 +5107,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -5124,7 +5124,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -5140,7 +5140,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2S      Pass    2NT
+1N     2S      Pass    2N
 Pass    3D      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -5158,7 +5158,7 @@ Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -5172,10 +5172,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:A543.65.T84.J987 KT862.AT7.AQ3.Q5 7.KQJ942.765.A42 QJ9.83.KJ92.KT63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -5191,8 +5191,8 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      3H      Pass
-3NT     Pass    4H      Pass
+1N     2S      3H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -5208,7 +5208,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -5221,10 +5221,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:QT963.KJ6.75.732 A4.AQT7.JT842.A8 K87.85.AK6.KQJ64 J52.9432.Q93.T95"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -5240,7 +5240,7 @@ Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3C      Pass
+1N     2C      3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5257,7 +5257,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      Pass    Pass
 2S      Pass    Pass    Pass
 
@@ -5275,7 +5275,7 @@ Pass    2H      Pass    Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -5289,10 +5289,10 @@ Pass    2H      Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:765.KJ9.T632.J97 KJT.A8653.K7.A85 AQ942.4.AQJ8.KT3 83.QT72.954.Q642"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -5308,7 +5308,7 @@ Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      3C      Pass    Pass
 Pass    
 
@@ -5325,7 +5325,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5342,7 +5342,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5359,7 +5359,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2H
 4D      Pass    Pass    X
 Pass    4H      Pass    Pass
@@ -5378,7 +5378,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       Pass    2H
+1N     X       Pass    2H
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -5395,7 +5395,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -5411,7 +5411,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -5429,7 +5429,7 @@ Pass
 [Contract "5D"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       2H
+1N     2C      X       2H
 Pass    Pass    2S      Pass
 3D      Pass    5D      Pass
 Pass    Pass    
@@ -5447,7 +5447,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -5465,7 +5465,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      4D      Pass
+1N     2C      4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5482,7 +5482,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -5499,7 +5499,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      2S      Pass    Pass
 Pass    
 
@@ -5513,11 +5513,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:J543.K85.8432.T7 KQT9.Q6.AQ96.K84 72.JT2.T5.AQJ532 A86.A9743.KJ7.96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
-2H      Pass    3NT     Pass
+1N     2C      2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5530,10 +5530,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:863.J983.J4.J932 QJ74.KQ65.AK.T64 AT2.AT7.Q8532.AQ K95.42.T976.K875"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -5546,11 +5546,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:J8542.7.83.T8632 AQ7.AT9.AQT72.74 3.KJ5432.65.AKQ9 KT96.Q86.KJ94.J5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      2NT     Pass
-3C      3H      3NT     Pass
+1N     2H      2N     Pass
+3C      3H      3N     Pass
 Pass    Pass    
 
 
@@ -5566,7 +5566,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -5583,7 +5583,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    3H
+1N     2D      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -5596,10 +5596,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:73.AT963.3.J9742 JT6.KQ85.AQT.KQ8 AKQ82..KJ864.AT5 954.J742.9752.63"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -5615,7 +5615,7 @@ Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -5632,7 +5632,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    2NT
+1N     2H      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -5649,7 +5649,7 @@ Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      X       3D      Pass
 Pass    Pass    
 
@@ -5666,7 +5666,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -5682,7 +5682,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3D      Pass
 4S      Pass    Pass    Pass
 
@@ -5697,11 +5697,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:987542.T65.765.K AJ.K982.Q82.AQ74 K3.Q4.AJT943.932 QT6.AJ73.K.JT865"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       2S
-Pass    Pass    3NT     Pass
+1N     2C      X       2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5717,7 +5717,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -5735,7 +5735,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -5751,7 +5751,7 @@ Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -5768,7 +5768,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -5784,7 +5784,7 @@ Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -5800,7 +5800,7 @@ Pass
 [Contract "5C"]
 [Declarer "W"]
 [Auction "E"]
-1NT     3D      Pass    4D
+1N     3D      Pass    4D
 X       Pass    5C      Pass
 Pass    Pass    
 
@@ -5817,7 +5817,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       Pass    2S
+1N     X       Pass    2S
 Pass    Pass    Pass    
 
 
@@ -5833,7 +5833,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5846,10 +5846,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:K8.Q7632.954.JT4 A954.AJ.KJ8.K832 QJ62.KT.A63.AQ95 T73.9854.QT72.76"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -5865,7 +5865,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5881,7 +5881,7 @@ Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -5894,10 +5894,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:JT.T98743.8642.Q Q8654.AJ6.AK9.J2 K93.K.75.AT98754 A72.Q52.QJT3.K63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -5913,7 +5913,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3C      Pass
+1N     2C      3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5930,7 +5930,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      2NT     3S
+1N     2S      2N     3S
 Pass    Pass    Pass    
 
 
@@ -5943,10 +5943,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:76.Q76.J872.8752 AKJ93.T9.AQ4.J43 Q842.AK543.K65.A T5.J82.T93.KQT96"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -5962,7 +5962,7 @@ Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -5979,7 +5979,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      Pass    2S
+1N     2C      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -5995,7 +5995,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    2S
+1N     2H      Pass    2S
 Pass    3C      Pass    4H
 Pass    Pass    Pass    
 
@@ -6012,7 +6012,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    3D
 Pass    3S      Pass    4D
 Pass    4S      Pass    Pass
@@ -6031,7 +6031,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -6045,10 +6045,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:876.94.AJ654.986 AKJ.73.QT97.AJ32 93.KQJT852.3.KQT QT542.A6.K82.754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     3H      3NT     Pass
+1N     3H      3N     Pass
 Pass    Pass    
 
 
@@ -6064,7 +6064,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      X       3D      Pass
 Pass    Pass    
 
@@ -6081,7 +6081,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -6097,7 +6097,7 @@ Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -6113,7 +6113,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       Pass    2H
+1N     X       Pass    2H
 Pass    Pass    Pass    
 
 
@@ -6129,7 +6129,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -6146,8 +6146,8 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
-2H      Pass    3NT     Pass
+1N     2C      2D      Pass
+2H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -6164,7 +6164,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -6180,7 +6180,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
 Pass    4S      Pass    Pass
 Pass    
@@ -6198,7 +6198,7 @@ Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2NT     Pass    3D
+1N     2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -6214,7 +6214,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -6231,7 +6231,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -6247,7 +6247,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -6263,7 +6263,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -6277,10 +6277,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:JT84.653.94.8752 K963.KJ74.K7.AK3 Q2.AQ2.QJT853.94 A75.T98.A62.QJT6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -6296,7 +6296,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -6312,7 +6312,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -6329,7 +6329,7 @@ Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       Pass    2C
+1N     X       Pass    2C
 Pass    3H      Pass    Pass
 Pass    
 
@@ -6346,7 +6346,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -6363,7 +6363,7 @@ Pass
 [Contract "3C"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      3C      Pass
 Pass    Pass    
 
@@ -6380,7 +6380,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -6394,10 +6394,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:5.952.AT982.KJ98 A3.K743.KJ3.AT73 KQT972.QJT86.7.2 J864.A.Q654.Q654"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -6410,10 +6410,10 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:963.J532.53.Q987 AKJ74.AQ.872.JT5 5.K74.AKQJ64.A42 QT82.T986.T9.K63"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -6429,7 +6429,7 @@ Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -6446,7 +6446,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -6459,11 +6459,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:T76.86.973.Q9432 KQ9.QJ954.K64.AJ 532.AKT732.A5.T8 AJ84..QJT82.K765"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2C      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6479,7 +6479,7 @@ Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       Pass    2H
+1N     X       Pass    2H
 Pass    Pass    Pass    
 
 
@@ -6495,7 +6495,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2H
+1N     2C      Pass    2H
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -6512,7 +6512,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -6529,7 +6529,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3S      Pass    Pass
+1N     3S      Pass    Pass
 Pass    
 
 
@@ -6545,7 +6545,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -6562,7 +6562,7 @@ Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -6578,7 +6578,7 @@ Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       Pass    2D
+1N     X       Pass    2D
 Pass    Pass    2H      Pass
 Pass    3D      Pass    Pass
 Pass    
@@ -6596,7 +6596,7 @@ Pass
 [Contract "5D"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 3D      X       Pass    3S
 Pass    Pass    4D      Pass
 5D      Pass    Pass    Pass
@@ -6612,11 +6612,11 @@ Pass    Pass    4D      Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:KJ8543..82.T9763 Q6.A42.KQ74.KQ52 T92.KQ9765.AJ6.J A7.JT83.T953.A84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       2S
-Pass    Pass    3NT     Pass
+1N     2C      X       2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6632,7 +6632,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -6649,7 +6649,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       Pass    2H
+1N     X       Pass    2H
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -6666,7 +6666,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -6682,7 +6682,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -6699,7 +6699,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      3S      Pass    Pass
 Pass    
 
@@ -6716,7 +6716,7 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -6733,7 +6733,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 X       2S      Pass    4S
 Pass    Pass    Pass    
 
@@ -6750,7 +6750,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      2S      3H
 Pass    Pass    Pass    
 
@@ -6767,7 +6767,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -6783,7 +6783,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -6796,11 +6796,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:T9432.8.T543.K42 AQ86.A73.Q6.QJT7 KJ.KJT52.KJ87.96 75.Q964.A92.A853"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2H      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6816,7 +6816,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       Pass    2C
+1N     X       Pass    2C
 Pass    Pass    2H      Pass
 Pass    Pass    
 
@@ -6833,8 +6833,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
-2S      Pass    3NT     Pass
+1N     2C      2H      Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -6851,7 +6851,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2H      Pass    2S
+1N     2H      Pass    2S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -6868,7 +6868,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -6881,10 +6881,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "EW"]
 [Deal "N:Q65.9753.T72.Q62 9743.AKQ.K53.A83 KT2.JT8.AQ9864.9 AJ8.642.J.KJT754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -6900,7 +6900,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -6917,7 +6917,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -6933,7 +6933,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     3S      4H      Pass
+1N     3S      4H      Pass
 Pass    Pass    
 
 
@@ -6949,7 +6949,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -6966,7 +6966,7 @@ Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -6983,7 +6983,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      4D      Pass
+1N     2C      4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -7000,7 +7000,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 2S      Pass    3C      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -7018,7 +7018,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -7035,7 +7035,7 @@ Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    2NT
+1N     2H      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -7052,7 +7052,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -7069,7 +7069,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -7085,7 +7085,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -7101,7 +7101,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -7114,10 +7114,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:A7.JT654.T963.63 642.KQ.AJ52.KQ75 KQT53.A98.Q4.AJ9 J98.732.K87.T842"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -7133,7 +7133,7 @@ Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7150,7 +7150,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      2NT     3S
+1N     2D      2N     3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -7167,7 +7167,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -7184,7 +7184,7 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4D      Pass    4S      Pass
 Pass    Pass    
 
@@ -7201,7 +7201,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -7218,7 +7218,7 @@ Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2H      Pass    3D
+1N     2H      Pass    3D
 Pass    Pass    Pass    
 
 
@@ -7234,7 +7234,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    Pass    2H      Pass
 Pass    Pass    
 
@@ -7251,7 +7251,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7268,7 +7268,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7285,7 +7285,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 X       Pass    3D      3H
 Pass    Pass    Pass    
 
@@ -7302,7 +7302,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      2NT     3S
+1N     2D      2N     3S
 Pass    Pass    Pass    
 
 
@@ -7318,7 +7318,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -7331,12 +7331,12 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:A764.A98.8.JT752 KQJT9.732.AQ5.A8 853.KJT654.KJ6.4 2.Q.T97432.KQ963"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2S      Pass
-2NT     Pass    3C      Pass
-3S      Pass    3NT     Pass
+1N     2C      2S      Pass
+2N     Pass    3C      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7352,7 +7352,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -7368,7 +7368,7 @@ Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      X       2S
+1N     2C      X       2S
 Pass    Pass    Pass    
 
 
@@ -7381,10 +7381,10 @@ Pass    Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:QT952.65.J975.Q7 K73.K3.AQT8.A942 AJ.AQJT8.K62.KJ6 864.9742.43.T853"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -7397,11 +7397,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:J4.7432.A84.T984 K2.J98.KQ95.AK72 AT965.KQT6.T76.3 Q873.A5.J32.QJ65"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2D      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2D      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7417,7 +7417,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -7433,7 +7433,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -7449,7 +7449,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      3C      Pass
+1N     2C      3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7463,13 +7463,13 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:9642.93.85.Q9762 T5.A5.A763.AKT83 AKJ73.QJT72.KT.4 Q8.K864.QJ942.J5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2D      X       2S
+1N     2D      X       2S
 3C      Pass    3D      Pass
 3S      X       Pass    Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7485,7 +7485,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    2NT
+1N     2S      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -7499,11 +7499,11 @@ Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:KT65.JT43.4.9654 AQJ92.Q87.QJ.QJT 73.A962.AT8532.3 84.K5.K976.AK872"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      3C      Pass
-3S      Pass    3NT     Pass
+1N     2H      3C      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7519,7 +7519,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       3C      Pass
+1N     X       3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7536,7 +7536,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -7552,7 +7552,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -7569,9 +7569,9 @@ Pass    Pass    Pass
 [Contract "7S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      4H      Pass
-4S      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+1N     2C      4H      Pass
+4S      Pass    4N     Pass
+5C      Pass    5N     Pass
 6S      Pass    7S      Pass
 Pass    Pass    
 
@@ -7588,7 +7588,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -7605,7 +7605,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -7622,7 +7622,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -7638,7 +7638,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2C      2D      X
+1N     2C      2D      X
 Pass    Pass    2H      Pass
 Pass    Pass    
 
@@ -7652,11 +7652,11 @@ Pass    Pass
 [Dealer "E"]
 [Vulnerable "All"]
 [Deal "N:852.KJT7.KQ732.2 K93.864.AT.AKJ86 Q76.AQ9532.J86.5 AJT4..954.QT9743"]
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      X       Pass
-2D      Pass    2NT     Pass
+1N     2C      X       Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7672,7 +7672,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -7689,7 +7689,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -7706,7 +7706,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     X       Pass    2D
+1N     X       Pass    2D
 Pass    Pass    2H      2S
 3H      Pass    4H      Pass
 Pass    Pass    
@@ -7724,7 +7724,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -7740,7 +7740,7 @@ Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -7757,7 +7757,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      X       3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -7775,7 +7775,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2NT     4H      Pass
+1N     2N     4H      Pass
 Pass    Pass    
 
 
@@ -7791,7 +7791,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    2S
 Pass    3C      3D      3S
 X       4C      Pass    Pass
@@ -7810,7 +7810,7 @@ Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       Pass    2S
+1N     X       Pass    2S
 Pass    Pass    Pass    
 
 
@@ -7826,7 +7826,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -7843,7 +7843,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -7859,7 +7859,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -7876,7 +7876,7 @@ Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -7892,7 +7892,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -7909,7 +7909,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -7926,7 +7926,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      3D      Pass    Pass
 Pass    
 
@@ -7943,7 +7943,7 @@ Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    3H
+1N     2D      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -7959,7 +7959,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    3S
 Pass    Pass    Pass    
 
@@ -7976,7 +7976,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -7992,7 +7992,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -8009,7 +8009,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -8025,7 +8025,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    3S
+1N     2D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -8042,7 +8042,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -8059,7 +8059,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      3D
 X       3H      Pass    4H
 Pass    Pass    Pass    
@@ -8077,7 +8077,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -8093,7 +8093,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    2NT
+1N     2S      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -8110,7 +8110,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8127,7 +8127,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -8144,7 +8144,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -8158,10 +8158,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:Q982.54.J95.9542 J7.KT98.AKT87.KQ KT653.AQ3.Q4.AJ3 A4.J762.632.T876"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -8177,7 +8177,7 @@ Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8194,7 +8194,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -8207,12 +8207,12 @@ Pass
 [Dealer "E"]
 [Vulnerable "none"]
 [Deal "N:.Q987652.JT93.43 KT.AJ4.754.AKJT7 AQ8653.KT.Q62.98 J9742.3.AK8.Q652"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8228,7 +8228,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -8244,7 +8244,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -8261,7 +8261,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "E"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -8278,7 +8278,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -8294,7 +8294,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -8310,7 +8310,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -8324,10 +8324,10 @@ Pass
 [Dealer "E"]
 [Vulnerable "NS"]
 [Deal "N:JT93.93.QJ93.953 Q7.AQ76.AT85.KJT AK54.KT42.7.AQ74 862.J85.K642.862"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "E"]
 [Auction "E"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -8343,7 +8343,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -8360,7 +8360,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "E"]
-1NT     3C      4H      Pass
+1N     3C      4H      Pass
 Pass    Pass    
 
 
@@ -8376,7 +8376,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "E"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -8392,8 +8392,8 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1NT     2C      2D      Pass
-2H      Pass    2NT     Pass
+1N     2C      2D      Pass
+2H      Pass    2N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -8410,7 +8410,7 @@ Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "E"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 

--- a/GIB/Drury.pbn
+++ b/GIB/Drury.pbn
@@ -1240,8 +1240,8 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1S      Pass
 2C      Pass    3S      Pass
-4C      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+4C      Pass    4N     Pass
+5S      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -1645,7 +1645,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    Pass    Pass
 
 
@@ -2020,12 +2020,12 @@ Pass    Pass
 {HCP 16 7 10 7}
 {TP 17 7 10 9}
 {Losers 4 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2231,12 +2231,12 @@ Pass    Pass
 {HCP 17 5 10 8}
 {TP 19 7 10 9}
 {Losers 4 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1D      Pass
-1NT     Pass    2H      Pass
-3D      Pass    3NT     Pass
+1N     Pass    2H      Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2744,7 +2744,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 Pass    Pass    
 
 
@@ -3530,9 +3530,9 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1C      Pass
 1H      Pass    2S      Pass
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 3D      Pass    3S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 5S      Pass    Pass    Pass
 
 
@@ -3978,7 +3978,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    4H      Pass
 Pass    Pass    
 
@@ -4465,7 +4465,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1S      Pass
 2C      Pass    3H      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -5476,8 +5476,8 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1H      Pass
 2D      Pass    2S      Pass
-2NT     Pass    3H      Pass
-3NT     Pass    4S      Pass
+2N     Pass    3H      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -5498,7 +5498,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 Pass    Pass    
 
 
@@ -5794,7 +5794,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1H      Pass
 2C      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    6H      Pass
 Pass    Pass    
 
@@ -7342,8 +7342,8 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1S      Pass
 2C      Pass    3H      Pass
-4H      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5H      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -7429,7 +7429,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    3H      Pass
+1N     Pass    3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -9455,7 +9455,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9817,7 +9817,7 @@ Pass    Pass
 [Auction "S"]
 Pass    Pass    1S      Pass
 2C      Pass    3D      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -10133,8 +10133,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    3H      Pass
-3NT     Pass    4H      Pass
+1N     Pass    3H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 

--- a/GIB/Fourth_Suit_Forcing
+++ b/GIB/Fourth_Suit_Forcing
@@ -31,11 +31,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J82.KT6542.K.AK2 KQ3.QJ3.QJ64.874 A5.A8.A9732.QT93 T9764.97.T85.J65"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -48,7 +48,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4C      Pass    4S      Pass
 Pass    Pass    
 
@@ -74,7 +74,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -83,11 +83,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQ8.KT9653.98.A5 JT743.872.K6.K43 962.A.AJT32.QJ86 K5.QJ4.Q754.T972"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -96,12 +96,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ.Q8.KQT975.Q74 T86.AJT4.8632.J3 A932.K73.4.AKT85 Q754.9652.AJ.962"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -110,11 +110,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K.K43.T9654.AK85 QJ52.J875.KJ3.72 A986.AQ6.Q8.J943 T743.T92.A72.QT6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -123,11 +123,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K54.AK973.K974.8 AQ7.8652.QT3.K92 T832.QT.AJ2.AQ63 J96.J4.865.JT754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -140,7 +140,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -188,11 +188,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:5.AKT75.J82.AJ83 K973.642.Q53.T94 Q862.QJ.KT7.KQ52 AJT4.983.A964.76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -201,11 +201,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q.8543.KQJ84.AK5 J632.AT92.7.Q642 A854.KJ6.A6.T983 KT97.Q7.T9532.J7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -218,9 +218,9 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5C      Pass    5D      Pass
-5NT     Pass    6C      Pass
+5N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -229,11 +229,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQT5.Q.Q9864.AQ2 AJ2.K972.K732.74 97.AJ63.AT5.KJT9 8643.T854.J.8653"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -242,11 +242,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQ8432.AQ6.KT2.4 K.K985.9654.JT93 6.J42.AQJ83.AQ52 JT975.T73.7.K876"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -255,11 +255,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:97.A93.KQJ972.K9 J32.T87.54.JT862 KQ85.KQ5.AT.7543 AT64.J642.863.AQ"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -268,11 +268,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:4.K8642.AQ.AT872 KQ53.97.876.J543 A976.A3.KT952.KQ JT82.QJT5.J43.96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -281,11 +281,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:984.KT9862.AK2.A J3.543.7643.KJ32 AKQ2.J7.Q9.QT985 T765.AQ.JT85.764"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -307,12 +307,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQ4.Q9764..AQJ85 K765.85.J642.K63 JT92.A3.AK973.T4 83.KJT2.QT85.972"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
 2D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -321,12 +321,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q8.J7.AT732.AQ73 AK75.T96.QJ8.T86 J94.AKQ4.96.KJ42 T632.8532.K54.95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 2D      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -339,7 +339,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -348,12 +348,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AK9854.K8.AT3.J4 T72.J962.KQ96.73 Q6.AQ.J872.AKQ82 J3.T7543.54.T965"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2D      Pass    2S      Pass
-2NT     Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+2N     Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -362,11 +362,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QJ6.K.AK98732.T9 T842.9653.Q.7652 AK5.JT74.5.AQJ83 973.AQ82.JT64.K4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -379,7 +379,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    2H      Pass
 2S      Pass    3C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -389,11 +389,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A852.KQJT6.J.K83 Q643.753.952.QT7 K7.A9.Q8763.A954 JT9.842.AKT4.J62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -402,12 +402,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQJ6.Q93.87543.A KT8.JT8.QT96.J85 943.AK74.A.KQ962 752.652.KJ2.T743"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -416,12 +416,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJ842.K4.KT53.Q7 T97.Q76.764.8432 K.AJT8.QJ82.KT95 Q653.9532.A9.AJ6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -430,11 +430,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A.AQ654.A84.9862 JT432.9872.Q62.7 Q876..KJT95.KQJ4 K95.KJT3.73.AT53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Db      1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -447,7 +447,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    4C      Pass
+3N     Pass    4C      Pass
 5C      Pass    6C      Pass
 Pass    Pass    
 
@@ -457,12 +457,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT843.72.KQ82.A6 QJ52.KJ9.964.K72 K7.AQ853.J3.Q853 96.T64.AT75.JT94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
 2H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -471,11 +471,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q32.3.AKQ93.AT64 J64.7642.JT6.K72 AKT7.KT85.72.Q83 985.AQJ9.854.J95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2D      Pass
 2S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -484,11 +484,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQ2.KJ98.QT976.A AT7.QT753.54.T52 J963.A.AKJ.87643 854.642.832.KQJ9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -522,11 +522,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A76.KJT764.KT7.A T92.92.A862.K874 KJ85.Q8.QJ93.QJ5 Q43.A53.54.T9632"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -539,7 +539,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -552,7 +552,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -561,11 +561,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T3.A9.K9732.AKJT J962.K87.T4.9763 AQ87.Q642.A5.Q54 K54.JT53.QJ86.82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -574,10 +574,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AKT87.2.KQJT32.J J94.JT97.5.AT862 65.AK85.A86.Q974 Q32.Q643.974.K53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -589,7 +589,7 @@ Pass    Pass
 [Contract "5D"]
 [Auction "S"]
 1D      Pass    2S      Pass
-2NT     Pass    3H      Pass
+2N     Pass    3H      Pass
 4C      Pass    5D      Pass
 Pass    Pass    
 
@@ -599,11 +599,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K97.AQ76.J9532.K Q83.32.K74.J8643 AJ42.K94.86.AT52 T65.JT85.AQT.Q97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -629,7 +629,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -638,11 +638,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQT95.AQ.J952.T7 74.K932.864.K643 J.JT74.AKT3.AQJ2 K8632.865.Q7.985"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -651,12 +651,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q83.KJ.AQ98652.K J765.QT9.K3.9864 KT4.A432.J7.AQT3 A92.8765.T4.J752"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2D      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -665,11 +665,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQ542.K9.QT862.K J87.732.KJ93.A95 K9.AQT65.A5.Q864 T63.J84.74.JT732"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -678,11 +678,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJ64.65.AQ854.QJ K82.A32.732.A873 QT3.KJ74.K9.KT54 975.QT98.JT6.962"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -705,11 +705,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJT7643.KJ2.9.KQ 52.A876.K83.T963 Q.QT3.QJ652.AJ75 K98.954.AT74.842"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -744,11 +744,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J765.K8.KQT98.A7 K93.742.J743.QT8 Q42.AQT6.A5.9653 AT8.J953.62.KJ42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -773,8 +773,8 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    3H      Pass
-4H      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5H      Pass    5N     Pass
 6D      Pass    6H      Pass
 Pass    Pass    
 
@@ -784,11 +784,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJT8.AT873.9.AJ9 Q75.QJ6.T876.Q72 K964.5.AKQJ4.KT8 32.K942.532.6543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -801,7 +801,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -814,7 +814,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    4C      Pass
+3N     Pass    4C      Pass
 4D      Pass    5D      Pass
 Pass    Pass    
 
@@ -824,11 +824,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A5.KJT87.KQT2.J6 J642.A4.873.KQ75 K973.2.AJ9.AT432 QT8.Q9653.654.98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -837,11 +837,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K97532.AK8.J9.K4 T8.JT95.KT5.J875 A.Q74.A8743.AT63 QJ64.632.Q62.Q92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -866,7 +866,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 5D      Pass    6D      Pass
 Pass    Pass    
 
@@ -903,13 +903,13 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J2.KT6.AQJT52.Q5 AT94.73.9643.A64 K87.QJ82.K8.KJT2 Q653.A954.7.9873"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2D      Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -922,7 +922,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -971,11 +971,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:9.AKQ843.A94.J32 JT865.962.Q72.Q6 KQ73.J.J653.AK85 A42.T75.KT8.T974"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -984,11 +984,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QJT85.94.A.AQT64 K93.JT53.QT72.K9 A2.AK872.J965.75 764.Q6.K843.J832"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -997,11 +997,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A.AQ8753.K84.J83 6432.T.J95.AT975 KQJ5.92.Q632.KQ2 T987.KJ64.AT7.64"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1010,11 +1010,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q92.QJ987.2.AKQ4 543.6432.J63.JT8 KJ7.K.AKQ84.6532 AT86.AT5.T975.97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1042,7 +1042,7 @@ Pass    Pass
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
 2H      Pass    3D      Pass
-3NT     Pass    6D      Pass
+3N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -1055,7 +1055,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -1069,8 +1069,8 @@ Pass    Pass
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 3S      Pass    4H      Pass
-4S      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5C      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -1085,7 +1085,7 @@ Pass    Pass
 1D      Pass    1S      Pass
 2H      Pass    2S      Pass
 3S      Pass    4C      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -1095,11 +1095,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:42.A7642.AKQT.Q3 A975.Q3.9765.975 QJT6.J8.J8.AKJ86 K83.KT95.432.T42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1108,11 +1108,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQ2.T5.AQJT865.3 T953.AJ4.43.J962 K64.KQ93.7.AKT75 J87.8762.K92.Q84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1125,7 +1125,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2H      Pass    3S      Pass
-3NT     Pass    4C      Pass
+3N     Pass    4C      Pass
 4S      Pass    Pass    Pass
 
 
@@ -1149,11 +1149,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJ6.6.AK852.A987 Q97.J9852.JT6.T2 A543.KQ43.Q9.Q65 T82.AT7.743.KJ43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2D      Pass
 2H      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1162,11 +1162,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQ932.AK97..Q652 T75.8642.A943.T9 K4.QT.KJT65.A873 J86.J53.Q872.KJ4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1179,7 +1179,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -1192,7 +1192,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -1201,11 +1201,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQ9.K63.AJT973.T T753.QJ.KQ4.J543 J842.A842.2.AKQ9 K6.T975.865.8762"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1214,12 +1214,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KT.AJ753.AQJ6.76 A876.6.952.JT942 J542.K4.KT73.AQ5 Q93.QT982.84.K83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1228,11 +1228,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q7.AK753.AQ42.85 962.Q84.963.Q973 KJ83.J6.J7.AKT62 AT54.T92.KT85.J4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1241,12 +1241,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KJ985.KJ.K8.A987 Q742.8743.Q7.Q42 A.AT65.AT53.JT63 T63.Q92.J9642.K5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3C      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3C      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1255,12 +1255,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:8753.AQ974.AQ8.Q JT9.KT52.652.J52 AK.63.K743.AK943 Q642.J8.JT9.T876"]
-[Contract "4NT"]
+[Contract "4N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    2H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    4NT     Pass
+2N     Pass    3S      Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -1269,11 +1269,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:8.AKJ9743.A63.Q2 KT2.86.K852.KJT5 AJ76.Q.QJT9.A743 Q9543.T52.74.986"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1282,11 +1282,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q2.T2.AKJ92.K854 T9863.654.Q876.J AJ74.AJ93.4.AT96 K5.KQ87.T53.Q732"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1295,11 +1295,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A9654.4.KJT.KQ53 KT72.AJT.Q92.T64 Q8.KQ982.A4.J987 J3.7653.87653.A2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1308,11 +1308,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AKQJ83.A4.85.864 7642.762.A63.J73 9.QJ3.KJT42.AKT5 T5.KT985.Q97.Q92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1321,12 +1321,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJT.95.KJT6543.A 6432.AJ2.97.KJ95 K9.Q843.AQ2.QT72 Q875.KT76.8.8643"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2D      Pass
-3D      Pass    3NT     Pass
+1N     Pass    2D      Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1339,7 +1339,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 4S      Pass    Pass    Pass
 
 
@@ -1353,7 +1353,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 3C      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -1364,11 +1364,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:82.A53.AKQJ54.42 KT95.QJ94.863.75 AJ74.K82.9.AT986 Q63.T76.T72.KQJ3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1377,11 +1377,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ9.K6.AK8742.98 A832.T85.JT.Q642 76.QJ73.Q3.AKJ73 QT54.A942.965.T5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1390,11 +1390,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A97.AJT9876.J4.K K4.K5432.93.T832 QJ32..AQ65.AJ965 T865.Q.KT872.Q74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1419,7 +1419,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -1428,12 +1428,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AKQ974.A4..Q9532 T832.KT93.K862.4 5.QJ86.AQJ94.AKJ J6.752.T753.T876"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2H      Pass    3S      Pass
-3NT     Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+3N     Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -1442,11 +1442,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A972.AQJ63.K43.J QT3.T54.82.87642 K64.9.AQT76.AT95 J85.K872.J95.KQ3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1482,11 +1482,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQ84.95.AT932.A2 J963.Q432.87.KQ9 K2.AJ76.K6.J7543 T75.KT8.QJ54.T86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1538,8 +1538,8 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    4H      Pass
+2N     Pass    3S      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -1560,11 +1560,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ852.QJ42.A.Q42 T4.KT953.962.K95 A3.A6.KJ754.J763 J976.87.QT83.AT8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1573,12 +1573,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:6.AKQ76.965.A976 J984.J94.KJ.JT85 KQ75.53.AQT74.Q4 AT32.T82.832.K32"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1600,11 +1600,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QJ873.KQ65.6.AQ4 AK92.T92.KJ73.72 5.A74.AT982.KJ63 T64.J83.Q54.T985"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1613,11 +1613,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K.QJT87.K64.KQ62 QT72.654.T7.AJ75 AJ85.K2.AQJ83.43 9643.A93.952.T98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1626,11 +1626,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q43.J.AKQ9652.K7 52.QT62.J843.A86 AK98.A974..QJ532 JT76.K853.T7.T94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1639,12 +1639,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T76.KQ8653.AK.J2 52.JT2.652.K6543 AKJ3.A7.Q974.987 Q984.94.JT83.AQT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
 2D      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1653,11 +1653,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AT63..AKJ97.QJ54 QJ98.J863.864.A6 K75.AK95.Q3.T983 42.QT742.T52.K72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2D      Pass
 2H      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1670,7 +1670,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -1679,12 +1679,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQ642.42.AKJ4.63 J975.986.86.AJ52 8.AQJT7.T95.KQT8 KT3.K53.Q732.974"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
 2H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1732,11 +1732,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:JT63.KQ963.AQ4.Q 842.T54.K97.J543 KQ75.J.J83.AK972 A9.A872.T652.T86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1745,11 +1745,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AT972.AKQ9.92.76 J853.J75.T83.K53 K.T432.QJ74.AQT2 Q64.86.AK65.J984"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1771,12 +1771,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A93.AQJ532.T9.A8 K854.84.KJ64.K32 QT72.K6.AQ82.QT6 J6.T97.753.J9754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
 2D      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1785,11 +1785,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T5.AK63.A9542.Q9 932.42.QT73.J852 AJ74.QJ7.K8.KT76 KQ86.T985.J6.A43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1798,11 +1798,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:96.K6.AKJ964.K75 Q742.742.T87.A86 KJT3.AQ3.Q3.JT92 A85.JT985.52.Q43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1824,11 +1824,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J763.T5.AKQ43.KQ QT985.842.85.983 A2.AK97.762.JT65 K4.QJ63.JT9.A742"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1851,12 +1851,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:8.AT2.AK854.A632 KJ93.943.Q973.84 Q765.KQ6.T6.KQT7 AT42.J875.J2.J95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2D      Pass
 2H      Pass    2S      Pass
 3C      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1865,11 +1865,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A4.QJT97.AQT96.8 QT65.K854..T9643 K982.3.K8754.AQ2 J73.A62.J32.KJ75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1878,11 +1878,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:83.T6532.A.AKQ52 J9764.J94.Q752.J AQ.A8.KT864.9643 KT52.KQ7.J93.T87"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1891,12 +1891,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q92.J2.AKQJ94.J6 JT5.986.76.Q9532 K743.AQ53.82.KT8 A86.KT74.T53.A74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1918,11 +1918,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJT2.K9754.QJ.A3 Q83.JT6.K4.T9862 A54.A.98532.KQJ5 976.Q832.AT76.74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1931,11 +1931,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J8.Q87.AKQ954.J3 K9732.T5.T32.987 Q654.K963.8.AKQ5 AT.AJ42.J76.T642"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1944,13 +1944,13 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:4.932.AK872.AK54 JT653.K4.JT96.T2 KQ2.AJT8.3.QJ863 A987.Q765.Q54.97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1959,11 +1959,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ6.T2.AKQ984.J8 9852.Q654.T72.AT QT43.AK9.J3.K942 A7.J873.65.Q7653"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1972,11 +1972,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQ65.K54.AK932.6 87.Q9863.Q64.K87 A42.AJ72.J.AQ942 JT93.T.T875.JT53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1991,7 +1991,7 @@ Pass    Pass
 1S      Pass    2H      Pass
 3D      Pass    3S      Pass
 4C      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -2001,12 +2001,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K9.A94.QJ9742.K5 J654.J2.KT86.987 Q732.K86.A.AQ643 AT8.QT753.53.JT2"]
-[Contract "4NT"]
+[Contract "4N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3NT     Pass    4D      Pass
-4NT     Pass    Pass    Pass
+3N     Pass    4D      Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -2015,11 +2015,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T7.AKQ92.T852.A5 A85.7654.743.Q63 KJ32.T.KQ96.KJT4 Q964.J83.AJ.9872"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2028,11 +2028,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:6.QJ8.QJ87542.AK KT74.T3.A6.T9743 Q852.AK95.T.QJ62 AJ93.7642.K93.85"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2041,11 +2041,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q86543.AK.QT.A53 K9.T975.A862.K76 A.QJ43.K953.QT92 JT72.862.J74.J84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2054,11 +2054,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AK.A872.K6542.J2 975.JT95.QJ93.A9 QJT2.Q63.A.KQ854 8643.K4.T87.T763"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2080,11 +2080,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A75.A7.Q98542.A7 J94.Q853.73.KT83 KQ82.KT64.A.J652 T63.J92.KJT6.Q94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2093,11 +2093,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AT953.53.AJ94.KJ K42.764.T82.Q842 8.AKQ82.KQ7.T975 QJ76.JT9.653.A63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2106,11 +2106,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:8.AK976.874.AQT8 KQT2.T542.KJ.754 AJ54.J.AT952.K63 9763.Q83.Q63.J92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2119,11 +2119,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KT653..KQT6.AQ65 J92.Q975.J98.J43 Q7.AKT43.A2.9872 A84.J862.7543.KT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2132,12 +2132,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K.K7643.KT98.AQ5 AT765.T52.J4.843 QJ32.8.AQ53.KJ62 984.AQJ9.762.T97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2159,12 +2159,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q64.T2.AKQ982.KJ 532.KJ9.J764.AQT AKJ7.A76.T.87543 T98.Q8543.53.962"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2173,11 +2173,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J62.AJT4.AQJ74.Q QT75.853.K6.JT94 9843.KQ.32.AK752 AK.9762.T985.863"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2186,11 +2186,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:JT873.J6.AK.AJ95 K2.KT84.T8643.87 A.A732.QJ52.KT64 Q9654.Q95.97.Q32"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2199,11 +2199,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJ.AKJ72.8432.76 874.Q654.KJ6.Q52 KQ65.T3.A97.KJT8 T932.98.QT5.A943"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2212,11 +2212,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T42.AK732.T.AQJT 976.JT86.J986.43 KQ8.5.AQ432.K952 AJ53.Q94.K75.876"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2243,7 +2243,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    5C      Pass
+3N     Pass    5C      Pass
 Pass    Pass    
 
 
@@ -2252,11 +2252,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ765.Q4.AJ984.8 J42.K763.T75.JT5 3.AJ952.KQ6.KQ62 KT98.T8.32.A9743"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2265,11 +2265,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AKJ82.T.AT64.QT7 QT95.A974.853.85 43.KJ853.KQ.A943 76.Q62.J972.KJ62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2278,11 +2278,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJ86.AQT85.Q.Q97 T9.KJ63.8765.JT2 752.4.AJT32.AK65 KQ43.972.K94.843"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2291,11 +2291,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q.AKJ9876.T3.K95 T652.542.KJ9.Q43 AJ98..AQ765.JT76 K743.QT3.842.A82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2308,7 +2308,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 3C      Pass    4C      Pass
 5C      Pass    Pass    Pass
 
@@ -2323,7 +2323,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -2332,11 +2332,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K7.KJ9.AQT974.J8 JT854.532.J85.A2 A632.AT6.6.KQT63 Q9.Q874.K32.9754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2345,12 +2345,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A95.AQT42.AJT5.6 KT3.953.862.AT32 Q864.J.KQ74.KJ95 J72.K876.93.Q874"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    2H      Pass
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2363,7 +2363,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -2372,11 +2372,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AKT876.K.3.AJ542 Q4.Q98.JT754.T76 2.AJT63.AKQ2.Q93 J953.7542.986.K8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2390,7 +2390,7 @@ Pass    Pass
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
 3C      Pass    3D      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -2451,12 +2451,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQ.AQ873.KT854.9 K86.KJ64.J96.Q54 T743..AQ32.AK763 J952.T952.7.JT82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2465,12 +2465,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q92.82.AKQJT5.J7 643.AQJ3.8763.65 AJT.T976.4.AKQ32 K875.K54.92.T984"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2483,7 +2483,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -2496,7 +2496,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4C      Pass    4S      Pass
 Pass    Pass    
 
@@ -2510,7 +2510,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 5D      Pass    Pass    Pass
 
 
@@ -2520,12 +2520,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ85.T.KJ986.AJ8 J743.8653.75.Q42 AT.AJ92.Q4.K9763 962.KQ74.AT32.T5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-2NT     Pass    3C      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3C      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2534,11 +2534,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:7642.KJ.AQT72.KQ T85.976.643.A863 AQJ.AQ85.85.7542 K93.T432.KJ9.JT9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2547,11 +2547,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A.JT542.QJ6.AQ98 9763.Q973.53.765 QJ42.6.AK842.K32 KT85.AK8.T97.JT4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2560,11 +2560,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q2.K87.AKT953.Q3 J75.953.QJ7.AT64 K843.AQT.4.KJ852 AT96.J642.862.97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2590,7 +2590,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -2599,11 +2599,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:53.AKQ74.Q9.A632 A986.J82.J8532.J QJ74.53.AKT.KT87 KT2.T96.764.Q954"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2612,11 +2612,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AK63.K73.QT832.K QT52.AT85.A7.T43 J.Q942.KJ9.AQ952 9874.J6.654.J876"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2625,11 +2625,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ9432.K74.T7.AQ T6.T95.A843.K975 J.A862.KQJ5.JT64 K875.QJ3.962.832"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2650,12 +2650,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T.AJ86532.J5.AK3 AQJ3.QT7.862.942 7652.K9.AK74.Q76 K984.4.QT93.JT85"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
 2D      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2664,11 +2664,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K9873.63.K873.AK J6.T92.652.QT973 A2.AQJ54.QT94.86 QT54.K87.AJ.J542"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2677,11 +2677,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T3.AJ986.93.AKJ3 A984.752.T842.95 KJ52.Q.AKQJ6.764 Q76.KT43.75.QT82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2694,7 +2694,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -2708,7 +2708,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -2717,12 +2717,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K6.AKJ54.T762.QT QT84.T763.QJ4.92 AJ73.92.A5.K8643 952.Q8.K983.AJ75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2745,11 +2745,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AK6432.64.J65.AK JT9.AJT.Q983.965 8.K872.AKT7.QJT4 Q75.Q953.42.8732"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2758,11 +2758,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A4.JT8532.AJ.A52 J95.A6.T9862.974 KQ73.9.KQ74.QJT8 T862.KQ74.53.K63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2796,11 +2796,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AK5432.A4.973.A9 876.K9765.65.JT5 .QJ83.AT842.KQ63 QJT9.T2.KQJ.8742"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2809,11 +2809,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KQJT532.KT2.K.Q8 A984.J86.AJ.JT97 7.A73.QT953.AK65 6.Q954.87642.432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2822,11 +2822,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:543.KQ83.AQ632.Q T8.T542.854.JT86 A762.A7.T9.AK972 KQJ9.J96.KJ7.543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2835,11 +2835,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AKT963.A53.K87.9 Q8.QT94.J2.JT753 J2.K6.QT543.AQ42 754.J872.A96.K86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2848,12 +2848,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q72.2.AK86432.KQ K9543.T963.T7.75 A6.AK54.Q5.JT862 JT8.QJ87.J9.A943"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2D      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2875,11 +2875,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:43.KQ96.AQJ92.J2 K985.AJ.8653.984 AJT6.43.T7.AKT73 Q72.T8752.K4.Q65"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2901,11 +2901,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQ652.2.KQ7.QJ85 9874.T84.JT85.AK A.AJ976.A962.T62 JT3.KQ53.43.9743"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2918,7 +2918,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4C      Pass
+3N     Pass    4C      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2928,11 +2928,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:5.A9652.A3.KQT92 KT97.Q43.92.8763 AQJ3.T7.KQ765.A5 8642.KJ8.JT84.J4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2941,11 +2941,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:8.AQJ84.Q84.AJT9 AQ94.62.973.7654 KJ53.97.AKJT6.K2 T762.KT53.52.Q83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2954,12 +2954,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT632.KT.64.AQ52 K85.Q94.JT82.T93 Q.A832.AK953.KJ4 J974.J765.Q7.876"]
-[Contract "4NT"]
+[Contract "4N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2H      Pass    2S      Pass
-2NT     Pass    3C      Pass
-3NT     Pass    4NT     Pass
+2N     Pass    3C      Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -2968,12 +2968,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A5.A9763.J5.AT92 Q43.8542.T8764.7 KT62.T.AK2.KJ643 J987.KQJ.Q93.Q85"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3H      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2986,8 +2986,8 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3H      Pass
+1N     Pass    2D      Pass
+2N     Pass    3H      Pass
 3S      Pass    4D      Pass
 5C      Pass    5H      Pass
 Pass    Pass    
@@ -3014,7 +3014,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4C      Pass    4S      Pass
 Pass    Pass    
 
@@ -3024,11 +3024,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:JT.AK753.AQ.9652 K7.Q982.T52.QJT8 A965.T4.KJ84.A73 Q8432.J6.9763.K4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3041,7 +3041,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -3064,12 +3064,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:32.AK9743.KJ7.A9 JT95.8.A9843.J87 AQ84.QJ.Q652.QT2 K76.T652.T.K6543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
 2D      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3078,11 +3078,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJ754.Q865.AJ2.J 962.J942.Q53.QT8 KT.AK.KT87.A9765 Q83.T73.964.K432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3103,11 +3103,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQJ7.A4.T9842.Q2 T8652.Q863.5.863 K9.JT97.AQ6.KJT7 43.K52.KJ73.A954"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3128,11 +3128,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:3.QJ63.QT965.AKQ K964.K98.43.J732 AQT2.A75.A8.T986 J875.T42.KJ72.54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3167,11 +3167,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T9.AKQJ62.AT8.97 J62.T984.QJ32.42 AK43.7.754.KQT63 Q875.53.K96.AJ85"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3180,11 +3180,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQJ43.52.Q972.A9 KT7.J93.84.QT862 85.AQ864.AJT6.J4 962.KT7.K53.K753"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3193,11 +3193,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQ4.2.AJT932.A65 T9753.J954.Q8.K2 J2.AQT6.K6.QJT43 A86.K873.754.987"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3233,11 +3233,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q7.J6.AKQT9.JT87 9854.A8532.J3.95 KJ32.KQ97.6.AQ64 AT6.T4.87542.K32"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3246,12 +3246,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQJT8.A.AJ65.T65 9763.T74.92.AQ82 A4.KJ985.Q3.KJ43 52.Q632.KT874.97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
 2H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3260,12 +3260,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QT865..AKT94.KJ9 KJ92.KJ76.652.T5 A.QT985.J87.AQ86 743.A432.Q3.7432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
 2H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3274,11 +3274,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T94.KQT8.AKJ95.6 K3.A543.T32.Q954 A862.6.Q64.AK873 QJ75.J972.87.JT2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3287,11 +3287,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T.AQ6.AQJ763.652 K986.J85.54.AT74 AJ43.92.K98.KQ93 Q752.KT743.T2.J8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3304,7 +3304,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -3318,7 +3318,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -3328,12 +3328,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AKJT93.K85.J5.J9 Q85.T63.943.AKQ3 4.AQ4.AK862.T765 762.J972.QT7.842"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3342,11 +3342,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AK83.JT987.K7.K8 42.AQ64.J953.932 JT6.K.AT864.AQT7 Q975.532.Q2.J654"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3382,12 +3382,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A.J653.QT853.AQT 9653.K987.K7.975 KQ42.42.AJ.KJ864 JT87.AQT.9642.32"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3409,11 +3409,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQ954.2.964.AK92 T632.T9874.Q3.T3 K.K53.AKJ85.J864 J87.AQJ6.T72.Q75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3426,7 +3426,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    3C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6C      Pass
 Pass    Pass    
@@ -3441,7 +3441,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -3450,11 +3450,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QJ.T7.AKJT8.AT75 64.K9653.Q65.J63 A873.QJ4.9.KQ942 KT952.A82.7432.8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3467,7 +3467,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -3476,12 +3476,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KJ2.AJ963.AQ32.2 T97.K2.JT97.T765 A864.QT.K64.AJ83 Q53.8754.85.KQ94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3490,11 +3490,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T.KQJT6.KQ93.KT2 K9763.984.J6.Q84 AQ54.A7.82.AJ963 J82.532.AT754.75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3503,12 +3503,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQ.Q53.AJ97653.T K532.JT2.K2.9732 J98.K976.8.AKQJ8 T764.A84.QT4.654"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 2D      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3517,12 +3517,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q2.KJ.T97652.AK8 KJ43.Q743.K3.T54 AT75.AT52.J.QJ62 986.986.AQ84.973"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3531,12 +3531,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KJT64.K.KT97.K42 Q872.Q952.AJ6.97 A3.AJ873.Q8.AT86 95.T64.5432.QJ53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3549,7 +3549,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4C      Pass    4S      Pass
 Pass    Pass    
 
@@ -3559,12 +3559,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K62.AK9843.K.Q32 Q4.T765.Q8743.94 AJ87.2.652.AKJ85 T953.QJ.AJT9.T76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3573,11 +3573,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A86.KT96.A8732.K T32.A2.KQT9.T654 KQJ5.QJ.J5.QJ982 974.87543.64.A73"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3586,12 +3586,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QT6.AKQJ652.Q4.4 9854.T7.A76.AJ65 AK73.9.KT985.QT9 J2.843.J32.K8732"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
 2D      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3604,7 +3604,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -3617,7 +3617,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -3627,12 +3627,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AKJ73.72.K.K6432 Q964.J6.T9432.75 2.AK943.875.AQJ8 T85.QT85.AQJ6.T9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
 2H      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3641,11 +3641,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A8632.K973.A4.A8 KQ7.A54.762.9742 JT.QT.KQ853.KQ65 954.J862.JT9.JT3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3654,11 +3654,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A.KJ93.JT843.A32 Q863.T62.952.JT5 KT74.Q75.A7.KQ84 J952.A84.KQ6.976"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3667,11 +3667,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ.KQ985.A954.J3 Q83.A43.QJ7.T942 A765.JT.KT62.A86 T942.762.83.KQ75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3694,11 +3694,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K.A62.QJ9632.QJ4 QJT9.J94.A5.T972 A432.QT53.4.AK63 8765.K87.KT87.85"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3726,7 +3726,7 @@ Pass    Pass
 1S      Pass    2H      Pass
 3C      Pass    3S      Pass
 4D      Pass    4H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -3754,7 +3754,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -3776,11 +3776,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:54.AKJT2.AQT4.93 Q973.98.J96.T542 KT86.Q6.72.AKQJ6 AJ2.7543.K853.87"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3789,11 +3789,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:975.AKJT74.KQ.95 64.Q965.6542.K82 AQJT.3.AT93.QT63 K832.82.J87.AJ74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3833,7 +3833,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -3846,8 +3846,8 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3H      Pass
-3NT     Pass    4H      Pass
+2N     Pass    3H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -3856,11 +3856,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T.A9873.AT76.KQ3 7642.K654.Q5.972 QJ98.Q.KJ93.AJ86 AK53.JT2.842.T54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3882,11 +3882,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJ9.AJ8643.KQ6.4 K642.KT95.J72.J9 Q753..A854.AQ863 T8.Q72.T93.KT752"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3895,11 +3895,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:8.AKT73.AQJ4.876 AT762.J42.T72.J4 KJ93.86.K86.AQ52 Q54.Q95.953.KT93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3908,11 +3908,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ64.9.AKJ93.J65 JT53.AQ8.542.987 K2.KJ63.876.KQ42 987.T7542.QT.AT3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3925,7 +3925,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3H      Pass
+2N     Pass    3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3949,11 +3949,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KT83.KQJ73.Q.KJ3 J5.A864.96532.Q5 Q7.T5.AKT87.A962 A9642.92.J4.T874"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3962,11 +3962,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KJ8.AQ9875.QJ8.6 T763.JT2.T4.AK92 A954.K.A532.QJ83 Q2.643.K976.T754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3979,7 +3979,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -4002,11 +4002,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQ75.KJ6.K8642.7 KT6.98742.J.QT63 9432.A3.AQ.AJ942 J8.QT5.T9753.K85"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4041,11 +4041,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A6.KQT4.AQ653.73 843.A9732.984.J6 KJT9.J.K72.AT954 Q752.865.JT.KQ82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4054,11 +4054,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:94.K63.AKQ763.K3 QT7.T97.J952.765 AJ62.AQJ8.8.9842 K853.542.T4.AQJT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4071,7 +4071,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4094,11 +4094,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A7.72.KJ974.AK73 Q954.T954.32.QT2 KT82.QJ83.AQ.J98 J63.AK6.T865.654"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4107,11 +4107,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q6.AKJ76.K753.42 AT7.T95.JT62.986 9843.32.AQ.KQJT7 KJ52.Q84.984.A53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4120,11 +4120,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:863.A4.AKT872.K6 A542.Q92.J94.Q42 KJT7.KJT5.63.AJT Q9.8763.Q5.98753"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4133,11 +4133,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AKJ6.43.KJ975.Q7 853.A952.A6.JT65 Q4.KQ87.T82.AK43 T972.JT6.Q43.982"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4158,11 +4158,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J.AQJ743.K9753.Q Q632.T2.JT84.KT3 A987.K8.AQ.87654 KT54.965.62.AJ92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4171,11 +4171,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AKT93.KJ93.QJ2.8 QJ5.Q754.T8.JT72 7.AT62.A976.AQ96 8642.8.K543.K543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4184,12 +4184,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AK742.A.QT652.Q9 J865.J8762.A.754 Q.KQT9.KJ93.J832 T93.543.874.AKT6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3H      Pass    3NT     Pass
+2N     Pass    3D      Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4198,12 +4198,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:.KT762.QJT3.AKT5 Q854.A3.K64.7643 AK62.J5.A872.Q82 JT973.Q984.95.J9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4212,12 +4212,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:74.AJ862.J8.AK96 T8532.K3.T972.QT AJ96.94.AK65.832 KQ.QT75.Q43.J754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4243,7 +4243,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -4252,11 +4252,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ763..A96.AK953 Q952.T543.J5.J72 A4.AQJ86.KQ73.64 T8.K972.T842.QT8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4265,11 +4265,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A.KQJ93.J54.QJ32 J7653.AT8.T97.T7 KQT9.7.AQ862.A94 842.6542.K3.K865"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4278,11 +4278,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J65.AQT532.A84.A K73.976.63.J9872 AT94.K8.KJ92.KT6 Q82.J4.QT75.Q543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4291,11 +4291,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K64.AKJ752.98.A6 T82.QT3.J72.J852 AQ93.4.QT43.KQ93 J75.986.AK65.T74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4304,12 +4304,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQ.98.QJT86.AQ62 J7543.Q742.4.T43 K8.AT65.K95.KJ85 T962.KJ3.A732.97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2C      Pass
-3C      Pass    3NT     Pass
+1N     Pass    2C      Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4334,7 +4334,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3H      Pass
+2N     Pass    3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4348,7 +4348,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4C      Pass    4S      Pass
 Pass    Pass    
 
@@ -4362,7 +4362,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -4388,7 +4388,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -4411,11 +4411,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:JT84.AJ.AKJT6.J3 A765.742.92.T982 3.KQT5.Q53.AQ765 KQ92.9863.874.K4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4424,11 +4424,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QJ72.A53.KQ732.Q K84.874.AT9.JT87 93.KQJ9.J4.AK654 AT65.T62.865.932"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4449,12 +4449,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AJ2.3.KQJ54.QJ65 754.AJ98.T7.KT87 Q6.Q642.A96.A932 KT983.KT75.832.4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 2C      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4463,11 +4463,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:7.QJ932.KQ6.AQT6 AK6.86.J942.9732 JT43.AK.AT753.K8 Q9852.T754.8.J54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4476,11 +4476,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AK86542.QJ.A64.3 QJT.A2.QJ98.T965 9.K8763.K75.AQ82 73.T954.T32.KJ74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4489,11 +4489,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AKT953.43.KQ.K53 Q86.AT872.9.JT96 74.KQ.AT432.A872 J2.J965.J8765.Q4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4502,11 +4502,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T3.AKQ74.AQ65.53 A52.T852.97.QT92 KQ96.J6.KT84.AJ7 J874.93.J32.K864"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    2H      Pass
 2S      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4515,11 +4515,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:.KQJ8753.AK6.872 QT982.T2.J75.KT3 KJ63.4.Q82.AQJ95 A754.A96.T943.64"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4528,11 +4528,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQT95.QJ5.9.KJ32 K8632.942.854.QT .AK83.AKJ76.9854 J74.T76.QT32.A76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4558,7 +4558,7 @@ Db      2S      4D      Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -4567,11 +4567,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KQ9853.43.AQ4.KT AT4.J876.J8.8543 .AKT5.K7532.QJ96 J762.Q92.T96.A72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4580,11 +4580,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A8.AJT4.K9752.J7 7432.K87.T.T8532 QT95.Q2.AJ6.KQ96 KJ6.9653.Q843.A4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4597,8 +4597,8 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    4S      Pass
+2N     Pass    3S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -4611,7 +4611,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -4637,7 +4637,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -4646,12 +4646,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AK962.Q962.3.A95 T73.AK53.985.732 Q5.T4.AKJ62.KJT6 J84.J87.QT74.Q84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
 3D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4660,12 +4660,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A2.T2.AK7542.K75 853.K986.Q6.9864 QJ97.Q754.J8.AQ2 KT64.AJ3.T93.JT3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4677,7 +4677,7 @@ Pass    Pass
 [Contract "4S"]
 [Auction "S"]
 1D      Pass    2S      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4691,7 +4691,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4C      Pass    4S      Pass
 Pass    Pass    
 
@@ -4714,11 +4714,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:973.K.AKQ32.JT53 85.A6542.T874.Q9 AQT2.JT93.6.AK87 KJ64.Q87.J95.642"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4727,12 +4727,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KQJT9.T6.AQ.K732 7543.953.K9752.Q A.KJ872.J86.AT98 862.AQ4.T43.J654"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
 2H      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4745,7 +4745,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -4754,11 +4754,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQJ64.AKT.8.JT54 T52.9854.Q653.KQ 7.Q763.AKJT.A986 K983.J2.9742.732"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4767,11 +4767,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:6.AJ9854.A94.AT7 KT97.K62.J875.K2 AQJ8.7.KT3.Q8543 5432.QT3.Q62.J96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4780,11 +4780,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AK65.94.A6432.KJ 872.875.J97.Q842 Q3.KQ63.QT8.AT76 JT94.AJT2.K5.953"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4799,7 +4799,7 @@ Pass    Pass
 2D      Pass    2H      Pass
 3H      Pass    3S      Pass
 4C      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -4810,11 +4810,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AKJT96.J.A.J8632 Q84.8763.Q932.QT 3.K952.KT85.AK95 752.AQT4.J764.74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4823,11 +4823,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:3.A6.AK87542.K74 AT72.873.Q93.J85 KJ95.KJT5.T.AT92 Q864.Q942.J6.Q63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4836,11 +4836,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J74.KQ954.AQJ8.2 932.T62.K64.KT74 AKT6.J.T532.AQ95 Q85.A873.97.J863"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4849,11 +4849,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QJT96.K.KJ.QJ982 K83.T9762.762.54 7.AJ83.A953.AKT7 A542.Q54.QT84.63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4866,7 +4866,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -4887,12 +4887,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K97.AJ864.9.AK72 42.KQ5.6542.QT54 AQJT.7.KQT83.J83 8653.T932.AJ7.96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4913,11 +4913,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AT4.K987.KJT62.K Q865.432.A75.Q72 KJ93.QT.Q9.AT853 72.AJ65.843.J964"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4926,11 +4926,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QJT.AJ543.AKT7.4 862.K9862.98.JT5 A953.Q7.QJ.KQ873 K74.T.65432.A962"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4939,11 +4939,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QT3.J.AKQJ842.76 KJ84.K73.93.QJ53 A975.AQ64.75.K84 62.T9852.T6.AT92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4965,11 +4965,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJ642.A.Q4.Q5432 Q97.K652.962.T98 K.QT43.KJ73.AK76 T853.J987.AT85.J"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4978,11 +4978,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT.J92.KQ76543.A KJ63.AK76.82.952 Q5.Q543.AJ.KJT43 98742.T8.T9.Q876"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Db
 1H      Pass    1S      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4991,11 +4991,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJT643.A73.AJ9.2 Q2.Q95.T64.T8653 8.KJ62.K832.AJ74 K975.T84.Q75.KQ9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5004,11 +5004,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QJ2.K542.AK982.4 98753.A6.Q76.J32 K.QJ83.J53.AK765 AT64.T97.T4.QT98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5017,11 +5017,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J42.AK9832.KQ.Q5 T98.T6.A9862.T93 A753.J.JT73.AK76 KQ6.Q754.54.J842"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5034,7 +5034,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 6D      Pass    Pass    Pass
 
 
@@ -5057,11 +5057,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K9.AK9832.KJ5.75 AT3.QT64.T72.J42 QJ62.J5.A963.AQ9 8754.7.Q84.KT863"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5070,11 +5070,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:9732.AKJT5.QJ6.A A654.962.AT.7632 KJ.74.K9874.KQ95 QT8.Q83.532.JT84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5083,11 +5083,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT642.K.K7.K8752 J83.A963.Q98.T43 K5.QT754.AJ64.Q6 Q97.J82.T532.AJ9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5126,7 +5126,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -5135,12 +5135,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AKJ86.KJT53.2.K8 754.Q64.9763.Q62 Q.A87.AKT84.T943 T932.92.QJ5.AJ75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3H      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5163,11 +5163,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:T9.KQJ42.K8.KQ87 KQ7.T953.QJT2.93 AJ64.8.A764.AJ54 8532.A76.953.T62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5176,11 +5176,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K2.AK643.KJ73.T4 AQ3.985.Q86.J873 T984.J2.A92.AK62 J765.QT7.T54.Q95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5189,11 +5189,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:952.KQJ87.A.K543 KQ7.9543.T983.J9 AJ83.2.J654.AQ76 T64.AT6.KQ72.T82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5202,12 +5202,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:43.AKQ652.K53.J5 T75.J97.T86.9764 AKJ8.8.942.AKT32 Q962.T43.AQJ7.Q8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5216,11 +5216,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AKQ.AQ43.T7542.T 952.J86.KJ8.KJ65 J876.92.AQ3.AQ82 T43.KT75.96.9743"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5233,7 +5233,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-3NT     Pass    6H      Pass
+3N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -5255,11 +5255,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AK8.AQ987.J765.8 Q5.J54.Q9843.J74 J742.T.AT2.AKQ52 T963.K632.K.T963"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5280,11 +5280,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AT2.KJ63.Q9864.A QJ7.875.AKT.8642 K643.AQ.J2.KQJ75 985.T942.753.T93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5293,12 +5293,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q96.K.AK6542.K93 A543.J932.J98.76 KT8.AQ65.T.QJT54 J72.T874.Q73.A82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2D      Pass
-3C      Pass    3NT     Pass
+1N     Pass    2D      Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5307,11 +5307,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:9.QT4.AK983.AJ74 JT84.J652.T7.Q82 AQ53.K8.Q62.K653 K762.A973.J54.T9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5320,11 +5320,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:54.K9532.A6.AKT8 K8.QJ76.Q732.Q64 AJ62.A.KJ54.J532 QT973.T84.T98.97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5333,11 +5333,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q32.AT643.2.AK63 954.Q9.KT654.QT8 AK76.K.QJ3.J7542 JT8.J8752.A987.9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5346,11 +5346,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:73.AKQ8764.6.A92 K62.J3.QT42.Q754 A854.T.KJ97.KJ83 QJT9.952.A853.T6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5363,7 +5363,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -5384,11 +5384,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K2.A852.QJ965.K4 A954.T943.874.T3 Q873.6.KT2.AQJ85 JT6.KQJ7.A3.9762"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5411,11 +5411,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ974.8.A73.KQ95 T32.J92.QT6.A432 Q6.AQ743.K854.J7 A85.KT65.J92.T86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5424,12 +5424,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QT.K5.AQT763.KT9 K42.Q97.854.AJ54 J987.AJ43.KJ.Q32 A653.T862.92.876"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5442,7 +5442,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6C      Pass
 Pass    Pass    
@@ -5457,7 +5457,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -5470,7 +5470,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 6D      Pass    Pass    Pass
 
 
@@ -5498,7 +5498,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -5507,11 +5507,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A9.AKT952.K52.65 T732.QJ.QJ6.Q984 KJ65.74.A983.AT2 Q84.863.T74.KJ73"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5524,7 +5524,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 5D      Pass    Pass    Pass
 
 
@@ -5534,11 +5534,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQ542.AT.85.A652 J863.932.AT764.9 .KJ654.KQ92.KJT3 KT97.Q87.J3.Q874"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5547,11 +5547,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A4.QJ875.AQ72.52 T75.T42.KT95.AJ8 KQJ2.K3.J8.KT763 9863.A96.643.Q94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5577,7 +5577,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4C      Pass    4S      Pass
 Pass    Pass    
 
@@ -5587,11 +5587,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K763.K.KQJ75.Q82 AQ5.9863.9632.73 T2.AT42.A8.KJT65 J984.QJ75.T4.A94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5607,7 +5607,7 @@ Pass    Pass
 2H      Pass    2S      Pass
 3D      Pass    3H      Pass
 4D      Pass    4H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -5617,12 +5617,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K7.KT.QJT853.AJ3 Q982.A862.72.QT7 A643.Q543.AK.986 JT5.J97.964.K542"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5631,12 +5631,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AKJ87.QJ9752..Q3 6.K64.9764.K9875 952.T.AKT85.AJ42 QT43.A83.QJ32.T6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5648,7 +5648,7 @@ Pass    Pass
 [Contract "5H"]
 [Auction "S"]
 1D      Pass    2H      Pass
-2NT     Pass    3H      Pass
+2N     Pass    3H      Pass
 4D      Pass    4S      Pass
 5D      Pass    5H      Pass
 Pass    Pass    
@@ -5672,11 +5672,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT65.KT9.KQ854.K K873.Q63.AT6.J53 Q42.AJ52.J.A9764 J9.874.9732.QT82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5685,11 +5685,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:532.AKJ82.Q.AT96 9876.T3.JT92.853 KQJT.96.AK843.Q7 A4.Q754.765.KJ42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5711,11 +5711,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A7.AT942.65.KQ52 K53.863.AQT3.T97 QJ86.Q7.KJ92.A63 T942.KJ5.874.J84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5724,11 +5724,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q9.AK75.AT872.QT J82.J8.KJ65.K964 AK73.62.Q94.AJ82 T654.QT943.3.753"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5741,7 +5741,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -5750,12 +5750,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQJ74.J9.AT75.J5 T62.8542.96.AT72 9.AQT63.K82.KQ83 K853.K7.QJ43.964"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5764,12 +5764,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q2.AJ986.J8.KQT9 AT94.KT73.K6.752 K865.Q.AQT52.J64 J73.542.9743.A83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5778,11 +5778,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:52.AT982.K.KQJ97 KJT7.54.AQ5.T654 AQ84.KQ.J9862.A3 963.J763.T743.82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5791,12 +5791,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A3.A9.KQ97532.J4 K7652.T853.86.87 JT4.KJ64.J.AK632 Q98.Q72.AT4.QT95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 2D      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5809,8 +5809,8 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    4S      Pass
+2N     Pass    3S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -5844,12 +5844,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q82.QT7543.AQT.A 74.J62.9863.KQ82 AJ95.K9.KJ42.J95 KT63.A8.75.T7643"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
 2D      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5858,11 +5858,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:72.AJ52.AQ742.KJ QT84.43.KT9.Q532 A963.K76.J.A9874 KJ5.QT98.8653.T6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5871,11 +5871,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A5432.A.Q754.A93 J98.K965.862.K86 QT.JT874.AKT3.Q2 K76.Q32.J9.JT754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5884,11 +5884,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J964.AKQ73.8.K72 KQ2.9542.Q72.JT9 A53.6.AK543.A653 T87.JT8.JT96.Q84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5901,7 +5901,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4C      Pass    4S      Pass
 Pass    Pass    
 
@@ -5915,7 +5915,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5S      Pass    6C      Pass
 Pass    Pass    
 
@@ -5925,12 +5925,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AKQ87.A.T762.843 JT9.9875.AK.J972 4.KQJ32.J95.KQT6 6532.T64.Q843.A5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
 2H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5939,11 +5939,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQT974.A6.J2.A73 J32.K975.QT4.QT2 K.QJT82.A53.K654 865.43.K9876.J98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5969,7 +5969,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 5H      Pass    5S      Pass
 Pass    Pass    
 
@@ -5983,7 +5983,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4C      Pass
+3N     Pass    4C      Pass
 4H      Pass    5D      Pass
 Pass    Pass    
 
@@ -5993,11 +5993,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J.AK7.AK9864.732 A93.Q542.J73.J85 Q865.863.QT.AKQ6 KT742.JT9.52.T94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6010,7 +6010,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -6019,11 +6019,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AKT86.K642.A4.98 7432.QJ.J732.Q65 5.A85.KQT95.A732 QJ9.T973.86.KJT4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6032,11 +6032,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q3.AJT2.AT982.A3 JT942.753.J75.K5 AK85.86.K4.QT964 76.KQ94.Q63.J872"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6084,11 +6084,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AKJT7.KQ74.J.T97 8532.2.K8632.J52 Q.AT85.AT75.AQ43 964.J963.Q94.K86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6097,11 +6097,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J972.KQJ43.A.K75 K654.A982.J7.JT6 AQT3.T.K8543.AQ2 8.765.QT962.9843"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6110,11 +6110,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQJ9.JT.AJT73.J4 T86.953.Q652.986 52.AQ74.K8.AT753 K743.K862.94.KQ2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6123,11 +6123,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AKT9852.2.Q4.A82 73.Q9876.A53.T95 Q.AK53.KT86.J764 J64.JT4.J972.KQ3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6136,11 +6136,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AK975.QJ98.T6.QJ T8.7642.J9542.A2 Q2.K3.AKQ3.K9863 J643.AT5.87.T754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6149,12 +6149,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A.QJ753.AK862.83 QT863.962.J.AT65 J975.AK.Q74.KJ42 K42.T84.T953.Q97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6163,11 +6163,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A32.AQJT987.6.QJ QT94.532.K742.KT KJ8.K.AQJ98.8764 765.64.T53.A9532"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6189,12 +6189,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K96.K.KJ876.AJ94 QJT2.QJ92.A2.752 A75.AT65.54.KQT8 843.8743.QT93.63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2C      Pass
-3C      Pass    3NT     Pass
+1N     Pass    2C      Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6203,11 +6203,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT.KQJ64.QJ97.T4 8743.93.8653.AK3 KJ52.A8.KT.J9865 Q96.T752.A42.Q72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6216,11 +6216,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K.KT86.AT932.KQ6 QJ4.9732.KQ7.752 8532.AQJ.J6.A983 AT976.54.854.JT4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6233,7 +6233,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -6274,7 +6274,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -6283,11 +6283,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJT9.KT.AT876.K7 Q2.J764.Q93.QT65 A3.A982.J4.A9432 87654.Q53.K52.J8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6296,11 +6296,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AKQT852.Q42.Q.J6 J3.T76.J865.T952 9.KJ95.9743.AKQ3 764.A83.AKT2.874"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6309,11 +6309,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQ96.Q86.AQT74.7 8742.432.62.KQ85 J5.AJ97.K5.A9432 KT3.KT5.J983.JT6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6322,12 +6322,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AKJ84.832.J.AJ94 9763.AQ4.T976.32 2.JT95.AK32.KQT8 QT5.K76.Q854.765"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6353,7 +6353,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -6362,12 +6362,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J87.AKQ982.8.AT7 932.J5.QJ95.Q432 AKQ5.43.KT64.J86 T64.T76.A732.K95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
 2D      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6376,11 +6376,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:6.AK9543.J73.AQ9 KT432.8.T42.T632 A985.62.AQ98.K84 QJ7.QJT7.K65.J75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6393,7 +6393,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2H      Pass    3D      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -6407,7 +6407,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 4D      Pass    4H      Pass
 Pass    Pass    
 
@@ -6430,11 +6430,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AK6.KQJ932.8.T92 Q843.A84.74.QJ74 T95.5.AKJ53.A865 J72.T76.QT962.K3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6447,7 +6447,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -6456,11 +6456,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ753.AK75.Q72.J A864.Q9.84.T8762 2.T62.AK963.KQ93 JT9.J843.JT5.A54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6469,12 +6469,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:9.Q8432.AKJ87.KQ 842.J97.Q542.A72 AKQ7.A6.T96.J854 JT653.KT5.3.T963"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6487,7 +6487,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -6509,11 +6509,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ985.T8.A6.A854 AJT4.K763.QJ4.96 3.AQ95.K932.KQT7 762.J42.T875.J32"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6526,7 +6526,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3H      Pass
+2N     Pass    3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -6540,7 +6540,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 5D      Pass    Pass    Pass
 
 
@@ -6550,11 +6550,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A8.KQJ93.T2.AJT7 754.A5.J8643.964 QJT3.72.A75.KQ83 K962.T864.KQ9.52"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6563,12 +6563,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJ2.KJ976.7.KQ42 T973.T5.A64.AT75 KQ86.Q.KQ982.J98 54.A8432.JT53.63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2D      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6577,11 +6577,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K54.Q.Q9632.AK97 QJ87.J752.A4.T42 AT62.KT94.K7.Q86 93.A863.JT85.J53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6590,11 +6590,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQ6.AQ965.4.K765 JT74.J8.K985.JT8 32.K3.AT763.AQ93 K985.T742.QJ2.42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 2C      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6607,7 +6607,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -6616,11 +6616,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q7543..A98.AK974 A82.JT86.QJ53.65 KJ.AKQ93.KT64.T2 T96.7542.72.QJ83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1H      Pass    1S      Pass
 2D      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6629,11 +6629,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:76.AK943.76.AQ85 KJT9.J7.J53.T743 Q532.Q2.AQT2.KJ9 A84.T865.K984.62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1D      Pass    1H      Pass
 1S      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6642,10 +6642,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AKT3.AT.A5432.84 975.K963.QJ87.53 Q64.J542.9.AKQT6 J82.Q87.KT6.J972"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 

--- a/GIB/GIB_1C-P-1D.pbn
+++ b/GIB/GIB_1C-P-1D.pbn
@@ -4,11 +4,11 @@
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:632.KQT.AKT43.K2 JT95.975.52.A984 KQ7.A64.Q98.QJ53 A84.J832.J76.T76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1NT     Pass    2H      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2H      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -17,12 +17,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QT2.A63.KQT653.6 AJ96.982.AJ4.J54 K753.KQ4.98.AQ87 84.JT75.72.KT932"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -31,10 +31,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J3.Q63.KQT64.JT5 862.J52.J9752.A6 KQ54.AK7.A3.K943 AT97.T984.8.Q872"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -56,10 +56,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:652.AT3.AQJ84.52 T984.Q97.752.Q93 AK7.KJ8.KT3.AT87 QJ3.6542.96.KJ64"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -68,11 +68,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q632.KQ.Q9642.A7 AJ84.JT98.KJ8.64 K.A52.A75.KQJT95 T975.7643.T3.832"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 3C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -81,12 +81,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:95.97.KJT9873.T9 K72.JT543.Q62.J4 QJ43.AK8.A.KQ832 AT86.Q62.54.A765"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2D      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -95,12 +95,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q9.KT7.AKQT65.84 A864.8653.842.63 K2.AQJ9.7.KQJT75 JT753.42.J93.A92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -121,11 +121,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:64.KQ3.A75432.JT 873.7642.KQ.9743 KQ92.AJ95.8.AQ86 AJT5.T8.JT96.K52"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -137,7 +137,7 @@ Pass    Pass
 [Contract "2D"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 Pass    Pass    
 
 
@@ -158,11 +158,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A82.KQ5.KJ765.JT J5.JT9.QT842.K98 KT4.A764.A.Q7632 Q9763.832.93.A54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -171,11 +171,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:53.KQT.QJ754.Q65 KT62.A6.AT83.732 A94.J954.6.AKT84 QJ87.8732.K92.J9"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    1NT     Pass
-2C      Pass    2NT     Pass
+1H      Pass    1N     Pass
+2C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -184,11 +184,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:754.43.AQ9832.J6 QT83.QT76.75.KQ7 AK.KJ92.K4.AT932 J962.A85.JT6.854"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -197,11 +197,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A.QT5.J9852.QJ94 KT875.72.A63.853 QJ42.KJ84.K7.AT2 963.A963.QT4.K76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -210,12 +210,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:952.K86.KQJ72.A5 AT83.975.AT9.987 KJ74.AQ4.6.QT643 Q6.JT32.8543.KJ2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -224,10 +224,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:52.Q542.AQ6532.K JT864.KT83..Q732 A93.76.KJT.AJT96 KQ7.AJ9.9874.854"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -236,10 +236,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T843.K3.AK987.K5 962.JT642.3.A972 AKQ.985.Q42.QJ64 J75.AQ7.JT65.T83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -248,11 +248,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J87.KJ3.K9843.A5 K963.76.AT6.7642 A542.AT54.Q.KQT8 QT.Q982.J752.J93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -261,11 +261,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:JT6.Q62.AQJ96.T3 7532.T8753.T7.K8 A4.A4.K53.AJ9642 KQ98.KJ9.842.Q75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 2C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -274,11 +274,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJ4.T82.KQJ632.Q 872.A64.T54.9862 AQ96.QJ75.8.AJT3 T53.K93.A97.K754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -299,11 +299,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A642.42.AKJ76.JT K.J975.T842.K943 JT3.AKT8.Q.A8652 Q9875.Q63.953.Q7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -336,11 +336,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T87.Q42.AKJ7.K74 932.AT83.QT96.QJ AKJ5.97.54.AT832 Q64.KJ65.832.965"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -362,12 +362,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K62.T63.AK642.T6 J983.AJ75.J97.92 754.KQ98.8.AKJ84 AQT.42.QT53.Q753"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    1NT     Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1H      Pass    1N     Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -376,10 +376,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J83.Q94.QT832.A2 7652.KT832.75.K7 AK9.A.AJ94.QJT83 QT4.J765.K6.9654"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -391,7 +391,7 @@ Pass    Pass
 [Contract "3C"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 3C      Pass    Pass    Pass
 
 
@@ -427,10 +427,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJ5.862.A932.K82 72.KJ75.JT87.JT4 9843.A9.Q65.AQ75 AQT6.QT43.K4.963"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -439,11 +439,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:43.J4.AK7642.AT6 Q6.T752.QT98.KJ2 AKT9.AK63.J.9754 J8752.Q98.53.Q83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -452,10 +452,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:875.Q84.AT73.KQ7 962.AT96.K95.T54 AKQT.KJ53.J2.AJ3 J43.72.Q864.9862"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -464,11 +464,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J74.T43.AQJ86.Q8 KT98.K5.T932.K76 AQ32.AJ82.7.AT54 65.Q976.K54.J932"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1H      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -477,10 +477,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q54.87.AKJ93.T43 AT72.Q953.T5.A86 K983.A642.Q2.KJ5 J6.KJT.8764.Q972"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -489,13 +489,13 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QT.K5.AK943.Q643 J974.98742.6.K92 A52.AJT6.J72.A75 K863.Q3.QT85.JT8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -508,7 +508,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -517,11 +517,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJ9.53.KQJ632.53 QT3.KJ84.987.J87 K65.AQ.54.AKQT62 8742.T9762.AT.94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -530,12 +530,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AJ7.953.A832.KJ6 K643.A6.QT97.Q54 QT52.KQ8.K54.A97 98.JT742.J6.T832"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3C      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3C      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -544,10 +544,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ7.JT2.A8642.A5 963.974.QT95.T42 Q42.AKQ3.K3.KJ96 AT85.865.J7.Q873"]
-[Contract "4NT"]
+[Contract "4N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    4NT     Pass
+2N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -556,10 +556,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQ3.K75.Q8765.T6 J6542.Q62.J4.K75 A7.AJ3.AKT.Q9842 T98.T984.932.AJ3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -568,13 +568,13 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A5.J.JT8753.AQJ6 KJT4.Q96.Q6.8542 Q83.AT73.K94.K97 9762.K8542.A2.T3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -597,11 +597,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AK7.53.KT8762.92 T984.K964.AJ.Q86 J653.AQ82.Q.KJT5 Q2.JT7.9543.A743"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -610,12 +610,12 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A65.873.AT743.AJ QT2.KT5.QJ8.Q942 KJ74.AJ2.K6.T853 983.Q964.952.K76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -628,8 +628,8 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    2H      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    2N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -639,11 +639,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQ3.Q965.QJT65.Q J75.J872.A72.J82 K964.K.98.AKT976 T82.AT43.K43.543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 

--- a/GIB/GIB_1C-P-1H.pbn
+++ b/GIB/GIB_1C-P-1H.pbn
@@ -4,10 +4,10 @@
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K74.J753.Q75.KJ7 QT3.Q842.J64.654 A652.AT9.A93.Q92 J98.K6.KT82.AT83"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -16,10 +16,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K85.A652.T75.Q87 A6.JT83.J863.KT4 9742.K94.AQ4.AJ5 QJT3.Q7.K92.9632"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -28,10 +28,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A752.QT98.QJ5.J8 KQ3.7632.962.K52 86.AJ.K874.AT976 JT94.K54.AT3.Q43"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -52,10 +52,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:754.Q732.876.AT5 KJ96.T86.J94.432 AQT2.KJ5.K32.KQ9 83.A94.AQT5.J876"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      1D      1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -64,10 +64,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJ74.KJ96.J963.T 9863.Q74.AKT5.J6 A2.AT2.842.AQ852 QT5.853.Q7.K9743"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -128,11 +128,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:872.AKT2.T7.T652 Q96.9843.KQ84.Q3 KJ3.J.A932.AKJ94 AT54.Q765.J65.87"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2D      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -141,11 +141,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q72.AJT3.JT8.QJT T43.K974.KQ73.82 AK96.852.92.AK63 J85.Q6.A654.9754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -154,10 +154,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJT7.J653.QJ7.65 8432.Q2.KT62.KT2 Q5.A98.A54.A8743 A96.KT74.983.QJ9"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -166,11 +166,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J864.J843.AT3.83 75.KT95.K75.KT65 AK3.Q72.Q8.AQJ97 QT92.A6.J9642.42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -179,10 +179,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T62.AT97.T6.A642 A94.8654.K943.87 KQJ.KJ2.QJ5.KQJ9 8753.Q3.A872.T53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -204,10 +204,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AT6.K642.T742.86 J432.QJ.K985.A73 K85.853.AQ.KQ942 Q97.AT97.J63.JT5"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -219,7 +219,7 @@ Pass    Pass
 [Contract "3C"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -229,11 +229,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:95.AKJ4.Q95.JT63 QJT.T5.KT74.A985 AK32.Q98.A63.KQ7 8764.7632.J82.42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3C      Pass
-3H      Pass    3NT     Pass
+2N     Pass    3C      Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -242,11 +242,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJ83.KQ42.K54.85 AT52.987.QJ.KJT9 Q7.A6.AT3.AQ7643 964.JT53.98762.2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -268,11 +268,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KT84.QT86.K873.3 J765.54.AJ2.9865 Q92.AK3.Q94.AQJ4 A3.J972.T65.KT72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -281,10 +281,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QJ92.KQ82.K3.Q83 T653.943.AJ64.K4 AK.A76.T2.AJ9652 874.JT5.Q9875.T7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -293,11 +293,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJ43.QT64.QJ8.J9 Q972.K93.T72.T63 A65.A82.A54.AK85 T8.J75.K963.Q742"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -319,10 +319,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QT.AQ98.965.QT32 K765.T632.J42.K7 J93.74.AK7.AJ954 A842.KJ5.QT83.86"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -331,11 +331,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:853.QT76.AK3.KQ4 J72.A542.QT72.65 AQ9.J.J94.AJ9832 KT64.K983.865.T7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -357,10 +357,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KQ73.KQ92.Q75.Q8 J652.64.J9863.J2 98.J83.AT4.AKT64 AT4.AT75.K2.9753"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -393,11 +393,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:65.AJ87.QJ9875.5 8732.Q9652.2.A96 AQJ4.K4.KT.QJT42 KT9.T3.A643.K873"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1S      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -409,7 +409,7 @@ Pass    Pass
 [Contract "3D"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3D      Pass
+1N     Pass    3D      Pass
 Pass    Pass    
 
 
@@ -418,11 +418,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QT63.AKT6.Q53.T8 975.J984.AT.KJ96 AJ2.752.K98.AQ74 K84.Q3.J7642.532"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -431,10 +431,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:864.A753.852.AJ2 T732.KQ2.T96.KQ7 AKJ5.J64.KJ7.983 Q9.T98.AQ43.T654"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -443,10 +443,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:43.AT42.KJT2.J62 AKT2.K93.876.T75 J96.J8.A53.AK983 Q875.Q765.Q94.Q4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -455,10 +455,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K75.J976.863.A95 AT842.K832.T42.4 Q6.Q5.AK75.QJ863 J93.AT4.QJ9.KT72"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -467,10 +467,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AT8.AJ52.Q984.A6 K932.QT8.K75.Q52 J65.K3.A6.KJT984 Q74.9764.JT32.73"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -479,10 +479,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KT.A632.AQJT.T84 AQJ2.QT7.984.J53 974.KJ4.K2.AK972 8653.985.7653.Q6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -491,11 +491,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQT7.T975.A4.Q98 A862.J832.T762.3 J4.AKQ.KQ5.AT765 953.64.J983.KJ42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -504,10 +504,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KT92.AT75.K973.A Q865.J863.QJ.873 AJ7.Q.A65.KT6542 43.K942.T842.QJ9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -532,7 +532,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -541,10 +541,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T64.J752.AQ82.95 K53.KQ3.943.Q842 AJ87.986.T65.AKT Q92.AT4.KJ7.J763"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -578,11 +578,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J43.K973.KQ752.Q A987.Q862.J43.K4 KQT2.JT4.A.AJ862 65.A5.T986.T9753"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -594,7 +594,7 @@ Pass    Pass
 [Contract "6H"]
 [Auction "S"]
 1C      Pass    1H      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -605,10 +605,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q9.AKJ7.Q862.T73 84.532.JT94.QJ98 AJ72.64.AK7.AK42 KT653.QT98.53.65"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -617,9 +617,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K92.K653.QJ76.QT T874.AJT4.A9.963 A653.Q8.853.AK42 QJ.972.KT42.J875"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 

--- a/GIB/GIB_1C-P-1N.pbn
+++ b/GIB/GIB_1C-P-1N.pbn
@@ -4,9 +4,9 @@
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T73.J84.A62.AJ62 J94.K95.KJ83.K93 AQ2.AQT7.T97.QT4 K865.632.Q54.875"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -15,10 +15,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QT7.T87.AJ74.853 K43.643.953.AQJT AJ86.AKQ.Q8.K972 952.J952.KT62.64"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -27,10 +27,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KJ6.T94.J42.K832 985.J62.9653.AT9 AQT.A53.AKT.Q754 7432.KQ87.Q87.J6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -41,7 +41,7 @@ Pass    Pass
 [Deal "N:A98.763.KQ97.J32 7432.KT95.JT.Q96 Q5.AJ2.632.AKT75 KJT6.Q84.A854.84"]
 [Contract "2S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2S
 Pass    Pass    Pass    
 
@@ -51,11 +51,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:72.Q96.KJT3.QT52 J9864.753.A942.3 AKT5.AKJ.8.KJ874 Q3.T842.Q765.A96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -64,10 +64,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:JT7.KQ.QJ82.7642 9862.J652.KT76.T A53.T93.A.AKQ983 KQ4.A874.9543.J5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3C      Pass    3NT     Pass
+1C      Pass    1N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -76,10 +76,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QT8.A82.T762.KT2 K943.T95.KQJ4.85 AJ5.KQ43.A8.A763 762.J76.953.QJ94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -88,11 +88,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QT3.J43.AT43.Q64 A965.T872.J98.K9 KJ72.AK.Q2.AJ752 84.Q965.K765.T83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -101,10 +101,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q86.Q43.KT52.T86 J532.72.Q873.QJ2 94.AK98.AJ9.AK75 AKT7.JT65.64.943"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -113,10 +113,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A86.KT3.QJ76.864 T94.9874.9432.A7 K32.A62.AK8.KQT5 QJ75.QJ5.T5.J932"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -125,11 +125,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J96.A76.Q762.765 AT432.J98.T85.98 K.KT32.AJ9.AKQ43 Q875.Q54.K43.JT2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -138,10 +138,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A98.JT7.Q76.T743 QT76.A9865.985.6 K3.32.AK4.AQJ982 J542.KQ4.JT32.K5"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -150,10 +150,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K43.862.K52.A952 Q652.KT4.Q3.KJ87 AJ8.AQ5.AJ4.QT64 T97.J973.T9876.3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -162,9 +162,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AJ9.K95.T986.Q92 KQ64.T74.KJ42.J4 853.QJ6.AQ.A8753 T72.A832.753.KT6"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -173,9 +173,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q87.Q76.K75.K983 JT53.AT2.QT2.A42 AK92.K985.J9.QT6 64.J43.A8643.J75"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -186,7 +186,7 @@ Pass    Pass
 [Deal "N:752.T74.AQ95.T96 863.K863.T7.AK85 JT94.AQJ.K32.Q42 AKQ.952.J864.J73"]
 [Contract "2H"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2H
 Pass    Pass    Pass    
 
@@ -196,9 +196,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J9.T93.QJ84.AJ54 Q75.K765.9763.Q2 A643.QJ42.K5.K96 KT82.A8.AT2.T873"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -207,9 +207,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:954.K9.QT43.AJ32 KQJ8.J863.K86.T7 A632.T42.AJ2.KQ5 T7.AQ75.975.9864"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -220,7 +220,7 @@ Pass    Pass
 [Deal "N:873.KT.A742.Q964 T96.Q432.QT8.AK7 AQ2.A986.J3.JT52 KJ54.J75.K965.83"]
 [Contract "2H"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2H
 Pass    Pass    Pass    
 
@@ -232,7 +232,7 @@ Pass    Pass    Pass
 [Deal "N:J54.J32.K942.K87 AT2.T76.A75.QJ53 KQ63.KQ4.QT6.T64 987.A985.J83.A92"]
 [Contract "2S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2S
 Pass    Pass    Pass    
 
@@ -242,9 +242,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AT7.Q32.JT32.865 9864.98.KQ94.KJT Q32.K754.A85.A74 KJ5.AJT6.76.Q932"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -253,9 +253,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:754.986.AK32.K97 AQ6.KT75.9854.T5 KT82.QJ3.J7.AJ43 J93.A42.QT6.Q862"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -264,10 +264,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ6.Q85.843.J765 974.762.Q765.T42 KT3.A943.AJT.AQ3 J852.KJT.K92.K98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -276,9 +276,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A42.42.J854.AJ74 J97.765.AT63.653 Q86.AQT8.K72.K92 KT53.KJ93.Q9.QT8"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -289,7 +289,7 @@ Pass    Pass
 [Deal "N:T87.A72.KJ65.763 A6.K984.Q97.8542 Q952.Q5.AT2.KQJT KJ43.JT63.843.A9"]
 [Contract "2H"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2H
 Pass    Pass    Pass    
 
@@ -301,7 +301,7 @@ Pass    Pass    Pass
 [Deal "N:K2.752.KT85.Q962 AJT3.T86.J9.AT83 764.AKJ3.763.KJ5 Q985.Q94.AQ42.74"]
 [Contract "2S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2S
 Pass    Pass    Pass    
 
@@ -311,11 +311,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:64.Q75.8753.AT74 K752.64.KQ92.865 AJT9.AKJ3.T.KJ93 Q83.T982.AJ64.Q2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2H      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -324,9 +324,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJT.J9.QJ52.JT65 A32.852.K986.A97 Q87.AKT3.743.KQ4 9654.Q764.AT.832"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -337,7 +337,7 @@ Pass    Pass
 [Deal "N:JT5.53.AKJ5.J943 A843.T96.Q62.KT7 K96.KJ72.43.AQ86 Q72.AQ84.T987.52"]
 [Contract "2S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2S
 Pass    Pass    Pass    
 
@@ -347,10 +347,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQ9.T85.AT95.T74 T843.Q9.832.J953 J52.AK64.KJ.AK62 A76.J732.Q764.Q8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -359,10 +359,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:643.A87.A752.987 Q972.Q65.JT.J653 AK.K932.Q84.AK42 JT85.JT4.K963.QT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -371,9 +371,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q9.K32.T985.AJ63 842.J84.AQ63.K98 AKJT.A765.72.Q72 7653.QT9.KJ4.T54"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -384,7 +384,7 @@ Pass    Pass
 [Deal "N:J64.A62.JT9.J986 T985.QT5.AQ73.QT AQ.K987.854.K542 K732.J43.K62.A73"]
 [Contract "2S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2S
 Pass    Pass    Pass    
 
@@ -394,10 +394,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A64.T86.QJ42.Q94 9832.J42.73.AJ83 KJ5.AKQ.K95.K762 QT7.9753.AT86.T5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -406,10 +406,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AT5.854.QT75.QT4 962.J63.AKJ2.875 KQ7.AKQ7.96.KJ96 J843.T92.843.A32"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -420,7 +420,7 @@ Pass    Pass
 [Deal "N:T2.KT3.AT87.KT74 QJ96.842.J63.QJ2 A743.Q975.K2.A85 K85.AJ6.Q954.963"]
 [Contract "2S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2S
 Pass    Pass    Pass    
 
@@ -430,11 +430,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A96.943.QJT3.Q64 842.J6.A8742.T93 KT5.KQT7.6.AKJ82 QJ73.A852.K95.75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2H      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -445,7 +445,7 @@ Pass    Pass
 [Deal "N:A84.AJT.T83.T753 Q762.652.A62.J94 J95.K874.Q75.AK6 KT3.Q93.KJ94.Q82"]
 [Contract "2S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2S
 Pass    Pass    Pass    
 
@@ -455,9 +455,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:632.K82.KT94.Q52 AT98.AJT9.J63.T6 QJ74.76.AQ5.AJ83 K5.Q543.872.K974"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -468,7 +468,7 @@ Pass    Pass
 [Deal "N:KJ.J93.T742.KT82 T97.KT5.J86.AQ64 AQ54.8764.AK.973 8632.AQ2.Q953.J5"]
 [Contract "2S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2S
 Pass    Pass    Pass    
 
@@ -480,7 +480,7 @@ Pass    Pass    Pass
 [Deal "N:JT4.AJ2.K73.T852 A63.T743.J865.K4 K982.K95.A4.Q976 Q75.Q86.QT92.AJ3"]
 [Contract "2H"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2H
 Pass    Pass    Pass    
 
@@ -490,9 +490,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K53.832.Q984.J73 A74.T65.K653.AT6 QJ82.QJ4.AT7.K95 T96.AK97.J2.Q842"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -501,9 +501,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A43.T75.KJ84.T42 62.K832.Q632.AJ8 JT75.A9.A75.KQ63 KQ98.QJ64.T9.975"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -512,9 +512,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A86.952.AT2.Q984 K32.QT43.J954.AT 975.AK86.KQ3.J63 QJT4.J7.876.K752"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -525,7 +525,7 @@ Pass    Pass
 [Deal "N:QJ5.954.AT64.Q82 T962.A72.K98.JT4 874.KQ86.Q7.AK93 AK3.JT3.J532.765"]
 [Contract "2S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2S
 Pass    Pass    Pass    
 
@@ -535,9 +535,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:987.A72.Q972.842 T5.JT43.AK5.QT76 AQJ2.KQ98.84.J53 K643.65.JT63.AK9"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -546,10 +546,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T85.QJ9.AT3.JT65 J972.A62.Q8765.2 AQ3.KT7.J9.AKQ83 K64.8543.K42.974"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -560,7 +560,7 @@ Pass    Pass
 [Deal "N:K74.Q5.QT98.QT98 A93.K862.7543.54 QJ2.AT97.2.AKJ63 T865.J43.AKJ6.72"]
 [Contract "2HX"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Db      Pass    2H
 Db      Pass    Pass    Pass
 
@@ -571,10 +571,10 @@ Db      Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A82.A32.843.J852 T973.T97.752.QT7 K54.KQJ8.AJ6.A64 QJ6.654.KQT9.K93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -583,8 +583,8 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQT.JT2.JT94.T43 KJ83.8765.65.KJ7 7542.A94.KQ3.A92 96.KQ3.A872.Q865"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 

--- a/GIB/GIB_1C-P-1S.pbn
+++ b/GIB/GIB_1C-P-1S.pbn
@@ -16,10 +16,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AJT9.Q3.J9853.Q3 82.AJ86.KQ7.J752 KQ6.KT74.642.A86 7543.952.AT.KT94"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -28,10 +28,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A986.A6.K963.J93 T54.QJ93.QJT7.72 732.754.A4.AKQT8 KQJ.KT82.852.654"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -43,7 +43,7 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 3S      Pass    4D      Pass
 5C      Pass    6C      Pass
 Pass    Pass    
@@ -54,11 +54,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KJ97.KT5.A962.72 AT853.762.85.J63 Q6.AQ93.Q43.AT54 42.J84.KJT7.KQ98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -67,10 +67,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:8642.A82.K865.QT T97.KT7.JT2.K853 AK3.654.AQ3.J642 QJ5.QJ93.974.A97"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -79,10 +79,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J965.Q95.A843.J6 743.JT4.QJ62.K74 AQ.A82.T9.AQT982 KT82.K763.K75.53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -91,10 +91,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QJ62.AK7.Q83.762 KT.JT85.J65.QJ85 754.Q42.AK7.KT93 A983.963.T942.A4"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -103,10 +103,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:7652.JT.KQT74.A4 KT8.7652.A83.K32 A4.AK94.J92.9865 QJ93.Q83.65.QJT7"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -128,10 +128,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J964.J9.KJ853.J9 T53.T752.42.A874 AQ7.AKQ.T96.KT63 K82.8643.AQ7.Q52"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -140,10 +140,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K843.AT9.A982.T8 AT92.Q84.643.653 J75.K72.J75.AKJ9 Q6.J653.KQT.Q742"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -152,10 +152,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K542.K83.Q43.Q92 T876.95.AJ8.AJT3 AJ.AQT4.T76.K876 Q93.J762.K952.54"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -164,11 +164,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T982.J.Q7654.KT6 QJ6.QT85.J32.QJ5 AK5.A963.A.A9872 743.K742.KT98.43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2H      Pass    2NT     Pass
-3S      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -201,10 +201,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J962.K73.AJ543.6 Q75.AJ65.K98.T75 AT3.QT4.QT.AJ932 K84.982.762.KQ84"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -213,10 +213,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJ76.KT6.QJ7.J86 852.A84.942.AT93 AQ.J953.T86.KQ74 T943.Q72.AK53.52"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -225,11 +225,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AK63.K64.Q543.72 9872.A92.T92.Q96 T5.QT3.K86.AKJ43 QJ4.J875.AJ7.T85"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -262,10 +262,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:JT76.Q86.A5.8653 K853.A73.QJT3.T2 A9.K95.K8.AKQJ74 Q42.JT42.97642.9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -277,7 +277,7 @@ Pass    Pass
 [Contract "4S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -299,11 +299,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AT72.KJ4.T83.A62 864.A532.J64.543 53.Q7.AKQ5.KT987 KQJ9.T986.972.QJ"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -312,10 +312,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:8762.876.K7642.A K53.J42.QJ5.Q753 J9.KQT9.A83.KJ96 AQT4.A53.T9.T842"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -324,10 +324,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J854.K85.K4.KQT4 T62.AT64.J873.73 A73.QJ2.652.AJ65 KQ9.973.AQT9.982"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -336,11 +336,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQJ8.T9.J8642.93 AT32.J754.Q9.K65 6.AK83.A5.AQJT42 9754.Q62.KT73.87"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2H      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -374,10 +374,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QJ52.A75.AJT.Q54 K87.QJ93.75.KT32 A96.T842.K62.AJ7 T43.K6.Q9843.986"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -412,10 +412,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A943.963.Q974.K3 JT2.JT75.K652.Q4 865.KQ4.AJ.AT982 KQ7.A82.T83.J765"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -451,10 +451,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ75.94.T965.642 9843.KQ87.KQ7.83 T2.A653.A2.AJT75 KJ6.JT2.J843.KQ9"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -476,10 +476,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QT84.Q75.KT54.64 62.J94.Q9873.JT7 A97.AKT3.AJ.K852 KJ53.862.62.AQ93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -500,11 +500,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AK76.J63.875.J87 QT4.T952.QJ2.632 85.KQ.KT93.AKQT5 J932.A874.A64.94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -513,10 +513,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:JT96.6.KT632.K86 873.T8753.4.A932 Q52.KQJ2.AQJ.QJ7 AK4.A94.9875.T54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -525,10 +525,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QJ62.JT5.7432.A7 AT98.Q982.QJT.T2 73.K74.K65.KQJ85 K54.A63.A98.9643"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -549,10 +549,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AKT5.J83.JT2.A94 8642.QT5.K854.53 Q3.AK4.Q76.QJ762 J97.9762.A93.KT8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -561,11 +561,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KT75.K43.A54.Q82 A9432.J8.JT86.63 8.AQ72.Q97.AKT95 QJ6.T965.K32.J74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -574,10 +574,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QJ84.J7.QJ72.963 T52.Q643.963.AQJ K97.K52.AK4.T542 A63.AT98.T85.K87"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -586,10 +586,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:9653.KT2.KT75.97 J72.J85.AQ2.J654 AKT.AQ96.J64.KQ3 Q84.743.983.AT82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -598,11 +598,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQT2.T54.QJ64.K2 8543.Q8.9872.A54 KJ.KJ97.K5.QJ873 976.A632.AT3.T96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -611,10 +611,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K874.9.A632.KT73 J93.QT85.J87.Q62 AQT.AJ72.Q4.AJ54 652.K643.KT95.98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3C      Pass
-3S      Pass    3NT     Pass
+2N     Pass    3C      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 

--- a/GIB/GIB_1C-P-2C.pbn
+++ b/GIB/GIB_1C-P-2C.pbn
@@ -4,10 +4,10 @@
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQT.K62.A52.J962 764.A85.Q93.A875 K53.Q974.K6.KQ43 J982.JT3.JT874.T"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -16,10 +16,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A32.J64.K4.KQ862 J7.K852.AQJ3.973 Q95.AQ97.876.AT5 KT864.T3.T952.J4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -28,10 +28,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A94.KT8.JT8.AKT3 76.J932.A432.Q92 KQ85.AQ6.Q9.J765 JT32.754.K765.84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -52,10 +52,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQT.64.AQ4.98652 863.KQJ9.J985.Q7 7542.AT2.K2.AKT3 KJ9.8753.T763.J4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -64,10 +64,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q9.J5.K984.AKT76 AJ32.Q432.T76.94 K864.K98.A52.Q53 T75.AT76.QJ3.J82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -76,11 +76,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AT.A9.J987.AQ975 J5432.QT7.QT64.6 Q9.KJ3.K5.KJ8432 K876.86542.A32.T"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -89,10 +89,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q32.J87.AJT.AJ92 J9765.965.K6.K87 AT8.AKT3.985.QT6 K4.Q42.Q7432.543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -101,10 +101,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AK.AT4.T85.K7652 T5432.J85.A762.4 Q87.K96.QJ3.A983 J96.Q732.K94.QJT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -113,11 +113,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q3.T6.AK53.KQ432 852.Q752.JT6.AT8 A764.AKJ4.74.765 KJT9.983.Q982.J9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
 2H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -126,10 +126,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:976.JT9.AT2.AKQ7 A52.A653.Q954.84 QJ83.KQ2.KJ.6532 KT4.874.8763.JT9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -150,10 +150,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K42.A8.QJ63.K652 J8753.K62.K54.84 A96.JT94.A7.QJT7 QT.Q753.T982.A93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -162,10 +162,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQ5.653.KT8.AJ98 A93.J74.QJ97.654 J862.AK98.5.KQ32 T74.QT2.A6432.T7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -174,10 +174,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K74.KQ8.Q86.A643 T93.94.K954.K985 AQJ5.A75.J7.JT72 862.JT632.AT32.Q"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -186,10 +186,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q5.AK9.QT8.Q8754 JT83.J84.K972.T3 AK2.Q632.A54.AJ9 9764.T75.J63.K62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -198,11 +198,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ5.K3.J96.JT764 J9874.Q97.AT42.8 32.AJ85.K53.A532 AT6.T642.Q87.KQ9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -211,10 +211,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:64.AT7.A94.QT643 K95.9643.T862.82 AQ72.K8.J53.AKJ5 JT83.QJ52.KQ7.97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -226,7 +226,7 @@ Pass    Pass
 [Contract "3C"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 Pass    Pass    
 
 
@@ -235,11 +235,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q7.983.KJ7.AT632 K832.QT5.QT4.Q87 AJ6.AJ42.983.KJ4 T954.K76.A652.95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -248,10 +248,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A65.J8.T6.KQT983 K932.KT65.J8532. QJT.A732.AK9.A76 874.Q94.Q74.J542"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -260,10 +260,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J74.QT8.Q4.AKQT9 32.K643.T752.J53 KQ96.A97.KJ9.862 AT85.J52.A863.74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -272,10 +272,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K43.AK9.K53.Q864 986.Q5432.Q762.5 QJ2.T86.AT8.AJ93 AT75.J7.J94.KT72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -287,7 +287,7 @@ Pass    Pass
 [Contract "3C"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 Pass    Pass    
 
 
@@ -296,11 +296,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T94.Q63.AKT.A865 A53.J754.Q743.K3 KQ7.AK82.52.Q742 J862.T9.J986.JT9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
 2H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -312,7 +312,7 @@ Pass    Pass
 [Contract "5C"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    4C      Pass
+2N     Pass    4C      Pass
 5C      Pass    Pass    Pass
 
 
@@ -322,11 +322,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:54.843.AKQ3.JT54 AJT9.AT9.T972.82 KQ7.QJ7.J8.AKQ76 8632.K652.654.93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
 2H      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -335,11 +335,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A82.T73.AQ5.K987 T93.A984.KJ86.Q5 KQJ7.J652.74.AJ3 654.KQ.T932.T642"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -348,10 +348,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A7.KQ8.A832.J963 9852.54.KQT.A875 KJ64.AT32.J6.KQ4 QT3.J976.9754.T2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -360,10 +360,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A5.KJ3.J975.AJ87 K842.T7.Q32.Q642 Q63.AQ96.A6.T953 JT97.8542.KT84.K"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -372,10 +372,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A53.AJ4.532.A764 KJ8.T53.J874.T32 9762.KQ82.K6.KQ5 QT4.976.AQT9.J98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -384,10 +384,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q7.KT8.AK2.Q8532 J8542.J543.654.K AK3.976.QT7.AJT7 T96.AQ2.J983.964"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -396,10 +396,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q2.Q75.AKJ.KT653 JT6.A962.QT74.72 AK8.KT43.983.QJ4 97543.J8.652.A98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -408,10 +408,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AK.QT3.984.AJ542 J7432.976.JT7.K9 QT5.AK8.K63.Q763 986.J542.AQ52.T8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -423,7 +423,7 @@ Pass    Pass
 [Contract "3C"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    2NT     Pass
+2S      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -433,10 +433,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KT3.A4.Q84.A9542 J542.T97.J765.87 AQ96.KJ62.A3.KJ6 87.Q853.KT92.QT3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -445,11 +445,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:6.Q9.KT32.AQ9752 98542.JT75.A964. AQJ7.AK83.Q.T643 KT3.642.J875.KJ8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
 2H      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -458,10 +458,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q95.Q83.T3.AKJ62 J763.974.AK87.54 KT82.AK2.Q96.873 A4.JT65.J542.QT9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -470,10 +470,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A73.854.AQJ.A642 KJ84.J63.KT97.75 Q52.AKQ9.84.QJT3 T96.T72.6532.K98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -482,10 +482,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQJ.J2.J62.KJ965 K6.97653.K54.742 T87.AQ4.QT3.AQT8 95432.KT8.A987.3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -494,10 +494,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K63.AQT.83.KJ962 AJ74.9853.AT9.54 QT9.K764.KJ5.AT7 852.J2.Q7642.Q83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -506,11 +506,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q2.A5.QJ72.Q6432 643.T962.AT986.9 KJ95.KQJ3.4.AJ87 AT87.874.K53.KT5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
 2H      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -519,10 +519,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T6.83.KJ72.AKQ72 Q8754.754.A53.J6 AKJ2.AKJ.Q84.T94 93.QT962.T96.853"]
-[Contract "4NT"]
+[Contract "4N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -531,11 +531,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J8.A92.KJ65.KQ54 AT63.KT8.QT87.83 Q52.QJ54.A.AT976 K974.763.9432.J2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
 2D      Pass    2H      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -559,7 +559,7 @@ Pass    Pass
 [Contract "5C"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -569,10 +569,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q.J32.AQ64.J9753 K6542.65.T82.A42 AJ7.KQT4.KJ9.KQT T983.A987.753.86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -581,10 +581,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A85.AQ7.QJ9.J974 J2.T53.AKT4.K632 KQ64.K6.73.AQT85 T973.J9842.8652."]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -593,10 +593,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q96.K84.KQ7.K762 JT5.63.T9432.984 K3.AQ72.AJ6.AJT5 A8742.JT95.85.Q3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -605,9 +605,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJ8.A7.Q764.A952 752.8532.T985.J3 AT96.KQJ6.K.Q874 Q43.T94.AJ32.KT6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 

--- a/GIB/GIB_1C-P-2N.pbn
+++ b/GIB/GIB_1C-P-2N.pbn
@@ -4,10 +4,10 @@
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K32.J76.AQJ9.T32 T74.Q82.872.A764 J965.AK5.KT6.Q98 AQ8.T943.543.KJ5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -16,10 +16,10 @@
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QT6.AK8.Q654.J73 98752.JT75.J8.A4 KJ3.942.AK7.K862 A4.Q63.T932.QT95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -28,10 +28,10 @@
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J52.QJT.AT7.K653 KT84.K7.Q832.987 A963.A843.96.AJ2 Q7.9652.KJ54.QT4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -40,10 +40,10 @@
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A86.J42.KT85.QJ9 J975.QT9.J942.K2 KQ.K753.Q3.A7543 T432.A86.A76.T86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -52,10 +52,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A93.A43.9843.QJ8 KJT4.T86.75.9642 875.KJ97.K62.AK5 Q62.Q52.AQJT.T73"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -64,10 +64,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AT9.A7.J932.KT93 75.943.A654.J765 J843.QJ85.K8.AQ4 KQ62.KT62.QT7.82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -76,10 +76,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:542.A4.A752.A762 T83.Q7632.T4.985 AKJ6.K85.KQ9.Q43 Q97.JT9.J863.KJT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -88,10 +88,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K42.Q63.AK72.763 63.KJ54.J983.AT2 AQT5.AT87.QT.Q98 J987.92.654.KJ54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -100,10 +100,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AK.983.J973.K872 653.Q65.KT62.654 QT74.AJ2.A8.QJ93 J982.KT74.Q54.AT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -112,9 +112,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQ6.J74.AT97.742 K5.KQ6.J542.Q863 943.T832.KQ8.AK5 JT872.A95.63.JT9"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -123,10 +123,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q52.972.KQJ.K752 K76.T853.T932.QT A984.KQJ.A87.A86 JT3.A64.654.J943"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -135,10 +135,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q8.T83.AKQ9.T985 AJT9.74.652.K732 K742.AKJ.T87.AQJ 653.Q9652.J43.64"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -147,10 +147,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J97.Q8.Q632.AK76 AQT2.J974.JT7.82 5.AK2.A854.QJT53 K8643.T653.K9.94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -159,10 +159,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQ3.J87.J765.A64 KT962.Q9.42.JT72 J74.AKT3.Q98.K95 85.6542.AKT3.Q83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -171,10 +171,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A96.54.QJ62.A875 Q732.T8632.K5.63 J84.QJ9.AT8.KQJ2 KT5.AK7.9743.T94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -185,7 +185,7 @@ Pass    Pass
 [Deal "N:A93.A96.KT42.976 Q854.K8754.J985. K76.Q2.3.AQJ8532 JT2.JT3.AQ76.KT4"]
 [Contract "3C"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -195,10 +195,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J7.J87.K982.AK85 AT95.96.QT64.Q63 Q863.AQ2.A75.J92 K42.KT543.J3.T74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -207,11 +207,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A74.J73.AJ82.QT6 98.K982.Q9653.87 KQT3.A.K74.AKJ94 J652.QT654.T.532"]
-[Contract "4NT"]
+[Contract "4N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3S      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3S      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -220,10 +220,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T3.AT3.AQ75.J942 Q974.J965.K93.KT AKJ8.K874.2.AQ87 652.Q2.JT864.653"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -232,10 +232,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT6.K74.AT8.J743 98542.862.Q94.52 KQ7.AJ3.J73.AK86 J3.QT95.K652.QT9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -244,10 +244,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ4.QT7.KJ95.J75 953.8532.A84.Q83 AT62.K4.Q7.AT964 Q87.AJ96.T632.K2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -256,10 +256,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J86.K53.KQ2.K975 Q75.QJ42.8765.A4 AK42.A876.JT.QT8 T93.T9.A943.J632"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -268,10 +268,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJ6.KQ.JT75.7542 KT9.JT654.9843.J Q854.A83.A6.KT93 732.972.KQ2.AQ86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -280,10 +280,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:82.KT6.AKJ6.J954 AT63.87.T542.A73 KJ97.A952.73.KQT Q54.QJ43.Q98.862"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -292,10 +292,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q95.K98.AT87.QJ2 63.Q74.Q32.KT985 A842.AJT3.65.A73 KJT7.652.KJ94.64"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -304,10 +304,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K92.J9.AQ73.JT85 83.Q754.JT865.A9 AQJT.AK86.42.643 7654.T32.K9.KQ72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -316,10 +316,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:986.Q32.KJ7.AQ75 KT7.A875.Q52.T98 AJ43.K4.A63.J632 Q52.JT96.T984.K4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -328,9 +328,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:72.A87.K873.KQ97 KQT.T3.QT95.JT63 9864.KJ64.A2.A42 AJ53.Q952.J64.85"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -339,10 +339,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q42.J84.A853.KQ2 T986.96.KQ4.AJ54 AKJ5.KQT.T92.873 73.A7532.J76.T96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -351,10 +351,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQ8.J62.QT76.QT2 75.543.A952.KJ43 KT96.KQ8.J8.A875 J432.AT97.K43.96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -363,9 +363,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q83.AJT.AJ95.953 64.Q732.Q32.AK84 AJT7.K94.KT8.J72 K952.865.764.QT6"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -374,10 +374,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QJ2.AK2.JT5.J984 K75.JT73.72.T652 A643.Q64.AQ6.AQ3 T98.985.K9843.K7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -386,9 +386,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQ4.A2.Q974.9876 J76.J8654.T32.A2 952.K93.AJ6.KJT4 KT83.QT7.K85.Q53"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -397,10 +397,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K42.T9.KJ74.KQ42 765.K8732.9652.J AT8.Q4.A83.AT983 QJ93.AJ65.QT.765"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -409,10 +409,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QT4.AQ4.A752.T96 A75.KT9.K984.872 KJ.J765.J.AKQJ53 98632.832.QT63.4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1C      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -421,10 +421,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A84.Q53.A654.QT3 J7.AT62.QJ93.764 KQ32.KJ97.K.KJ95 T965.84.T872.A82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -433,10 +433,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:72.A74.AJ54.QJ73 QT54.QT92.K93.T9 AKJ9.KJ6.Q87.652 863.853.T62.AK84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -445,9 +445,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:T87.AT4.QJ2.KJ54 952.KQ2.T743.A92 AK63.8765.K8.Q63 QJ4.J93.A965.T87"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -456,10 +456,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K43.A6.K643.Q965 J986.J8732.A2.43 A2.KT.J97.AKJ872 QT75.Q954.QT85.T"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -468,10 +468,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q64.A65.KT84.Q42 T98.J987.AQ32.95 AJ2.K32.7.AKJ876 K753.QT4.J965.T3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -480,10 +480,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AT6.JT3.A87.Q743 J85.Q542.Q653.65 K972.98.KJT.AKT8 Q43.AK76.942.J92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -492,10 +492,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J93.AT4.Q52.KJ75 A82.QJ85.K64.T42 Q74.763.AJ.AQ963 KT65.K92.T9873.8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -504,9 +504,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A98.AT.Q532.QT83 J74.KQ62.96.A942 KQ62.J83.AJT.J65 T53.9754.K874.K7"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -515,10 +515,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A64.K63.983.AT43 9832.J97.AK75.Q8 KQJ7.AQ8.QT.KJ72 T5.T542.J642.965"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -527,10 +527,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K84.AK7.J873.976 962.Q98.954.A852 QJT5.J63.AKT.QT3 A73.T542.Q62.KJ4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -539,10 +539,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQ.Q82.J862.QT32 T6542.K96.K975.5 K87.AJ4.Q43.KJ96 J93.T753.AT.A874"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -551,10 +551,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q32.J54.K865.AJ7 K986.T9.QJT9.T53 AJ5.AK7.3.KQ9862 T74.Q8632.A742.4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -563,10 +563,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A75.A54.Q43.JT87 9832.J3.A852.KQ5 KQ4.K87.JT7.A642 JT6.QT962.K96.93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -586,9 +586,9 @@ Pass    Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QJ6.A32.J65.A653 AT73.T8.A97.K742 K98.Q976.KQT.QJ8 542.KJ54.8432.T9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 

--- a/GIB/GIB_1C-P-3C.pbn
+++ b/GIB/GIB_1C-P-3C.pbn
@@ -37,10 +37,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:JT4.K32.54.Q7532 K97.985.KT3.KJ84 A62.AQT.AJ2.AT96 Q853.J764.Q9876."]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -49,10 +49,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:62.T85.982.AK654 J97.A643.QT.JT83 KQT3.KJ7.AK6.Q72 A854.Q92.J7543.9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -84,10 +84,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J92.85.J85.A9732 T76.KQJ.KQ94.T54 AQ85.A963.A6.KJ8 K43.T742.T732.Q6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -96,10 +96,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:76.A4.QJ74.QT953 843.K873.T65.K74 AQJ.QT9.A92.AJ86 KT952.J652.K83.2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -119,10 +119,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A9.542.76.KJ8754 Q432.K97.J842.AT KJ75.AJT3.AK.Q63 T86.Q86.QT953.92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -154,10 +154,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T5.QJ2.AJT.J6542 A7643.963.532.K7 QJ8.AKT4.K6.AQ83 K92.875.Q9874.T9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -166,10 +166,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:9.J72.J97.AJT642 KJ84.864.T653.98 QT75.AKQ5.AQ.Q53 A632.T93.K842.K7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -211,10 +211,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T86.8.KQT.KJ6543 943.K974.7652.Q2 KJ75.AQT5.A3.AT9 AQ2.J632.J984.87"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -245,10 +245,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KT.T54.Q95.A9753 J97.A62.KT43.T62 A83.KJ3.AJ7.KQ84 Q6542.Q987.862.J"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -317,10 +317,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q3.J94.KJT.75432 T876.87.962.AKJ6 KJ54.AKQ.AQ3.T98 A92.T6532.8754.Q"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -340,10 +340,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:832.T4.T43.AJT87 AK6.Q753.J752.95 QJ.KJ82.AK8.KQ43 T9754.A96.Q96.62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -377,10 +377,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q84.K2.652.QT853 T952.Q864.KT83.9 A73.AJ93.A97.AJ6 KJ6.T75.QJ4.K742"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -433,10 +433,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:985.6.T984.KQ752 AQ6.KT85.J7.T643 KT73.QJ9.AK6.AJ8 J42.A7432.Q532.9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -445,10 +445,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:74.A8.Q532.J8742 KJ32.Q975.64.A93 AQ9.KJ4.AJT.KT65 T865.T632.K987.Q"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -468,10 +468,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T94.6.KT63.AJ982 KQ5.J75.9875.KQ7 AJ8.AKT2.AQ.6543 7632.Q9843.J42.T"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -492,10 +492,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q2.J43.K93.Q8753 A976.87.J64.AT94 K854.AQ6.AQ8.KJ6 JT3.KT952.T752.2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -526,10 +526,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:754.J64.JT.AQJ53 Q962.Q873.A82.T2 AK83.AT5.KQ9.K98 JT.K92.76543.764"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -538,10 +538,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K.653.742.KT9652 A875.T84.KJT.J84 Q62.KQJ9.A83.AQ7 JT943.A72.Q965.3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 

--- a/GIB/GIB_1C-P-3N.pbn
+++ b/GIB/GIB_1C-P-3N.pbn
@@ -4,9 +4,9 @@
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KJ2.Q64.AJ86.QJ8 Q953.987.KQ95.K9 A8.A53.732.AT763 T764.KJT2.T4.542"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -15,9 +15,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQ3.QJ8.AJ54.QT3 T875.A95.T92.J64 A964.K3.K87.A975 J2.T7642.Q63.K82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -26,10 +26,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q54.K98.KQ73.A53 763.QJT6.T65.T64 AK2.A3.J4.KQJ872 JT98.7542.A982.9"]
-[Contract "4NT"]
+[Contract "4N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -38,9 +38,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A87.AQ7.T754.KQ2 QT6.KJ42.K86.T76 K2.65.AQ92.AJ954 J9543.T983.J3.83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -49,9 +49,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ6.KJ7.7654.KQ7 KT2.T95.J82.A932 853.AQ64.AQ9.J86 J974.832.KT3.T54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -60,9 +60,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A96.KQT.AT92.T32 QJT.9542.865.AK7 K843.AJ8.K73.Q64 752.763.QJ4.J985"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -71,9 +71,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AK5.Q76.AJ74.653 63.KT53.KT86.K92 QJT8.AJ42.Q5.AT7 9742.98.932.QJ84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -82,10 +82,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQT.J85.AT65.KT7 A97.QT964.943.62 8632.AK3.KQ2.AQ8 J54.72.J87.J9543"]
-[Contract "4NT"]
+[Contract "4N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -94,9 +94,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q64.AT3.K953.KQ9 T92.K52.64.JT652 AK7.Q987.JT8.A73 J853.J64.AQ72.84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -105,9 +105,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQ2.A92.A854.T75 AT964.T86.J73.Q4 J3.KQ.Q96.AKJ963 875.J7543.KT2.82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -116,9 +116,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ8.QT3.Q943.KQ4 A64.J95.AT52.762 Q932.AK4.J.AT953 T75.8762.K876.J8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -127,9 +127,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AJ4.AK2.Q943.T87 QT97.864.AJ72.94 63.QJ73.KT6.AQ62 K852.T95.85.KJ53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -138,9 +138,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KJ2.K76.QT96.AQ8 A8653.52.8732.J7 T7.AT84.AK.K9543 Q94.QJ93.J54.T62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -149,9 +149,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K93.A54.KQ98.KT5 864.862.AT75.862 AT72.KQ73.J4.A74 QJ5.JT9.632.QJ93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -160,9 +160,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A63.K84.KT94.AJ6 J985.AJ9.Q32.532 KQ2.Q763.A.K9874 T74.T52.J8765.QT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -171,9 +171,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A72.AK7.QJ83.984 KT65.T5.AT7.T762 J9.J86.952.AKQJ3 Q843.Q9432.K64.5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -182,9 +182,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A97.Q98.AKT9.J97 865.764.752.AK65 JT3.AKT5.QJ6.QT8 KQ42.J32.843.432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -193,9 +193,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AJ5.QJ7.JT87.AQ5 T643.K432.K42.J7 K982.A6.AQ3.T862 Q7.T985.965.K943"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -204,9 +204,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J43.AQ6.J876.AQ9 KT65.T8543.K9.73 A.J972.AQ2.K8542 Q9872.K.T543.JT6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -215,9 +215,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K73.K82.Q954.KQT AJ8.Q95.JT72.J72 952.AJ43.K3.A853 QT64.T76.A86.964"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -226,9 +226,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ8.AT5.QJ82.J42 T63.K74.6543.AKT AJ52.832.AKT.Q86 974.QJ96.97.9753"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -237,9 +237,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AJ3.KQ9.J852.QT6 Q84.543.Q976.KJ3 KT2.AJ2.43.A7542 9765.T876.AKT.98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -248,10 +248,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQ8.Q74.8763.KQ3 T975.JT652.Q95.T KJ3.A.AKJ4.A9864 642.K983.T2.J752"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -260,9 +260,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q43.A53.AK96.Q96 T65.K964.J73.A32 AJ8.QJT7.T5.KJ84 K972.82.Q842.T75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -271,9 +271,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ6.J42.KJ84.K75 A94.T985.Q93.J32 JT53.AK7.652.A94 872.Q63.AT7.QT86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -282,9 +282,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A75.J42.KQ83.AT4 JT42.T96.AJT4.J8 K3.AQ87.9.KQ9653 Q986.K53.7652.72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -293,9 +293,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AT6.AT4.Q984.K98 J983.J7653.AT6.3 752.KQ.K32.AQ654 KQ4.982.J75.JT72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -304,9 +304,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:JT4.K43.AQ97.K53 AK87.J75.6532.76 Q96.AT9.KJ8.QT82 532.Q862.T4.AJ94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -315,9 +315,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AT3.A65.KQT3.985 QJ62.JT7.986.QJ7 K984.K4.J2.AKT42 75.Q9832.A754.63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -326,9 +326,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A96.KQ7.KQ75.JT8 32.T942.A932.975 KQ74.A8.J64.K642 JT85.J653.T8.AQ3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -337,9 +337,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJ4.A62.QJ72.KT7 T65.Q87.843.A964 Q97.K4.AT9.QJ853 K832.JT953.K65.2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -348,9 +348,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A76.QJ7.KJ62.KJ5 532.A62.AQT4.T92 KQJT.KT8.97.A643 984.9543.853.Q87"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -359,9 +359,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ9.J93.AKJT.876 JT642.Q6.9843.A9 K85.AK84.76.KJ43 73.T752.Q52.QT52"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -370,10 +370,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQ2.AT7.Q543.Q96 T963.9853.A7.832 A8.QJ42.KJT.AKJT J754.K6.9862.754"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -382,9 +382,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJT.AK4.J754.J43 954.J63.AQT9.Q75 K72.QT97.K3.AT82 Q863.852.862.K96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -393,9 +393,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJ9.A82.T542.KQJ AQ6.KJ53.J6.5432 852.Q64.AK9.A976 T743.T97.Q873.T8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -404,9 +404,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJT.AJ2.KT93.JT7 K842.QT87.Q65.82 Q76.54.A4.AKQ543 953.K963.J872.96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -415,9 +415,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:JT7.JT7.AKT2.AJ2 AKQ.9843.95.8643 963.AK2.QJ7.K975 8542.Q65.8643.QT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -426,9 +426,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K76.KJ2.KQJ2.872 A5.853.9863.QJ53 QJT3.QT97.74.AK6 9842.A64.AT5.T94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -437,10 +437,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A97.AJ3.T754.KJT 42.8654.J96.Q976 KQT8.KQ72.KQ.A54 J653.T9.A832.832"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -449,9 +449,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QJT.Q86.AQJ3.Q83 964.T74.K64.K975 875.AK2.T75.AJT6 AK32.J953.982.42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -460,9 +460,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT4.A43.JT73.A72 982.92.A986.KJ98 KQJ.KJ76.K54.654 7653.QT85.Q2.QT3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -471,9 +471,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A87.QT4.QT53.AJ8 JT952.92.962.K62 Q3.A873.AJ8.Q954 K64.KJ65.K74.T73"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -484,7 +484,7 @@ Pass    Pass
 [Deal "N:KT9.A95.KQ87.Q83 843.JT76.9642.52 QJ.KQ8.AJ.AK9764 A7652.432.T53.JT"]
 [Contract "6C"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -494,9 +494,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K75.AQ6.A986.865 982.K93.K532.QJ7 AT64.874.QJ7.AKT QJ3.JT52.T4.9432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -505,9 +505,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A86.K98.Q963.A54 Q543.J653.KT4.J9 K7.AT7.A87.K8762 JT92.Q42.J52.QT3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -516,9 +516,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q97.Q65.AK94.A82 AT632.92.J53.JT4 KJ85.AJT.T82.KQ9 4.K8743.Q76.7653"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -527,9 +527,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AK6.Q83.KQT8.732 JT8.A752.76.KQT9 Q542.KJ.AJ3.J654 973.T964.9542.A8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -538,9 +538,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ2.A52.QJT8.K95 986.QT6.A942.QT3 A54.J7.K65.AJ872 JT73.K9843.73.64"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -549,8 +549,8 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQ4.K92.A943.Q65 9872.65.J8752.A2 AJ3.JT83.KT.KJ83 T65.AQ74.Q6.T974"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 

--- a/GIB/GIB_1C-P-3x.pbn
+++ b/GIB/GIB_1C-P-3x.pbn
@@ -4,10 +4,10 @@
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:6.Q52.J872.AKQT7 T854.K986.65.J53 AQ97.AT4.AT3.982 KJ32.J73.KQ94.64"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -16,10 +16,10 @@
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:4.AJ7.AT65.KJT76 AQJ5.Q853.J72.43 K872.KT62.KQ.Q98 T963.94.9843.A52"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -28,10 +28,10 @@
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q.A9.QJ543.AJT84 6542.J652.AT.Q95 AJT8.QT3.K76.K76 K973.K874.982.32"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -52,10 +52,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:3.AKJ.9642.A7652 K954.QT42.QT.KJT AJ7.9875.AJ3.Q43 QT862.63.K875.98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -67,7 +67,7 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6C      Pass    Pass    Pass
 
 
@@ -77,10 +77,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J9.T.AK86.KJT987 T642.AQ94.Q73.42 AQ7.7532.J92.AQ6 K853.KJ86.T54.53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -89,10 +89,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:9.AQ2.AT72.KT953 QJ83.865.K853.62 A642.KJ3.Q94.Q87 KT75.T974.J6.AJ4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -113,10 +113,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KT9.A.KQ65.J9843 Q42.KT652.9842.6 AJ73.Q987.73.AKT 865.J43.AJT.Q752"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -125,10 +125,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:3.AT9.JT98.AKT75 A94.KJ42.7532.Q3 KJT2.7653.AK.J64 Q8765.Q8.Q64.982"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -140,8 +140,8 @@ Pass    Pass
 [Contract "7C"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5H      Pass
+5N     Pass    6C      Pass
 7C      Pass    Pass    Pass
 
 
@@ -175,10 +175,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A53.4.JT95.AKJ74 Q9874.9872.K8.65 KJ6.AJT3.A72.T82 T2.KQ65.Q643.Q93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -228,7 +228,7 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6C      Pass    Pass    Pass
 
 
@@ -238,10 +238,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QJ7.A.T5.AQT7432 T543.T9752.A942. AK2.QJ83.Q76.986 986.K64.KJ83.KJ5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -274,10 +274,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q.J8.KQJ93.AT974 T642.7642.T7.K52 KJ93.KQ5.A42.J83 A875.AT93.865.Q6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -289,7 +289,7 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -315,8 +315,8 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5H      Pass
+5N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -328,7 +328,7 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -341,7 +341,7 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -351,10 +351,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:4.QJ7.KQJ6.KJ754 K753.94.T7432.A6 QJ2.AT83.A98.Q32 AT986.K652.5.T98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -363,10 +363,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:8.63.AJT82.KQJ86 QT763.Q92.Q654.3 AJ95.AJ85.K3.T75 K42.KT74.97.A942"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -387,10 +387,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:7.K98.AJ73.KJT93 9853.T65.Q94.A52 AJ62.Q32.KT5.Q64 KQT4.AJ74.862.87"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -402,7 +402,7 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -412,10 +412,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K54.Q.AJ92.QJ732 T93.K9542.QT63.6 Q86.AT63.K84.A94 AJ72.J87.75.KT85"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -424,10 +424,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:9.84.KQJ83.AJT53 QJ3.AJT5.T97.K92 KT72.K96.A52.Q84 A8654.Q732.64.76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -439,8 +439,8 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5C      Pass
+5N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -461,10 +461,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q84.2.AQ9.KQT642 T6532.9863.K87.3 AK7.JT54.J52.A85 J9.AKQ7.T643.J97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -476,7 +476,7 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -486,10 +486,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A9.8.T762.AKJ875 T872.A9654.K8.96 J653.KJ3.AQ5.QT2 KQ4.QT72.J943.43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -501,7 +501,7 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6C      Pass    Pass    Pass
 
 
@@ -511,10 +511,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AK9.Q.A752.JT972 Q876.JT943.83.54 J542.K65.QJT.AQ3 T3.A872.K964.K86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -523,10 +523,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T.A4.QJ532.KQT76 A964.KT95.T764.9 QJ32.Q873.A.AJ82 K875.J62.K98.543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -551,8 +551,8 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5S      Pass
+5N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -564,7 +564,7 @@ Pass    Pass
 [Contract "6C"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -574,10 +574,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A6.5.A6543.A6543 K43.JT82.JT2.K72 J92.AK64.Q7.QJ98 QT875.Q973.K98.T"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -586,10 +586,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QT5.7.K976.AK983 832.KT92.Q8432.5 A964.A853.AJ.T74 KJ7.QJ64.T5.QJ62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -610,9 +610,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AJ4.8.KJ97.AT763 K85.J743.QT6.Q52 Q963.KQT6.A2.J84 T72.A952.8543.K9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 

--- a/GIB/GIB_1C-P-Resp.pbn
+++ b/GIB/GIB_1C-P-Resp.pbn
@@ -79,12 +79,12 @@ Pass    Pass
 {HCP 11 8 13 8}
 {TP 11 8 14 9}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -101,13 +101,13 @@ Pass    Pass
 {HCP 16 4 12 8}
 {TP 16 5 13 8}
 {Losers 6 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
 2D      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -124,11 +124,11 @@ Pass    Pass
 {HCP 10 7 17 6}
 {TP 11 7 19 7}
 {Losers 8 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -167,11 +167,11 @@ Pass    Pass
 {HCP 11 0 19 10}
 {TP 11 1 19 11}
 {Losers 9 11 5 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -188,11 +188,11 @@ Pass    Pass
 {HCP 22 5 13 0}
 {TP 23 5 13 1}
 {Losers 4 9 8 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    6NT     Pass
+1S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -273,13 +273,13 @@ Pass    Pass
 {HCP 15 3 17 5}
 {TP 17 3 17 6}
 {Losers 6 10 5 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    5NT     Pass
-6NT     Pass    Pass    Pass
+2N     Pass    3S      Pass
+3N     Pass    5N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -296,13 +296,13 @@ Pass    Pass
 {HCP 15 4 14 7}
 {TP 17 4 15 7}
 {Losers 6 10 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
-4NT     Pass    6NT     Pass
+3C      Pass    3N     Pass
+4N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -319,12 +319,12 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 14 6 16 7}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -341,10 +341,10 @@ Pass    Pass
 {HCP 9 9 13 9}
 {TP 10 9 14 9}
 {Losers 8 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -361,11 +361,11 @@ Pass    Pass
 {HCP 11 9 14 6}
 {TP 12 9 15 6}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -382,12 +382,12 @@ Pass    Pass
 {HCP 21 3 11 5}
 {TP 24 4 13 5}
 {Losers 3 10 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 2C      Pass    2H      Pass
-3C      Pass    6NT     Pass
+3C      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -404,11 +404,11 @@ Pass    Pass
 {HCP 11 10 12 7}
 {TP 11 11 14 8}
 {Losers 9 8 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -425,11 +425,11 @@ Pass    Pass
 {HCP 5 8 19 8}
 {TP 6 8 19 8}
 {Losers 10 8 6 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -446,11 +446,11 @@ Pass    Pass
 {HCP 7 6 18 9}
 {TP 9 6 18 9}
 {Losers 9 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -493,7 +493,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -515,7 +515,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-3D      Pass    4NT     Pass
+3D      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    Pass    Pass
 
@@ -534,11 +534,11 @@ Pass    Pass
 {HCP 16 8 12 4}
 {TP 16 8 12 4}
 {Losers 6 10 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -555,11 +555,11 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 12 6 14 10}
 {Losers 7 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -576,11 +576,11 @@ Pass    Pass
 {HCP 7 5 19 9}
 {TP 9 5 19 10}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -597,12 +597,12 @@ Pass    Pass
 {HCP 16 3 13 8}
 {TP 17 4 14 8}
 {Losers 5 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -619,11 +619,11 @@ Pass    Pass
 {HCP 14 6 12 8}
 {TP 16 7 12 9}
 {Losers 6 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -640,12 +640,12 @@ Pass    Pass
 {HCP 13 3 15 9}
 {TP 15 3 18 9}
 {Losers 6 11 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -666,8 +666,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3C      Pass
-3S      Pass    3NT     Pass
+2N     Pass    3C      Pass
+3S      Pass    3N     Pass
 4C      Pass    5C      Pass
 Pass    Pass    
 
@@ -685,11 +685,11 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 7 14 7}
 {Losers 9 10 6 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -706,12 +706,12 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 10 11 16 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -728,12 +728,12 @@ Pass    Pass
 {HCP 16 7 16 1}
 {TP 16 7 18 2}
 {Losers 7 9 5 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -750,11 +750,11 @@ Pass    Pass
 {HCP 10 10 12 8}
 {TP 11 10 14 9}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -771,11 +771,11 @@ Pass    Pass
 {HCP 7 8 18 7}
 {TP 8 8 18 8}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -792,11 +792,11 @@ Pass    Pass
 {HCP 16 2 12 10}
 {TP 16 2 12 10}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -835,11 +835,11 @@ Pass    Pass
 {HCP 9 10 18 3}
 {TP 10 10 19 4}
 {Losers 9 9 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -856,11 +856,11 @@ Pass    Pass
 {HCP 7 7 19 7}
 {TP 7 8 20 7}
 {Losers 10 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -877,12 +877,12 @@ Pass    Pass
 {HCP 9 5 16 10}
 {TP 11 5 18 10}
 {Losers 7 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1S      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -899,12 +899,12 @@ Pass    Pass
 {HCP 15 5 14 6}
 {TP 15 6 16 8}
 {Losers 6 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -925,7 +925,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -942,12 +942,12 @@ Pass    Pass
 {HCP 7 8 18 7}
 {TP 8 9 19 8}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2H      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -964,12 +964,12 @@ Pass    Pass
 {HCP 13 7 17 3}
 {TP 13 8 18 3}
 {Losers 8 8 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2D      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -986,11 +986,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 13 8 14 5}
 {Losers 7 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1034,7 +1034,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1052,13 +1052,13 @@ Pass    Pass
 {HCP 10 7 13 10}
 {TP 13 9 14 11}
 {Losers 6 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1075,11 +1075,11 @@ Pass    Pass
 {HCP 10 7 18 5}
 {TP 10 7 18 5}
 {Losers 9 9 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1096,12 +1096,12 @@ Pass    Pass
 {HCP 16 9 12 3}
 {TP 16 10 13 3}
 {Losers 6 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1118,11 +1118,11 @@ Pass    Pass
 {HCP 12 5 19 4}
 {TP 12 6 19 4}
 {Losers 7 9 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1165,8 +1165,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    4NT     Pass
+2N     Pass    3D      Pass
+3N     Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -1184,12 +1184,12 @@ Pass    Pass
 {HCP 8 5 17 10}
 {TP 9 6 19 10}
 {Losers 8 9 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1227,13 +1227,13 @@ Pass    Pass
 {HCP 12 8 12 8}
 {TP 13 8 13 8}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
 3D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1271,12 +1271,12 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 14 9 15 4}
 {Losers 7 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1293,12 +1293,12 @@ Pass    Pass
 {HCP 14 5 15 6}
 {TP 15 6 15 6}
 {Losers 7 10 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+2C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -1315,12 +1315,12 @@ Pass    Pass
 {HCP 15 4 12 9}
 {TP 15 5 12 9}
 {Losers 7 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2D      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1337,11 +1337,11 @@ Pass    Pass
 {HCP 5 9 19 7}
 {TP 6 9 19 7}
 {Losers 10 8 5 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -1358,12 +1358,12 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 14 6 14 8}
 {Losers 7 10 6 8}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+2C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -1384,7 +1384,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1402,12 +1402,12 @@ Pass    Pass
 {HCP 11 10 14 5}
 {TP 11 10 15 5}
 {Losers 9 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1424,11 +1424,11 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 7 13 7}
 {Losers 7 8 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1466,13 +1466,13 @@ Pass    Pass
 {HCP 17 8 15 0}
 {TP 18 8 17 1}
 {Losers 5 11 4 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
-4NT     Pass    6NT     Pass
+3C      Pass    3N     Pass
+4N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -1489,12 +1489,12 @@ Pass    Pass
 {HCP 11 4 19 6}
 {TP 11 4 19 6}
 {Losers 7 10 5 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2S      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -1511,11 +1511,11 @@ Pass    Pass
 {HCP 8 10 13 9}
 {TP 9 10 13 10}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1532,11 +1532,11 @@ Pass    Pass
 {HCP 13 6 12 9}
 {TP 13 6 12 9}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1556,7 +1556,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    Pass
 
 
@@ -1574,12 +1574,12 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 15 7 14 6}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1596,11 +1596,11 @@ Pass    Pass
 {HCP 9 10 19 2}
 {TP 9 10 19 3}
 {Losers 9 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1641,7 +1641,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 2C      Pass    Pass    2H
 3C      3H      Pass    Pass
 Pass    
@@ -1682,11 +1682,11 @@ Pass    Pass
 {HCP 10 7 14 9}
 {TP 10 8 15 9}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1703,11 +1703,11 @@ Pass    Pass
 {HCP 5 8 19 8}
 {TP 6 9 19 8}
 {Losers 9 8 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -1724,11 +1724,11 @@ Pass    Pass
 {HCP 15 6 14 5}
 {TP 15 7 14 6}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1750,7 +1750,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3H      Pass
+2N     Pass    3H      Pass
 4D      Pass    4H      Pass
 Pass    Pass    
 
@@ -1768,12 +1768,12 @@ Pass    Pass
 {HCP 6 10 16 8}
 {TP 8 10 17 9}
 {Losers 8 8 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1S      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -1790,12 +1790,12 @@ Pass    Pass
 {HCP 10 6 19 5}
 {TP 11 6 19 6}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1816,7 +1816,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1838,9 +1838,9 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    3D      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -1878,12 +1878,12 @@ Pass    Pass
 {HCP 18 2 14 6}
 {TP 18 3 15 7}
 {Losers 6 11 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2D      Pass
-2H      Pass    2NT     Pass
-6NT     Pass    Pass    Pass
+2H      Pass    2N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -1900,12 +1900,12 @@ Pass    Pass
 {HCP 13 5 19 3}
 {TP 13 5 19 4}
 {Losers 7 11 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+2N     Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -1944,11 +1944,11 @@ Pass    Pass
 {HCP 13 9 14 4}
 {TP 14 9 14 5}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1969,7 +1969,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -1987,13 +1987,13 @@ Pass    Pass
 {HCP 10 4 18 8}
 {TP 12 4 19 8}
 {Losers 7 10 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    2H      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2010,12 +2010,12 @@ Pass    Pass
 {HCP 6 10 17 7}
 {TP 8 10 18 7}
 {Losers 8 10 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2032,12 +2032,12 @@ Pass    Pass
 {HCP 6 10 18 6}
 {TP 8 10 21 7}
 {Losers 8 8 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2D      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2054,11 +2054,11 @@ Pass    Pass
 {HCP 8 9 18 5}
 {TP 10 9 18 5}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2096,11 +2096,11 @@ Pass    Pass
 {HCP 11 7 18 4}
 {TP 12 7 18 4}
 {Losers 7 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2117,12 +2117,12 @@ Pass    Pass
 {HCP 13 6 18 3}
 {TP 13 6 18 4}
 {Losers 8 10 5 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+2N     Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -2139,11 +2139,11 @@ Pass    Pass
 {HCP 9 10 12 9}
 {TP 9 10 12 9}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2181,13 +2181,13 @@ Pass    Pass
 {HCP 19 5 14 2}
 {TP 19 7 14 3}
 {Losers 6 8 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3C      Pass
-3NT     Pass    6NT     Pass
+2N     Pass    3C      Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -2204,12 +2204,12 @@ Pass    Pass
 {HCP 11 8 14 7}
 {TP 11 9 15 9}
 {Losers 8 8 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2226,11 +2226,11 @@ Pass    Pass
 {HCP 13 7 14 6}
 {TP 13 8 15 7}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2247,12 +2247,12 @@ Pass    Pass
 {HCP 8 6 18 8}
 {TP 10 6 19 8}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 2H      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2292,12 +2292,12 @@ Pass    Pass
 {HCP 9 10 16 5}
 {TP 9 10 19 6}
 {Losers 9 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1S      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2314,11 +2314,11 @@ Pass    Pass
 {HCP 16 8 12 4}
 {TP 16 8 13 4}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2335,11 +2335,11 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 7 13 8}
 {Losers 7 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2356,11 +2356,11 @@ Pass    Pass
 {HCP 6 5 19 10}
 {TP 7 6 19 10}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2377,10 +2377,10 @@ Pass    Pass
 {HCP 10 8 12 10}
 {TP 10 9 12 11}
 {Losers 9 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -2397,12 +2397,12 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 15 6 16 8}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2424,7 +2424,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4C      Pass    5C      Pass
 5S      Pass    Pass    Pass
 
@@ -2443,12 +2443,12 @@ Pass    Pass
 {HCP 9 6 16 9}
 {TP 9 6 17 9}
 {Losers 8 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1S      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2470,8 +2470,8 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2S      Pass    3C      Pass
-4S      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5C      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -2489,11 +2489,11 @@ Pass    Pass
 {HCP 10 3 18 9}
 {TP 11 4 18 9}
 {Losers 9 10 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2514,7 +2514,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2536,7 +2536,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2S      Pass
+1N     Pass    2S      Pass
 Pass    Pass    
 
 
@@ -2553,11 +2553,11 @@ Pass    Pass
 {HCP 7 4 19 10}
 {TP 7 4 19 10}
 {Losers 9 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2574,11 +2574,11 @@ Pass    Pass
 {HCP 9 9 14 8}
 {TP 9 10 14 8}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2618,12 +2618,12 @@ Pass    Pass
 {HCP 9 4 18 9}
 {TP 11 5 19 9}
 {Losers 7 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2640,12 +2640,12 @@ Pass    Pass
 {HCP 10 3 18 9}
 {TP 12 5 18 9}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2662,12 +2662,12 @@ Pass    Pass
 {HCP 11 7 16 6}
 {TP 13 7 17 6}
 {Losers 6 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2684,11 +2684,11 @@ Pass    Pass
 {HCP 11 9 14 6}
 {TP 11 9 14 6}
 {Losers 8 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2705,12 +2705,12 @@ Pass    Pass
 {HCP 12 9 15 4}
 {TP 15 10 17 4}
 {Losers 5 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2731,7 +2731,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2749,12 +2749,12 @@ Pass    Pass
 {HCP 17 5 13 5}
 {TP 17 5 13 6}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2D      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2771,11 +2771,11 @@ Pass    Pass
 {HCP 12 9 13 6}
 {TP 12 9 13 6}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2792,11 +2792,11 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 6 13 7}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2834,10 +2834,10 @@ Pass    Pass
 {HCP 11 7 12 10}
 {TP 11 8 12 11}
 {Losers 8 9 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
+1C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2854,12 +2854,12 @@ Pass    Pass
 {HCP 14 3 14 9}
 {TP 14 5 14 9}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2D      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2880,7 +2880,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2898,12 +2898,12 @@ Pass    Pass
 {HCP 19 1 14 6}
 {TP 19 2 14 7}
 {Losers 6 11 7 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
-3H      Pass    6NT     Pass
+1N     Pass    2D      Pass
+3H      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -2920,13 +2920,13 @@ Pass    Pass
 {HCP 14 1 18 7}
 {TP 14 2 18 7}
 {Losers 6 11 4 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3NT     Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+3N     Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -2943,12 +2943,12 @@ Pass    Pass
 {HCP 11 7 13 9}
 {TP 11 9 14 9}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2965,12 +2965,12 @@ Pass    Pass
 {HCP 12 5 14 9}
 {TP 12 5 14 9}
 {Losers 8 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2987,11 +2987,11 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 13 10 13 6}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3008,11 +3008,11 @@ Pass    Pass
 {HCP 10 8 13 9}
 {TP 10 8 13 9}
 {Losers 8 10 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3033,7 +3033,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3051,11 +3051,11 @@ Pass    Pass
 {HCP 9 7 19 5}
 {TP 11 8 19 6}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3077,8 +3077,8 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 3S      Pass    4H      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5S      Pass
+5N     Pass    6C      Pass
 7S      Pass    Pass    Pass
 
 
@@ -3096,11 +3096,11 @@ Pass    Pass
 {HCP 14 3 13 10}
 {TP 15 5 14 10}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3117,13 +3117,13 @@ Pass    Pass
 {HCP 12 10 12 6}
 {TP 12 11 12 6}
 {Losers 8 8 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1NT     Pass    2H      Pass
-2NT     Pass    3D      Pass
-3H      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2N     Pass    3D      Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3188,7 +3188,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -3227,12 +3227,12 @@ Pass    Pass
 {HCP 10 4 16 10}
 {TP 12 5 18 10}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3249,12 +3249,12 @@ Pass    Pass
 {HCP 13 2 19 6}
 {TP 13 2 19 6}
 {Losers 7 12 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3C      Pass
-3S      Pass    3NT     Pass
+2N     Pass    3C      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3292,12 +3292,12 @@ Pass    Pass
 {HCP 7 6 20 7}
 {TP 10 7 21 8}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3344,9 +3344,9 @@ Pass    Pass
 1S      Pass    2D      Pass
 2H      Pass    2S      Pass
 3C      Pass    3H      Pass
-3NT     Pass    4H      Pass
-4S      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+3N     Pass    4H      Pass
+4S      Pass    4N     Pass
+5S      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -3364,12 +3364,12 @@ Pass    Pass
 {HCP 14 4 15 7}
 {TP 15 6 17 7}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3386,12 +3386,12 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 13 7 13 9}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3408,13 +3408,13 @@ Pass    Pass
 {HCP 10 8 12 10}
 {TP 13 8 12 11}
 {Losers 5 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2D      Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3431,12 +3431,12 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 16 7 13 9}
 {Losers 6 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
 2H      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3453,12 +3453,12 @@ Pass    Pass
 {HCP 10 3 18 9}
 {TP 10 4 18 9}
 {Losers 8 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3497,11 +3497,11 @@ Pass    Pass
 {HCP 10 9 19 2}
 {TP 10 10 19 2}
 {Losers 7 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3518,11 +3518,11 @@ Pass    Pass
 {HCP 11 3 18 8}
 {TP 12 5 18 8}
 {Losers 7 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3539,11 +3539,11 @@ Pass    Pass
 {HCP 16 4 14 6}
 {TP 16 4 14 8}
 {Losers 6 11 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3560,12 +3560,12 @@ Pass    Pass
 {HCP 6 8 16 10}
 {TP 6 9 17 10}
 {Losers 10 9 5 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1S      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -3582,11 +3582,11 @@ Pass    Pass
 {HCP 16 5 13 6}
 {TP 16 5 13 6}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3603,11 +3603,11 @@ Pass    Pass
 {HCP 9 7 16 8}
 {TP 9 8 17 8}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3628,7 +3628,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    4S      Pass
+1N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -3645,13 +3645,13 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 13 8 12 8}
 {Losers 7 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3689,11 +3689,11 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 15 7 13 7}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3710,12 +3710,12 @@ Pass    Pass
 {HCP 20 4 12 4}
 {TP 20 5 12 5}
 {Losers 5 9 8 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    4C      Pass
-4S      Pass    6NT     Pass
+1N     Pass    4C      Pass
+4S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -3732,13 +3732,13 @@ Pass    Pass
 {HCP 14 7 16 3}
 {TP 14 7 18 3}
 {Losers 7 8 5 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+3C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -3755,12 +3755,12 @@ Pass    Pass
 {HCP 12 9 15 4}
 {TP 12 10 16 5}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3777,11 +3777,11 @@ Pass    Pass
 {HCP 11 7 12 10}
 {TP 12 7 13 10}
 {Losers 8 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3798,12 +3798,12 @@ Pass    Pass
 {HCP 11 6 16 7}
 {TP 11 8 17 7}
 {Losers 7 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3845,7 +3845,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3863,11 +3863,11 @@ Pass    Pass
 {HCP 10 10 12 8}
 {TP 11 10 12 8}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -3905,12 +3905,12 @@ Pass    Pass
 {HCP 16 7 12 5}
 {TP 16 9 13 5}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3950,12 +3950,12 @@ Pass    Pass
 {HCP 6 8 18 8}
 {TP 7 8 18 8}
 {Losers 10 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3993,13 +3993,13 @@ Pass    Pass
 {HCP 16 3 14 7}
 {TP 16 4 14 7}
 {Losers 6 11 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
-4NT     Pass    6NT     Pass
+3C      Pass    3N     Pass
+4N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -4016,12 +4016,12 @@ Pass    Pass
 {HCP 13 4 19 4}
 {TP 13 4 19 4}
 {Losers 8 10 5 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    2H      Pass
-2S      Pass    6NT     Pass
+2S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -4038,11 +4038,11 @@ Pass    Pass
 {HCP 9 8 14 9}
 {TP 9 8 15 10}
 {Losers 8 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4059,12 +4059,12 @@ Pass    Pass
 {HCP 16 5 18 1}
 {TP 16 7 18 2}
 {Losers 6 9 7 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    4C      Pass
-4S      Pass    6NT     Pass
+2N     Pass    4C      Pass
+4S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -4102,12 +4102,12 @@ Pass    Pass
 {HCP 13 4 17 6}
 {TP 14 5 20 8}
 {Losers 6 10 4 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4124,14 +4124,14 @@ Pass    Pass
 {HCP 19 4 13 4}
 {TP 21 4 14 4}
 {Losers 4 10 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+1N     Pass    2D      Pass
+2N     Pass    3D      Pass
+3N     Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -4152,7 +4152,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    2S      Pass
 3C      Pass    3D      Pass
 4S      Pass    Pass    Pass
@@ -4172,12 +4172,12 @@ Pass    Pass
 {HCP 10 4 18 8}
 {TP 11 4 18 8}
 {Losers 8 11 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3D      Pass
-3S      Pass    3NT     Pass
+2N     Pass    3D      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4194,11 +4194,11 @@ Pass    Pass
 {HCP 5 7 19 9}
 {TP 6 10 19 9}
 {Losers 9 7 5 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -4219,7 +4219,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3H      Pass
+1N     Pass    3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4258,11 +4258,11 @@ Pass    Pass
 {HCP 10 6 18 6}
 {TP 10 7 18 6}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1C      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4283,7 +4283,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4301,12 +4301,12 @@ Pass    Pass
 {HCP 21 0 13 6}
 {TP 21 2 13 6}
 {Losers 5 10 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    4C      Pass
-4H      Pass    6NT     Pass
+1N     Pass    4C      Pass
+4H      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -4323,12 +4323,12 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 12 5 17 10}
 {Losers 6 11 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
-3C      Pass    3NT     Pass
+1S      Pass    1N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4366,12 +4366,12 @@ Pass    Pass
 {HCP 6 9 17 8}
 {TP 9 9 19 8}
 {Losers 7 10 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2D      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4388,12 +4388,12 @@ Pass    Pass
 {HCP 10 9 16 5}
 {TP 11 10 17 5}
 {Losers 7 9 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4410,11 +4410,11 @@ Pass    Pass
 {HCP 14 4 14 8}
 {TP 14 5 14 8}
 {Losers 8 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4431,13 +4431,13 @@ Pass    Pass
 {HCP 16 5 16 3}
 {TP 16 6 17 4}
 {Losers 6 9 4 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+3C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -4477,13 +4477,13 @@ Pass    Pass
 {HCP 15 5 17 3}
 {TP 16 5 17 4}
 {Losers 6 10 5 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    5NT     Pass
-6NT     Pass    Pass    Pass
+2N     Pass    3S      Pass
+3N     Pass    5N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -4522,13 +4522,13 @@ Pass    Pass
 {HCP 18 5 12 5}
 {TP 18 6 13 5}
 {Losers 6 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4545,11 +4545,11 @@ Pass    Pass
 {HCP 12 8 12 8}
 {TP 13 8 12 8}
 {Losers 7 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4570,9 +4570,9 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    3D      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -4610,11 +4610,11 @@ Pass    Pass
 {HCP 13 10 13 4}
 {TP 14 10 13 5}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4631,12 +4631,12 @@ Pass    Pass
 {HCP 11 8 14 7}
 {TP 12 8 15 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4653,12 +4653,12 @@ Pass    Pass
 {HCP 11 6 19 4}
 {TP 12 7 19 4}
 {Losers 7 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3C      Pass
-3S      Pass    3NT     Pass
+2N     Pass    3C      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4675,12 +4675,12 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 13 9 13 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2D      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4697,11 +4697,11 @@ Pass    Pass
 {HCP 15 8 13 4}
 {TP 16 9 15 5}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4723,8 +4723,8 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2H      Pass    3C      Pass
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -4742,11 +4742,11 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 15 6 13 8}
 {Losers 7 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4768,7 +4768,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 2H      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -4790,7 +4790,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2D      Pass    4NT     Pass
+2D      Pass    4N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -4808,11 +4808,11 @@ Pass    Pass
 {HCP 20 6 14 0}
 {TP 20 6 14 1}
 {Losers 5 10 7 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    6NT     Pass
+1S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -4871,12 +4871,12 @@ Pass    Pass
 {HCP 7 10 18 5}
 {TP 8 10 18 6}
 {Losers 8 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4893,12 +4893,12 @@ Pass    Pass
 {HCP 14 5 12 9}
 {TP 15 5 13 9}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4915,12 +4915,12 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 15 7 13 7}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4959,12 +4959,12 @@ Pass    Pass
 {HCP 17 8 10 5}
 {TP 18 8 13 7}
 {Losers 6 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4981,11 +4981,11 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 15 6 14 7}
 {Losers 6 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5006,7 +5006,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5024,11 +5024,11 @@ Pass    Pass
 {HCP 11 10 13 6}
 {TP 12 11 13 6}
 {Losers 8 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5087,12 +5087,12 @@ Pass    Pass
 {HCP 10 6 18 6}
 {TP 11 7 18 6}
 {Losers 8 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5131,12 +5131,12 @@ Pass    Pass
 {HCP 13 7 13 7}
 {TP 13 8 13 7}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5153,13 +5153,13 @@ Pass    Pass
 {HCP 13 5 13 9}
 {TP 14 6 14 10}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3C      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3C      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5180,7 +5180,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5264,12 +5264,12 @@ Pass    Pass
 {HCP 13 10 17 0}
 {TP 14 11 17 2}
 {Losers 8 8 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    6NT     Pass
+2N     Pass    3D      Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5286,11 +5286,11 @@ Pass    Pass
 {HCP 20 7 11 2}
 {TP 20 7 14 4}
 {Losers 6 10 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    6NT     Pass
+1S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5307,11 +5307,11 @@ Pass    Pass
 {HCP 14 5 12 9}
 {TP 14 7 14 9}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    3NT     Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5391,12 +5391,12 @@ Pass    Pass
 {HCP 12 8 15 5}
 {TP 12 8 17 6}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5434,11 +5434,11 @@ Pass    Pass
 {HCP 11 10 12 7}
 {TP 11 10 12 7}
 {Losers 8 9 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5476,11 +5476,11 @@ Pass    Pass
 {HCP 10 10 12 8}
 {TP 11 10 12 8}
 {Losers 8 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -5497,10 +5497,10 @@ Pass    Pass
 {HCP 13 10 13 4}
 {TP 13 10 13 5}
 {Losers 8 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
+1C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5522,7 +5522,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2H      Pass    2S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    5H      Pass
 Pass    Pass    
 
@@ -5540,12 +5540,12 @@ Pass    Pass
 {HCP 13 7 14 6}
 {TP 14 7 15 8}
 {Losers 8 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2D      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5562,12 +5562,12 @@ Pass    Pass
 {HCP 11 7 14 8}
 {TP 13 8 15 8}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5588,7 +5588,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5610,7 +5610,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -5633,7 +5633,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2S      Pass    3D      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -5650,13 +5650,13 @@ Pass    Pass
 {HCP 5 10 17 8}
 {TP 7 10 19 8}
 {Losers 9 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5715,12 +5715,12 @@ Pass    Pass
 {HCP 15 3 16 6}
 {TP 16 3 19 6}
 {Losers 5 11 4 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 2H      Pass    3D      Pass
-3S      Pass    6NT     Pass
+3S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5759,11 +5759,11 @@ Pass    Pass
 {HCP 8 9 13 10}
 {TP 8 10 14 11}
 {Losers 9 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5784,7 +5784,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -5823,12 +5823,12 @@ Pass    Pass
 {HCP 8 8 17 7}
 {TP 9 9 17 7}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1H      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5845,11 +5845,11 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 14 7 12 11}
 {Losers 7 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5866,12 +5866,12 @@ Pass    Pass
 {HCP 12 10 14 4}
 {TP 12 11 14 5}
 {Losers 9 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5888,11 +5888,11 @@ Pass    Pass
 {HCP 12 10 12 6}
 {TP 12 10 13 6}
 {Losers 8 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5909,13 +5909,13 @@ Pass    Pass
 {HCP 15 9 12 4}
 {TP 16 9 13 4}
 {Losers 5 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3H      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5932,11 +5932,11 @@ Pass    Pass
 {HCP 11 9 13 7}
 {TP 11 9 13 7}
 {Losers 8 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5953,11 +5953,11 @@ Pass    Pass
 {HCP 11 3 18 8}
 {TP 12 3 19 8}
 {Losers 8 11 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6000,7 +6000,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -6040,12 +6040,12 @@ Pass    Pass
 {HCP 15 7 11 7}
 {TP 16 7 13 8}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6062,12 +6062,12 @@ Pass    Pass
 {HCP 9 8 16 7}
 {TP 10 8 17 7}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1H      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6089,7 +6089,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 3D      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    6C      Pass
 6H      Pass    Pass    Pass
 
@@ -6108,11 +6108,11 @@ Pass    Pass
 {HCP 10 9 13 8}
 {TP 11 9 15 9}
 {Losers 7 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6129,13 +6129,13 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 13 8 15 9}
 {Losers 7 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6152,12 +6152,12 @@ Pass    Pass
 {HCP 15 4 12 9}
 {TP 16 6 13 10}
 {Losers 6 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2D      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6174,10 +6174,10 @@ Pass    Pass
 {HCP 8 10 12 10}
 {TP 8 10 13 10}
 {Losers 9 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6194,10 +6194,10 @@ Pass    Pass
 {HCP 10 7 13 10}
 {TP 10 7 13 10}
 {Losers 8 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -6214,12 +6214,12 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 13 7 12 9}
 {Losers 7 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6236,11 +6236,11 @@ Pass    Pass
 {HCP 16 7 10 7}
 {TP 16 7 13 7}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6261,7 +6261,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6279,12 +6279,12 @@ Pass    Pass
 {HCP 12 4 14 10}
 {TP 13 4 14 10}
 {Losers 7 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6322,11 +6322,11 @@ Pass    Pass
 {HCP 8 6 19 7}
 {TP 8 6 19 7}
 {Losers 9 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6343,11 +6343,11 @@ Pass    Pass
 {HCP 8 6 17 9}
 {TP 9 7 19 10}
 {Losers 9 9 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6364,12 +6364,12 @@ Pass    Pass
 {HCP 11 6 14 9}
 {TP 12 7 15 9}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6386,12 +6386,12 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 16 10 14 5}
 {Losers 5 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6429,12 +6429,12 @@ Pass    Pass
 {HCP 8 6 16 10}
 {TP 8 6 18 11}
 {Losers 9 10 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6451,12 +6451,12 @@ Pass    Pass
 {HCP 12 5 17 6}
 {TP 12 5 19 6}
 {Losers 8 11 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6473,11 +6473,11 @@ Pass    Pass
 {HCP 21 1 14 4}
 {TP 21 2 15 4}
 {Losers 5 11 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    6NT     Pass
+1S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -6499,7 +6499,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-3NT     Pass    6C      Pass
+3N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -6516,11 +6516,11 @@ Pass    Pass
 {HCP 10 7 14 9}
 {TP 11 7 15 9}
 {Losers 7 9 5 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6537,12 +6537,12 @@ Pass    Pass
 {HCP 12 3 18 7}
 {TP 12 5 18 7}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3C      Pass
-3S      Pass    3NT     Pass
+2N     Pass    3C      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6559,12 +6559,12 @@ Pass    Pass
 {HCP 13 7 19 1}
 {TP 13 8 19 1}
 {Losers 8 8 6 12}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2NT     Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+2N     Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -6625,11 +6625,11 @@ Pass    Pass
 {HCP 12 7 18 3}
 {TP 12 7 18 4}
 {Losers 9 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6646,12 +6646,12 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 13 9 13 7}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6668,13 +6668,13 @@ Pass    Pass
 {HCP 13 10 12 5}
 {TP 13 10 13 6}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6691,11 +6691,11 @@ Pass    Pass
 {HCP 12 10 12 6}
 {TP 12 11 12 7}
 {Losers 7 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6712,11 +6712,11 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 15 7 14 7}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6733,12 +6733,12 @@ Pass    Pass
 {HCP 12 6 18 4}
 {TP 12 7 18 5}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3D      Pass
-3S      Pass    3NT     Pass
+2N     Pass    3D      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6755,12 +6755,12 @@ Pass    Pass
 {HCP 7 10 17 6}
 {TP 9 10 18 6}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 3C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6777,12 +6777,12 @@ Pass    Pass
 {HCP 12 8 19 1}
 {TP 12 8 20 3}
 {Losers 8 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 2S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6821,12 +6821,12 @@ Pass    Pass
 {HCP 16 3 12 9}
 {TP 18 5 12 10}
 {Losers 5 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1NT     Pass    2H      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2H      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6843,12 +6843,12 @@ Pass    Pass
 {HCP 15 3 18 4}
 {TP 15 5 18 5}
 {Losers 6 9 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    4C      Pass
-4NT     Pass    6NT     Pass
+2N     Pass    4C      Pass
+4N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -6865,11 +6865,11 @@ Pass    Pass
 {HCP 11 6 13 10}
 {TP 11 7 13 10}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6886,13 +6886,13 @@ Pass    Pass
 {HCP 12 5 14 9}
 {TP 15 5 15 10}
 {Losers 5 10 6 9}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2S      Pass
-3S      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+3S      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -6909,12 +6909,12 @@ Pass    Pass
 {HCP 6 8 17 9}
 {TP 8 8 18 9}
 {Losers 8 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2D      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6931,12 +6931,12 @@ Pass    Pass
 {HCP 7 6 19 8}
 {TP 9 6 20 9}
 {Losers 7 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6953,11 +6953,11 @@ Pass    Pass
 {HCP 10 9 12 9}
 {TP 10 9 13 9}
 {Losers 7 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6978,7 +6978,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3H      Pass
+2N     Pass    3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -6996,13 +6996,13 @@ Pass    Pass
 {HCP 12 7 13 8}
 {TP 13 8 13 8}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7045,7 +7045,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2S      Pass    3D      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -7063,12 +7063,12 @@ Pass    Pass
 {HCP 16 6 15 3}
 {TP 16 6 15 4}
 {Losers 5 10 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -7085,11 +7085,11 @@ Pass    Pass
 {HCP 11 4 19 6}
 {TP 11 5 19 6}
 {Losers 8 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7126,11 +7126,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 14 8 15 6}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7151,7 +7151,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3D      Pass
+2N     Pass    3D      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7191,11 +7191,11 @@ Pass    Pass
 {HCP 11 8 13 8}
 {TP 11 9 14 8}
 {Losers 8 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7212,12 +7212,12 @@ Pass    Pass
 {HCP 17 3 14 6}
 {TP 17 3 14 9}
 {Losers 5 11 7 7}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
-4NT     Pass    6NT     Pass
+2H      Pass    3N     Pass
+4N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -7255,12 +7255,12 @@ Pass    Pass
 {HCP 15 6 11 8}
 {TP 16 7 13 8}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 2C      Pass    2S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7343,11 +7343,11 @@ Pass    Pass
 {HCP 16 4 12 8}
 {TP 16 7 12 9}
 {Losers 6 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7390,7 +7390,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3NT     Pass    5C      Pass
+3N     Pass    5C      Pass
 6C      Pass    Pass    Pass
 
 
@@ -7413,7 +7413,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    3C      Pass
-3NT     Pass    5C      Pass
+3N     Pass    5C      Pass
 Pass    Pass    
 
 
@@ -7430,11 +7430,11 @@ Pass    Pass
 {HCP 11 10 12 7}
 {TP 11 10 12 7}
 {Losers 8 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7451,11 +7451,11 @@ Pass    Pass
 {HCP 7 9 14 10}
 {TP 7 10 14 10}
 {Losers 9 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7472,12 +7472,12 @@ Pass    Pass
 {HCP 8 8 18 6}
 {TP 9 8 19 7}
 {Losers 8 9 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7494,11 +7494,11 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 16 6 13 7}
 {Losers 7 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7515,11 +7515,11 @@ Pass    Pass
 {HCP 8 10 12 10}
 {TP 8 10 13 10}
 {Losers 10 9 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7541,7 +7541,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2H      Pass    2S      Pass
-2NT     Pass    3H      Pass
+2N     Pass    3H      Pass
 Pass    Pass    
 
 
@@ -7558,11 +7558,11 @@ Pass    Pass
 {HCP 11 7 18 4}
 {TP 11 8 18 5}
 {Losers 9 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7579,11 +7579,11 @@ Pass    Pass
 {HCP 13 5 12 10}
 {TP 13 6 12 10}
 {Losers 9 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7600,11 +7600,11 @@ Pass    Pass
 {HCP 17 6 12 5}
 {TP 17 7 12 6}
 {Losers 6 9 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7642,12 +7642,12 @@ Pass    Pass
 {HCP 15 10 14 1}
 {TP 16 10 14 3}
 {Losers 6 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2S      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2S      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7685,11 +7685,11 @@ Pass    Pass
 {HCP 9 9 18 4}
 {TP 9 9 18 4}
 {Losers 9 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7706,13 +7706,13 @@ Pass    Pass
 {HCP 10 9 16 5}
 {TP 13 9 18 6}
 {Losers 6 10 5 8}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+3C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -7734,7 +7734,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -7751,12 +7751,12 @@ Pass    Pass
 {HCP 6 9 18 7}
 {TP 8 9 18 7}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3C      Pass
-3H      Pass    3NT     Pass
+2N     Pass    3C      Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7773,13 +7773,13 @@ Pass    Pass
 {HCP 11 10 12 7}
 {TP 14 11 14 7}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7796,11 +7796,11 @@ Pass    Pass
 {HCP 10 7 19 4}
 {TP 12 8 21 4}
 {Losers 7 9 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7839,11 +7839,11 @@ Pass    Pass
 {HCP 12 8 12 8}
 {TP 13 9 12 8}
 {Losers 7 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7886,7 +7886,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -7903,11 +7903,11 @@ Pass    Pass
 {HCP 16 5 14 5}
 {TP 16 6 14 5}
 {Losers 7 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7924,12 +7924,12 @@ Pass    Pass
 {HCP 15 4 14 7}
 {TP 15 5 16 8}
 {Losers 7 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7946,12 +7946,12 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 13 8 14 8}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7989,11 +7989,11 @@ Pass    Pass
 {HCP 7 8 18 7}
 {TP 7 8 18 7}
 {Losers 10 10 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -8010,13 +8010,13 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 13 7 15 7}
 {Losers 7 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8033,10 +8033,10 @@ Pass    Pass
 {HCP 9 7 14 10}
 {TP 9 7 15 10}
 {Losers 9 11 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8075,11 +8075,11 @@ Pass    Pass
 {HCP 8 9 14 9}
 {TP 8 9 15 10}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8117,13 +8117,13 @@ Pass    Pass
 {HCP 12 4 14 10}
 {TP 14 6 16 11}
 {Losers 7 9 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8160,12 +8160,12 @@ Pass    Pass
 {HCP 16 5 15 4}
 {TP 17 5 16 6}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8182,12 +8182,12 @@ Pass    Pass
 {HCP 14 2 16 8}
 {TP 15 2 16 8}
 {Losers 7 11 5 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+2C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -8204,12 +8204,12 @@ Pass    Pass
 {HCP 11 9 16 4}
 {TP 14 9 18 4}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8226,11 +8226,11 @@ Pass    Pass
 {HCP 11 7 13 9}
 {TP 11 7 13 9}
 {Losers 8 10 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8247,13 +8247,13 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 15 6 13 7}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2H      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8270,13 +8270,13 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 15 5 15 8}
 {Losers 7 10 7 9}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2S      Pass
-3C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+3C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -8314,12 +8314,12 @@ Pass    Pass
 {HCP 16 6 13 5}
 {TP 16 6 14 5}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8336,12 +8336,12 @@ Pass    Pass
 {HCP 14 10 14 2}
 {TP 14 10 16 3}
 {Losers 7 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8385,8 +8385,8 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2S      Pass
-2NT     Pass    3C      Pass
-4NT     Pass    5D      Pass
+2N     Pass    3C      Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -8404,12 +8404,12 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 13 8 12 7}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8426,11 +8426,11 @@ Pass    Pass
 {HCP 14 4 14 8}
 {TP 14 6 14 8}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8447,11 +8447,11 @@ Pass    Pass
 {HCP 11 8 14 7}
 {TP 11 9 14 7}
 {Losers 8 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8473,7 +8473,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2S      Pass    3C      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5S      Pass    6C      Pass
 Pass    Pass    
 
@@ -8513,11 +8513,11 @@ Pass    Pass
 {HCP 14 8 11 7}
 {TP 15 8 13 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8534,11 +8534,11 @@ Pass    Pass
 {HCP 11 8 13 8}
 {TP 11 8 13 8}
 {Losers 8 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8555,10 +8555,10 @@ Pass    Pass
 {HCP 6 10 14 10}
 {TP 6 10 15 10}
 {Losers 10 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -8596,11 +8596,11 @@ Pass    Pass
 {HCP 15 10 13 2}
 {TP 15 10 14 2}
 {Losers 7 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8617,11 +8617,11 @@ Pass    Pass
 {HCP 11 8 14 7}
 {TP 12 9 14 7}
 {Losers 8 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8638,12 +8638,12 @@ Pass    Pass
 {HCP 9 8 13 10}
 {TP 11 8 14 10}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8686,7 +8686,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -8708,7 +8708,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8747,11 +8747,11 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 9 13 8}
 {Losers 8 8 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8768,13 +8768,13 @@ Pass    Pass
 {HCP 9 7 18 6}
 {TP 11 8 21 6}
 {Losers 6 9 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    2H      Pass
-2NT     Pass    3H      Pass
-3S      Pass    3NT     Pass
+2N     Pass    3H      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8797,8 +8797,8 @@ Pass    Pass
 1C      Pass    1S      Pass
 3D      Pass    3H      Pass
 4C      Pass    4D      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5H      Pass
+5N     Pass    6D      Pass
 6S      Pass    7S      Pass
 Pass    Pass    
 
@@ -8816,12 +8816,12 @@ Pass    Pass
 {HCP 14 9 15 2}
 {TP 14 9 16 4}
 {Losers 8 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8838,11 +8838,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 15 8 13 6}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8859,13 +8859,13 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 13 9 14 8}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3H      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8882,12 +8882,12 @@ Pass    Pass
 {HCP 11 10 16 3}
 {TP 11 11 16 4}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8904,13 +8904,13 @@ Pass    Pass
 {HCP 12 9 15 4}
 {TP 14 9 16 5}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
 3D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8927,12 +8927,12 @@ Pass    Pass
 {HCP 16 5 13 6}
 {TP 16 7 14 7}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8972,13 +8972,13 @@ Pass    Pass
 {HCP 11 7 13 9}
 {TP 13 7 13 9}
 {Losers 6 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8995,12 +8995,12 @@ Pass    Pass
 {HCP 12 7 16 5}
 {TP 13 8 16 6}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9017,12 +9017,12 @@ Pass    Pass
 {HCP 5 8 18 9}
 {TP 6 8 18 10}
 {Losers 9 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3D      Pass
-3S      Pass    3NT     Pass
+2N     Pass    3D      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9060,12 +9060,12 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 14 10 14 7}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9082,12 +9082,12 @@ Pass    Pass
 {HCP 11 5 17 7}
 {TP 12 6 17 7}
 {Losers 8 10 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9104,11 +9104,11 @@ Pass    Pass
 {HCP 10 9 12 9}
 {TP 10 9 12 10}
 {Losers 8 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9125,12 +9125,12 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 13 8 16 7}
 {Losers 7 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9147,11 +9147,11 @@ Pass    Pass
 {HCP 6 10 14 10}
 {TP 6 11 14 11}
 {Losers 10 7 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9195,8 +9195,8 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2D      Pass    2S      Pass
-3C      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+3C      Pass    4N     Pass
+5S      Pass    5N     Pass
 6C      Pass    7C      Pass
 Pass    Pass    
 
@@ -9214,11 +9214,11 @@ Pass    Pass
 {HCP 9 9 18 4}
 {TP 9 9 18 5}
 {Losers 9 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9239,7 +9239,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2D      Pass    2NT     Pass
+2D      Pass    2N     Pass
 3C      Pass    3D      Pass
 3S      Pass    4D      Pass
 5D      Pass    Pass    Pass
@@ -9263,7 +9263,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3D      Pass
+2N     Pass    3D      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9281,11 +9281,11 @@ Pass    Pass
 {HCP 10 10 14 6}
 {TP 10 10 14 6}
 {Losers 8 9 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -9302,10 +9302,10 @@ Pass    Pass
 {HCP 9 9 14 8}
 {TP 9 9 14 9}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
+1C      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -9322,12 +9322,12 @@ Pass    Pass
 {HCP 8 6 18 8}
 {TP 10 7 18 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9344,12 +9344,12 @@ Pass    Pass
 {HCP 12 6 14 8}
 {TP 12 6 15 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9387,12 +9387,12 @@ Pass    Pass
 {HCP 7 9 20 4}
 {TP 7 9 21 4}
 {Losers 10 9 4 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2D      Pass    2NT     Pass
-3H      Pass    3NT     Pass
+2D      Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9409,11 +9409,11 @@ Pass    Pass
 {HCP 13 6 19 2}
 {TP 13 6 19 3}
 {Losers 8 10 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -9435,7 +9435,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3D      Pass    4NT     Pass
+3D      Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -9453,13 +9453,13 @@ Pass    Pass
 {HCP 16 2 14 8}
 {TP 17 3 14 8}
 {Losers 5 11 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 3H      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9476,11 +9476,11 @@ Pass    Pass
 {HCP 16 3 12 9}
 {TP 16 4 13 9}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9497,11 +9497,11 @@ Pass    Pass
 {HCP 13 6 19 2}
 {TP 13 8 19 4}
 {Losers 8 9 5 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    3NT     Pass
-6NT     Pass    Pass    Pass
+1C      Pass    3N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -9518,11 +9518,11 @@ Pass    Pass
 {HCP 8 9 13 10}
 {TP 8 10 14 11}
 {Losers 9 8 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -9543,7 +9543,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9561,12 +9561,12 @@ Pass    Pass
 {HCP 13 4 13 10}
 {TP 14 4 15 10}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9583,12 +9583,12 @@ Pass    Pass
 {HCP 12 4 14 10}
 {TP 12 4 15 10}
 {Losers 8 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9605,12 +9605,12 @@ Pass    Pass
 {HCP 12 9 18 1}
 {TP 12 9 18 2}
 {Losers 7 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3C      Pass
-3H      Pass    3NT     Pass
+2N     Pass    3C      Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9648,12 +9648,12 @@ Pass    Pass
 {HCP 16 7 12 5}
 {TP 16 7 13 5}
 {Losers 7 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2D      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9670,12 +9670,12 @@ Pass    Pass
 {HCP 13 10 14 3}
 {TP 15 10 14 3}
 {Losers 6 10 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9692,11 +9692,11 @@ Pass    Pass
 {HCP 7 6 18 9}
 {TP 7 7 18 10}
 {Losers 10 9 6 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    1NT     Pass
-2NT     Pass    Pass    Pass
+1C      Pass    1N     Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -9717,8 +9717,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2D      Pass
+2S      Pass    2N     Pass
 3C      Pass    3D      Pass
 3H      Pass    3S      Pass
 Pass    Pass    
@@ -9737,12 +9737,12 @@ Pass    Pass
 {HCP 11 10 13 6}
 {TP 11 10 14 6}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9759,11 +9759,11 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 14 7 14 6}
 {Losers 6 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9785,7 +9785,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    2S      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 4S      Pass    6S      Pass
 Pass    Pass    
 
@@ -9824,11 +9824,11 @@ Pass    Pass
 {HCP 13 10 14 3}
 {TP 15 10 14 6}
 {Losers 5 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9850,7 +9850,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -9868,12 +9868,12 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 15 5 14 9}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2D      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9890,12 +9890,12 @@ Pass    Pass
 {HCP 10 7 13 10}
 {TP 12 8 13 10}
 {Losers 7 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    Pass    Pass
+1N     Pass    2D      Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -9918,7 +9918,7 @@ Pass    Pass
 1C      Pass    1S      Pass
 2C      Pass    2H      Pass
 3S      Pass    4S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    5S      Pass
 6S      Pass    Pass    Pass
 
@@ -9937,13 +9937,13 @@ Pass    Pass
 {HCP 12 5 13 10}
 {TP 14 6 15 11}
 {Losers 7 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2S      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9982,12 +9982,12 @@ Pass    Pass
 {HCP 12 8 15 5}
 {TP 12 9 15 5}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10004,12 +10004,12 @@ Pass    Pass
 {HCP 19 5 12 4}
 {TP 19 6 12 5}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10026,13 +10026,13 @@ Pass    Pass
 {HCP 14 4 14 8}
 {TP 14 4 17 9}
 {Losers 6 10 5 8}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    2S      Pass
-3C      Pass    3NT     Pass
-4NT     Pass    Pass    Pass
+3C      Pass    3N     Pass
+4N     Pass    Pass    Pass
 
 
 
@@ -10049,12 +10049,12 @@ Pass    Pass
 {HCP 12 3 18 7}
 {TP 12 5 19 7}
 {Losers 7 9 4 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2D      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10071,12 +10071,12 @@ Pass    Pass
 {HCP 12 7 13 8}
 {TP 12 8 15 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+1S      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10115,12 +10115,12 @@ Pass    Pass
 {HCP 8 5 19 8}
 {TP 9 5 19 8}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10158,11 +10158,11 @@ Pass    Pass
 {HCP 11 5 18 6}
 {TP 11 5 18 6}
 {Losers 8 10 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10205,7 +10205,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -10223,12 +10223,12 @@ Pass    Pass
 {HCP 5 10 19 6}
 {TP 7 10 19 7}
 {Losers 9 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10245,11 +10245,11 @@ Pass    Pass
 {HCP 18 10 12 0}
 {TP 18 10 13 2}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10266,11 +10266,11 @@ Pass    Pass
 {HCP 10 8 14 8}
 {TP 10 8 14 8}
 {Losers 9 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -10312,7 +10312,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -10335,7 +10335,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2H      Pass    3C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -10375,11 +10375,11 @@ Pass    Pass
 {HCP 9 10 14 7}
 {TP 9 10 14 7}
 {Losers 9 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -10396,11 +10396,11 @@ Pass    Pass
 {HCP 12 6 19 3}
 {TP 12 8 19 4}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10421,7 +10421,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    5S      Pass
 Pass    Pass    
 
@@ -10461,12 +10461,12 @@ Pass    Pass
 {HCP 10 7 14 9}
 {TP 11 7 15 10}
 {Losers 7 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10483,12 +10483,12 @@ Pass    Pass
 {HCP 5 8 17 10}
 {TP 6 8 17 10}
 {Losers 9 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10505,12 +10505,12 @@ Pass    Pass
 {HCP 14 6 12 8}
 {TP 14 7 15 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10527,11 +10527,11 @@ Pass    Pass
 {HCP 9 10 12 9}
 {TP 10 10 12 10}
 {Losers 8 10 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -10548,12 +10548,12 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 14 6 13 7}
 {Losers 7 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10570,11 +10570,11 @@ Pass    Pass
 {HCP 10 10 12 8}
 {TP 10 10 12 9}
 {Losers 8 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -10612,12 +10612,12 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 16 9 15 6}
 {Losers 6 9 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1S      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10634,12 +10634,12 @@ Pass    Pass
 {HCP 17 4 14 5}
 {TP 17 5 16 6}
 {Losers 6 10 4 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10656,12 +10656,12 @@ Pass    Pass
 {HCP 12 6 12 10}
 {TP 14 7 14 10}
 {Losers 6 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1D      Pass
 1H      Pass    1S      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10678,11 +10678,11 @@ Pass    Pass
 {HCP 17 1 12 10}
 {TP 17 1 12 10}
 {Losers 6 12 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10699,12 +10699,12 @@ Pass    Pass
 {HCP 14 8 14 4}
 {TP 16 9 16 4}
 {Losers 7 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10725,7 +10725,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-2NT     Pass    3S      Pass
+2N     Pass    3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -10743,11 +10743,11 @@ Pass    Pass
 {HCP 17 8 12 3}
 {TP 17 8 12 5}
 {Losers 6 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10769,7 +10769,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2D      Pass    2H      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -10786,12 +10786,12 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 13 7 13 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1D      Pass
-1NT     Pass    2H      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2H      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10808,12 +10808,12 @@ Pass    Pass
 {HCP 12 8 13 7}
 {TP 12 9 14 7}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10834,7 +10834,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-2NT     Pass    4H      Pass
+2N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -10851,13 +10851,13 @@ Pass    Pass
 {HCP 12 12 13 3}
 {TP 13 13 14 4}
 {Losers 6 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "N"]
 1H      Pass    2D      Pass
-2H      Pass    2NT     Pass
+2H      Pass    2N     Pass
 3H      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 

--- a/GIB/GIB_1N-P-2C
+++ b/GIB/GIB_1N-P-2C
@@ -6,7 +6,7 @@
 [Deal "N:7.K642.742.KQJ65 QJT98652.Q3.K5.8 AK43.AJ87.J9.AT4 .T95.AQT863.9732"]
 [Contract "4SX"]
 [Auction "S"]
-1NT     Pass    2C      4S
+1N     Pass    2C      4S
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -16,10 +16,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A854.982.K52.Q94 KQ.T53.3.AKJT632 62.AKQJ6.AJT.875 JT973.74.Q98764."]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      3C
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3C
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -28,11 +28,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:42.K643.J94.KQ96 AKJT85.AJ5.6.542 Q93.QT9.AKQ2.A73 76.872.T8753.JT8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      2S
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -43,7 +43,7 @@ Pass    Pass    2NT     Pass
 [Deal "N:K643.QJ75.J94.K5 A7.K.AQT875.JT83 QT2.A643.K3.AQ42 J985.T982.62.976"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -55,7 +55,7 @@ Pass    Pass
 [Deal "N:AT62.T7.95.KQT98 4.K854.AKQT42.J2 QJ973.AQJ.J3.A76 K85.9632.876.543"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -67,7 +67,7 @@ Pass    Pass
 [Deal "N:T4.K652.J32.A875 AQJ852..A875.Q32 K97.AQ93.KQ94.KT 63.JT874.T6.J964"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -78,7 +78,7 @@ Pass    Pass    Pass
 [Deal "N:T.KQ75.JT9.AJ762 AQJ97654.3.854.4 K82.AJT6.KQ7.K98 3.9842.A632.QT53"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -89,7 +89,7 @@ Pass    Pass    Pass
 [Deal "N:A875.963.76.KQ84 J.AKJ872.KQ5.962 KQ642.T4.AJT.AJT T93.Q5.98432.753"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -101,7 +101,7 @@ Pass    Pass
 [Deal "N:76.KJ83.863.KJT3 KQT983.A652.AT9. A4.Q94.KQ752.AQ9 J52.T7.J4.876542"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -112,7 +112,7 @@ Pass    Pass    Pass
 [Deal "N:9653.KJ92.J8.KJ7 QJT8..AKQ7432.62 AK72.AQ63.96.A53 4.T8754.T5.QT984"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -121,10 +121,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A62.AT62.8.QJ876 KQT875.J94.AK9.3 J93.KQ3.Q53.AKT5 4.875.JT7642.942"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -135,7 +135,7 @@ Pass    Pass
 [Deal "N:Q6.KJ82.T65.K643 7.96.AJ98743.AQJ AK53.AT3.KQ.T952 JT9842.Q754.2.87"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -146,7 +146,7 @@ Pass    Pass    Pass
 [Deal "N:873.K964.6.AJ986 5.AQ85.AJ98542.7 AK2.T72.KQT7.K53 QJT964.J3.3.QT42"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -157,7 +157,7 @@ Pass    Pass    Pass
 [Deal "N:3.QJ83.AJ654.864 AKJ8762.T962..AT QT95.AK5.KQ2.Q93 4.74.T9873.KJ752"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -168,7 +168,7 @@ Pass    Pass    Pass
 [Deal "N:AT76.7.QT64.Q964 QJ53.AJT8632.A9. 82.KQ954.KJ5.AK2 K94..8732.JT8753"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -179,7 +179,7 @@ Pass    Pass    Pass
 [Deal "N:K875.8.AJ3.AKJ75 6.JT976532.97.T4 Q93.AKQ.KT52.Q63 AJT42.4.Q864.982"]
 [Contract "4HX"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -191,7 +191,7 @@ Pass    Pass
 [Deal "N:QJ52.KJ74.72.K42 .Q6.AJT98654.AJ6 A97.A93.KQ3.QT83 KT8643.T852..975"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -200,10 +200,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A983.AQ8.9852.A9 52.KJ73..KQJT853 KQ4.942.AKQJ3.76 JT76.T65.T764.42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      3C
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3C
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -212,10 +212,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ98.KJ2.6432.54 6.AQ97653.8.AQ93 K7432.84.AKQ.K86 JT5.T.JT975.JT72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      3H
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3H
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -226,7 +226,7 @@ Pass    Pass
 [Deal "N:K.AQJ6.T872.T543 QJT65432.75.95.A A97.842.AKQ64.QJ 8.KT93.J3.K98762"]
 [Contract "4SX"]
 [Auction "S"]
-1NT     Pass    2C      4S
+1N     Pass    2C      4S
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -238,7 +238,7 @@ Pass    Pass
 [Deal "N:KJ72.5.QJ98.JT64 643.AKT843.A.K82 AT.QJ972.KT6.AQ9 Q985.6.75432.753"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -250,7 +250,7 @@ Pass    Pass
 [Deal "N:QJ97.QT.T73.AJ86 K.J542.AKQ642.Q9 A8653.AK9.J85.K7 T42.8763.9.T5432"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -262,7 +262,7 @@ Pass    Pass
 [Deal "N:KJ43.72.KJT5.965 AQ9862.A653.86.K T7.K4.AQ432.AQ32 5.QJT98.97.JT874"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -273,7 +273,7 @@ Pass    Pass    Pass
 [Deal "N:KQJ8.65.8765.KJ9 9542.AQ9873..AQ8 A3.KT4.AKJ93.753 T76.J2.QT42.T642"]
 [Contract "4D"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 3D      Pass    4D      Pass
 Pass    Pass    
@@ -286,7 +286,7 @@ Pass    Pass
 [Deal "N:KJT7.JT97.74.A64 Q.Q6.AKQJ62.7532 A8532.AK.953.KQT 964.85432.T8.J98"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -298,7 +298,7 @@ Pass    Pass
 [Deal "N:QJT3.84.A9632.K3 A2.AQJT93.QT75.T K76.K76.KJ4.AJ84 9854.52.8.Q97652"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -310,7 +310,7 @@ Pass    Pass
 [Deal "N:KJ87.87.KQ8.K942 Q62.AQJT6432.7.J AT5.K9.AJ42.AT75 943.5.T9653.Q863"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -321,7 +321,7 @@ Pass    Pass    Pass
 [Deal "N:A963.J54.AT.9862 .KQT9876.K9762.A KQT7.A2.Q54.KQJ4 J8542.3.J83.T753"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -332,7 +332,7 @@ Pass    Pass    Pass
 [Deal "N:J962.AJ53.A72.Q3 KQ7.K7.6.AJT9865 A3.Q86.KQJ94.K42 T854.T942.T853.7"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -343,7 +343,7 @@ Pass    Pass    Pass
 [Deal "N:KJ96.QT3.K98.QT5 2.54.AQJ65432.K3 AT83.AK76.T7.A98 Q754.J982..J7642"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    Db      Pass
 4H      Pass    Pass    Pass
 
@@ -354,10 +354,10 @@ Pass    Pass    Db      Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K76.QJT7.743.KT8 A98543..K95.AJ76 QJT.AK83.AJ86.43 2.96542.QT2.Q952"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -368,7 +368,7 @@ Pass    Pass
 [Deal "N:542.AT86.KJ.A987 AKQ873.54.Q.Q652 JT96.KQJ.AT8.KJ4 .9732.9765432.T3"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -379,7 +379,7 @@ Pass    Pass    Pass
 [Deal "N:A765.3.J87.KJ872 KJ.KJT98642.T9.6 94.AQ7.AKQ52.543 QT832.5.643.AQT9"]
 [Contract "4HX"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -391,7 +391,7 @@ Pass    Pass
 [Deal "N:T4.QJ65.A95.A542 AK92.4.KQJT32.T3 QJ3.AK973.864.KQ 8765.T82.7.J9876"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -403,7 +403,7 @@ Pass    Pass
 [Deal "N:AK75.QT9.2.AT865 T4.KJ876542.7.J3 Q92.A3.AK543.K97 J863..QJT986.Q42"]
 [Contract "4HX"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -413,10 +413,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K972.532.AK2.987 54.T98764.Q.AKQJ AQJ.AKQ.7654.543 T863.J.JT983.T62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -427,7 +427,7 @@ Pass    Pass
 [Deal "N:J4.AJ96.QT975.97 K6.Q754..AKT6532 QT95.K832.AK2.QJ A8732.T.J8643.84"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -438,7 +438,7 @@ Pass    Pass    Pass
 [Deal "N:A862.9864.8.KJT7 Q.7.AQJT9763.Q64 74.AKQ5.K52.A832 KJT953.JT32.4.95"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -447,10 +447,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AT.KQT2.K8543.J5 KQ987643.74.92.A J5.AJ8.AJT7.KQT3 2.9653.Q6.987642"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      3S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -459,10 +459,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AJ76.92.95.AJ982 T52.Q73.AKQJ87.T KQ8.AKJ5.642.K74 943.T864.T3.Q653"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      2D
-2H      Pass    3NT     Pass
+1N     Pass    2C      2D
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -473,8 +473,8 @@ Pass    Pass
 [Deal "N:95.K952.852.AQ87 AKQT82.73.4.KJ65 643.AQT.AKQT3.T3 J7.J864.J976.942"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    2NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    2N     Pass
 3D      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -487,7 +487,7 @@ Pass    Pass    2NT     Pass
 [Deal "N:AQ82.95.KT643.86 J65.AKJ743.8.A43 KT4.QT82.AJ2.KQ5 973.6.Q975.JT972"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -499,9 +499,9 @@ Pass    Pass
 [Deal "N:KQJ.A942.7.AK942 62.T.AT985432.T3 AT5.KQ73.KQ.QJ65 98743.J865.J6.87"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    Db      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5S      Pass    6H      Pass
 Pass    Pass    
 
@@ -511,11 +511,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:64.AJ32.J6.K9732 2.876.AKQT95.QJ6 AQJ75.KQT.82.A85 KT983.954.743.T4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      2D
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      2D
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -526,7 +526,7 @@ Pass    Pass
 [Deal "N:K8.K983.AQ83.743 AJ976543.T7.6.65 Q2.A542.J75.AKJ9 T.QJ6.KT942.QT82"]
 [Contract "4SX"]
 [Auction "S"]
-1NT     Pass    2C      4S
+1N     Pass    2C      4S
 Pass    Pass    Db      Pass
 Pass    Pass    
 
@@ -538,7 +538,7 @@ Pass    Pass
 [Deal "N:KT94.5.KQ84.T732 7.AK8732.T6.KQJ6 AQ8.JT94.AJ75.A4 J6532.Q6.932.985"]
 [Contract "5D"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 3D      Pass    4D      Pass
 5D      Pass    Pass    Pass
@@ -552,7 +552,7 @@ Pass    Pass    2S      Pass
 [Deal "N:A986.53.T3.KJ743 .K742.AKJ9842.96 KQJT.AJ98.76.AT2 75432.QT6.Q5.Q85"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -563,7 +563,7 @@ Pass    Pass    Pass
 [Deal "N:73.K987.AJ5.A954 KQJT654..932.KQJ A98.AQT63.KQ.T62 2.J542.T8764.873"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -574,7 +574,7 @@ Pass    Pass    Pass
 [Deal "N:83.AT32.A8753.95 T64.7.KQ.AQJT862 AQ7.KQJ9.J9.K743 KJ952.8654.T642."]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -585,6 +585,6 @@ Pass    Pass    Pass
 [Deal "N:65.KJ52.972.KJ75 AQJ8732.A9.KT8.8 KT4.QT63.AQ3.AT4 9.874.J654.Q9632"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 

--- a/GIB/GIB_1N-P-2C-BID.pbn
+++ b/GIB/GIB_1N-P-2C-BID.pbn
@@ -15,7 +15,7 @@
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -36,7 +36,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    5D      Pass
 Pass    Pass    
 
@@ -57,7 +57,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -75,11 +75,11 @@ Pass    Pass
 {HCP 8 11 15 6}
 {TP 9 14 15 8}
 {Losers 9 5 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
-2S      Pass    2NT     Pass
+1N     Pass    2C      2D
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -96,11 +96,11 @@ Pass    Pass
 {HCP 11 10 16 3}
 {TP 12 13 16 5}
 {Losers 6 5 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3D
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3D
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -117,11 +117,11 @@ Pass    Pass
 {HCP 10 8 16 6}
 {TP 10 10 17 9}
 {Losers 8 6 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -141,7 +141,7 @@ Pass    Pass
 [Contract "2DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 X       Pass    Pass    Pass
 
 
@@ -162,7 +162,7 @@ X       Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -182,7 +182,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -203,7 +203,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -223,7 +223,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -244,7 +244,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -265,7 +265,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -283,11 +283,11 @@ Pass    Pass
 {HCP 8 15 15 2}
 {TP 10 16 15 5}
 {Losers 7 5 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -307,7 +307,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -325,12 +325,12 @@ Pass    Pass
 {HCP 9 4 16 11}
 {TP 11 8 16 11}
 {Losers 7 7 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -350,7 +350,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -371,7 +371,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -391,7 +391,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      4C      4H      Pass
 Pass    Pass    
 
@@ -412,7 +412,7 @@ Pass    Pass
 [Contract "3DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    Pass    Pass
 
 
@@ -433,7 +433,7 @@ X       Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -453,7 +453,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -474,7 +474,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -495,7 +495,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -513,11 +513,11 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 10 10 16 6}
 {Losers 9 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    3NT     Pass
+1N     Pass    2C      X
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -537,7 +537,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -558,7 +558,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -576,11 +576,11 @@ Pass    Pass
 {HCP 14 8 15 3}
 {TP 14 12 16 5}
 {Losers 7 5 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3D
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3D
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -597,11 +597,11 @@ Pass    Pass
 {HCP 8 12 15 5}
 {TP 9 13 15 6}
 {Losers 9 7 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    2NT     Pass
+1N     Pass    2C      X
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -621,7 +621,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -642,7 +642,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -664,7 +664,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    4H      Pass    Pass
 Pass    
 
@@ -685,7 +685,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -706,7 +706,7 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4S
+1N     Pass    2C      4S
 Pass    Pass    6D      Pass
 Pass    Pass    
 
@@ -727,7 +727,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    Pass    
 
 
@@ -747,7 +747,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -768,7 +768,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -789,7 +789,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -810,7 +810,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -831,7 +831,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -853,7 +853,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -874,7 +874,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -894,7 +894,7 @@ Pass    Pass    Pass
 [Contract "2DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 X       Pass    Pass    Pass
 
 
@@ -915,7 +915,7 @@ X       Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -935,7 +935,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -956,7 +956,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -978,7 +978,7 @@ Pass    Pass    3S      Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -998,7 +998,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1019,7 +1019,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1037,13 +1037,13 @@ Pass    Pass
 {HCP 9 13 15 3}
 {TP 10 15 15 5}
 {Losers 8 6 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 3H      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1063,7 +1063,7 @@ Pass    Pass    2S      Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -1081,10 +1081,10 @@ Pass    Pass
 {HCP 20 2 15 3}
 {TP 20 6 15 6}
 {Losers 5 7 6 8}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    7NT     Pass
+1N     Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1104,7 +1104,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -1124,7 +1124,7 @@ Pass    Pass    Pass
 [Contract "4D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    Pass    
 
 
@@ -1144,7 +1144,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1165,7 +1165,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    5C      Pass
 Pass    Pass    
 
@@ -1186,7 +1186,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -1204,13 +1204,13 @@ Pass    Pass
 {HCP 9 13 15 3}
 {TP 11 15 15 5}
 {Losers 7 5 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1230,7 +1230,7 @@ Pass    Pass    2S      Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -1251,7 +1251,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4S
+1N     Pass    2C      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -1272,7 +1272,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -1293,7 +1293,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -1313,7 +1313,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -1334,7 +1334,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -1355,7 +1355,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -1375,7 +1375,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -1393,13 +1393,13 @@ Pass    Pass
 {HCP 9 14 15 2}
 {TP 11 16 15 3}
 {Losers 7 5 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    2NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    2N     Pass
 Pass    3S      Pass    Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1419,7 +1419,7 @@ Pass    3S      Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -1440,7 +1440,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -1457,11 +1457,11 @@ Pass    Pass    Pass
 {HCP 14 7 15 4}
 {TP 14 9 15 6}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    3NT     Pass
+1N     Pass    2C      X
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1481,7 +1481,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 Pass    3H      Pass    Pass
 Pass    
@@ -1500,12 +1500,12 @@ Pass
 {HCP 9 12 16 3}
 {TP 12 12 16 5}
 {Losers 6 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      X
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1525,7 +1525,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -1543,11 +1543,11 @@ Pass    Pass
 {HCP 8 15 15 2}
 {TP 9 15 15 2}
 {Losers 8 8 6 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    2NT     Pass
+1N     Pass    2C      X
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1567,7 +1567,7 @@ Pass    Pass
 [Contract "3CX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 X       Pass    Pass    Pass
 
 
@@ -1588,7 +1588,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -1606,12 +1606,12 @@ Pass    Pass
 {HCP 8 12 17 3}
 {TP 11 15 17 5}
 {Losers 7 5 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1628,11 +1628,11 @@ Pass    Pass    3D      Pass
 {HCP 11 11 15 3}
 {TP 12 11 15 3}
 {Losers 7 8 8 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    3NT     Pass
+1N     Pass    2C      X
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1652,7 +1652,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -1672,7 +1672,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1690,11 +1690,11 @@ Pass    Pass
 {HCP 10 9 16 5}
 {TP 11 10 16 6}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    3NT     Pass
+1N     Pass    2C      X
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1714,7 +1714,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -1732,11 +1732,11 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 10 7 15 9}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    3NT     Pass
+1N     Pass    2C      X
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1753,11 +1753,11 @@ Pass    Pass
 {HCP 13 7 16 4}
 {TP 14 9 16 5}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2H      Pass    3NT     Pass
+1N     Pass    2C      X
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1777,7 +1777,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -1797,7 +1797,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -1817,7 +1817,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1838,7 +1838,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -1859,7 +1859,7 @@ Pass    Pass
 [Contract "3SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 X       Pass    Pass    Pass
 
 
@@ -1880,7 +1880,7 @@ X       Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1901,7 +1901,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1922,7 +1922,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -1939,12 +1939,12 @@ Pass    Pass    Pass
 {HCP 9 12 16 3}
 {TP 10 15 16 3}
 {Losers 8 5 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      2D
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1964,7 +1964,7 @@ Pass    Pass    2NT     Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1985,7 +1985,7 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 X       Pass    6D      Pass
 Pass    Pass    
 
@@ -2006,7 +2006,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 X       Pass    Pass    Pass
 
 
@@ -2027,7 +2027,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    4S      Pass
 Pass    Pass    
 
@@ -2048,7 +2048,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -2068,7 +2068,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -2086,12 +2086,12 @@ Pass    Pass
 {HCP 9 6 16 9}
 {TP 10 7 16 10}
 {Losers 8 8 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      X
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2108,11 +2108,11 @@ Pass    Pass
 {HCP 10 12 16 2}
 {TP 10 15 16 4}
 {Losers 8 6 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2132,7 +2132,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2153,7 +2153,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    Pass    
 
 
@@ -2173,7 +2173,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2194,7 +2194,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4D      Pass
 4H      Pass    Pass    Pass
 
@@ -2213,12 +2213,12 @@ Pass    Pass
 {HCP 9 13 16 2}
 {TP 10 15 16 3}
 {Losers 8 5 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      2S
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2235,12 +2235,12 @@ Pass    Pass    2NT     Pass
 {HCP 8 13 16 3}
 {TP 9 15 17 4}
 {Losers 9 5 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      2D
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2260,7 +2260,7 @@ Pass    Pass    2NT     Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2281,7 +2281,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -2302,7 +2302,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 X       Pass    Pass    Pass
 
 
@@ -2320,12 +2320,12 @@ X       Pass    Pass    Pass
 {HCP 9 7 17 7}
 {TP 9 8 17 8}
 {Losers 10 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      X
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2345,7 +2345,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -2366,7 +2366,7 @@ Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -2386,7 +2386,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2407,7 +2407,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -2425,11 +2425,11 @@ Pass    Pass
 {HCP 11 7 17 5}
 {TP 12 8 17 5}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    3NT     Pass
+1N     Pass    2C      X
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2446,12 +2446,12 @@ Pass    Pass
 {HCP 9 6 17 8}
 {TP 11 8 17 9}
 {Losers 7 7 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2471,7 +2471,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2492,9 +2492,9 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    5NT     Pass
+3N     Pass    5N     Pass
 6D      Pass    7D      Pass
 Pass    Pass    
 
@@ -2515,7 +2515,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -2535,7 +2535,7 @@ Pass    Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -2556,9 +2556,9 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6D      Pass    Pass    Pass
 
 
@@ -2579,7 +2579,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    3H      X
 4H      Pass    Pass    Pass
 
@@ -2601,7 +2601,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -2622,7 +2622,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2640,11 +2640,11 @@ Pass    Pass
 {HCP 8 12 15 5}
 {TP 10 15 16 7}
 {Losers 7 5 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
-2S      Pass    2NT     Pass
+1N     Pass    2C      2H
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2664,7 +2664,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      4C      4H      Pass
 Pass    Pass    
 
@@ -2685,7 +2685,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2706,7 +2706,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    5D      Pass
 Pass    Pass    
 
@@ -2727,7 +2727,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -2748,7 +2748,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    Pass    Pass
 
 
@@ -2769,7 +2769,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2790,7 +2790,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -2810,7 +2810,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -2830,7 +2830,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2851,7 +2851,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -2872,7 +2872,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -2893,7 +2893,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    2S      Pass
 3D      Pass    4S      Pass
 Pass    Pass    
@@ -2915,7 +2915,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2936,8 +2936,8 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    2NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2958,7 +2958,7 @@ Pass    Pass    2NT     Pass
 [Contract "6C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 4H      Pass    6C      Pass
 Pass    Pass    
@@ -2980,7 +2980,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3001,7 +3001,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -3021,7 +3021,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3042,7 +3042,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4S
+1N     Pass    2C      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -3063,7 +3063,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3084,7 +3084,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -3105,7 +3105,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -3125,7 +3125,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      3D
 Pass    3H      Pass    Pass
 Pass    
@@ -3147,7 +3147,7 @@ Pass
 [Contract "4D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    Pass    
 
 
@@ -3167,7 +3167,7 @@ Pass    Pass    Pass
 [Contract "4SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4S
+1N     Pass    2C      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -3188,7 +3188,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -3209,7 +3209,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    4H      Pass
 Pass    Pass    
 
@@ -3230,7 +3230,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -3247,11 +3247,11 @@ Pass    Pass    Pass
 {HCP 9 10 16 5}
 {TP 9 14 17 7}
 {Losers 8 5 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3D
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3D
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3268,11 +3268,11 @@ Pass    Pass
 {HCP 14 6 15 5}
 {TP 15 10 16 7}
 {Losers 7 6 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3292,9 +3292,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3H      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -3316,7 +3316,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -3337,7 +3337,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4S
+1N     Pass    2C      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -3358,7 +3358,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -3379,7 +3379,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      4C      4S      Pass
 Pass    Pass    
 
@@ -3400,7 +3400,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      X
 Pass    Pass    Pass    
 
@@ -3421,7 +3421,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -3441,7 +3441,7 @@ Pass    Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -3459,12 +3459,12 @@ Pass    Pass
 {HCP 9 12 16 3}
 {TP 11 14 17 3}
 {Losers 7 6 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      2S
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3484,7 +3484,7 @@ Pass    Pass    2NT     Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -3504,7 +3504,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -3525,7 +3525,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -3547,7 +3547,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3568,7 +3568,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3589,7 +3589,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    Pass    
 
 
@@ -3609,7 +3609,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      4D      4H      Pass
 Pass    Pass    
 
@@ -3630,7 +3630,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3651,7 +3651,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3672,7 +3672,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3690,11 +3690,11 @@ Pass    Pass
 {HCP 9 13 15 3}
 {TP 9 16 15 4}
 {Losers 8 4 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3H
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3H
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3714,7 +3714,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 4S      Pass    Pass    Pass
 
@@ -3736,7 +3736,7 @@ Pass    Pass    X       Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -3753,12 +3753,12 @@ Pass    Pass    Pass
 {HCP 9 13 16 2}
 {TP 11 15 16 2}
 {Losers 7 6 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3775,11 +3775,11 @@ Pass    Pass    2S      Pass
 {HCP 11 12 15 2}
 {TP 11 16 16 4}
 {Losers 8 3 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3799,7 +3799,7 @@ Pass    Pass
 [Contract "2SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -3820,7 +3820,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    Pass    Pass
 
 
@@ -3841,9 +3841,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    4S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -3864,8 +3864,8 @@ Pass    Pass    4S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    2NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    2N     Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3886,7 +3886,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -3908,7 +3908,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 Pass    Pass    Pass    
 
 
@@ -3928,7 +3928,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3946,11 +3946,11 @@ Pass    Pass
 {HCP 8 14 15 3}
 {TP 9 15 15 4}
 {Losers 8 7 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    2NT     Pass
+1N     Pass    2C      X
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3970,7 +3970,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -3988,11 +3988,11 @@ Pass    Pass
 {HCP 14 9 16 1}
 {TP 14 11 16 3}
 {Losers 7 6 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3D
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3D
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4012,10 +4012,10 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3D      Pass
-4C      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+4C      Pass    4N     Pass
+5S      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -4036,7 +4036,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4054,11 +4054,11 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 11 8 15 8}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2H      Pass    3NT     Pass
+1N     Pass    2C      X
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4075,11 +4075,11 @@ Pass    Pass
 {HCP 12 13 15 0}
 {TP 13 16 15 3}
 {Losers 7 5 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2H
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4099,7 +4099,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4120,7 +4120,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -4141,7 +4141,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    2S      Pass
 Pass    Pass    
 
@@ -4162,7 +4162,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -4183,7 +4183,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -4204,7 +4204,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -4221,11 +4221,11 @@ Pass    Pass    Pass
 {HCP 11 13 15 1}
 {TP 11 15 16 2}
 {Losers 8 6 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4245,7 +4245,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -4266,7 +4266,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 X       Pass    4C      Pass
 4S      Pass    Pass    Pass
 
@@ -4288,7 +4288,7 @@ X       Pass    4C      Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -4308,7 +4308,7 @@ Pass    Pass    Pass
 [Contract "4HX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -4329,7 +4329,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4350,7 +4350,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 X       Pass    4H      Pass
 Pass    Pass    
 
@@ -4368,12 +4368,12 @@ Pass    Pass
 {HCP 9 7 17 7}
 {TP 11 10 17 9}
 {Losers 7 7 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      X
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4390,12 +4390,12 @@ Pass    Pass
 {HCP 10 10 17 3}
 {TP 12 11 17 4}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4412,11 +4412,11 @@ Pass    Pass
 {HCP 15 7 16 2}
 {TP 15 11 17 4}
 {Losers 7 6 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3D
-X       Pass    3NT     Pass
+1N     Pass    2C      3D
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4433,11 +4433,11 @@ Pass    Pass
 {HCP 13 3 17 7}
 {TP 13 7 17 10}
 {Losers 7 7 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4457,9 +4457,9 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3D      Pass
-3NT     Pass    6D      Pass
+3N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -4476,11 +4476,11 @@ Pass    Pass
 {HCP 13 7 15 5}
 {TP 13 9 15 6}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    3NT     Pass
+1N     Pass    2C      X
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4500,7 +4500,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4518,11 +4518,11 @@ Pass    Pass
 {HCP 11 9 17 3}
 {TP 12 9 17 4}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    3NT     Pass
+1N     Pass    2C      X
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4542,7 +4542,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -4563,7 +4563,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4584,7 +4584,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -4606,7 +4606,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -4626,7 +4626,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4647,7 +4647,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 X       Pass    Pass    Pass
 
 
@@ -4665,11 +4665,11 @@ X       Pass    Pass    Pass
 {HCP 15 3 15 7}
 {TP 15 7 15 10}
 {Losers 6 7 8 7}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      4D
-Pass    Pass    6NT     Pass
+1N     Pass    2C      4D
+Pass    Pass    6N     Pass
 Pass    Pass    
 
 
@@ -4689,7 +4689,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    5D      Pass
 Pass    Pass    
 
@@ -4710,7 +4710,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4728,12 +4728,12 @@ Pass    Pass
 {HCP 9 6 17 8}
 {TP 12 8 17 9}
 {Losers 6 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      X
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4753,7 +4753,7 @@ Pass    Pass    2NT     Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -4772,11 +4772,11 @@ Pass    Pass    2NT     Pass
 {HCP 9 13 15 3}
 {TP 10 15 15 4}
 {Losers 8 7 6 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    2NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4796,7 +4796,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -4816,7 +4816,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 Pass    3H      Pass    Pass
 Pass    
@@ -4838,7 +4838,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4859,7 +4859,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -4879,7 +4879,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -4900,7 +4900,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4921,7 +4921,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4942,7 +4942,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    4S      Pass
 Pass    Pass    
 
@@ -4963,7 +4963,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    2S      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
@@ -4985,7 +4985,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -5007,7 +5007,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5025,12 +5025,12 @@ Pass    Pass
 {HCP 9 14 15 2}
 {TP 10 16 15 2}
 {Losers 9 6 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5050,7 +5050,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -5070,7 +5070,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -5088,12 +5088,12 @@ Pass    Pass
 {HCP 8 13 16 3}
 {TP 10 14 16 5}
 {Losers 8 6 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5113,7 +5113,7 @@ Pass    Pass    2S      Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -5134,7 +5134,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5152,11 +5152,11 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 11 13 15 10}
 {Losers 8 5 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3H
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3H
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5176,7 +5176,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5194,11 +5194,11 @@ Pass    Pass
 {HCP 9 7 15 9}
 {TP 10 10 15 10}
 {Losers 8 7 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    2NT     Pass
+1N     Pass    2C      X
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5215,11 +5215,11 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 12 9 16 7}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    3NT     Pass
+1N     Pass    2C      X
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5236,11 +5236,11 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 13 7 15 7}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    3NT     Pass
+1N     Pass    2C      X
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5257,11 +5257,11 @@ Pass    Pass
 {HCP 14 5 16 5}
 {TP 14 8 16 7}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2H      Pass    3NT     Pass
+1N     Pass    2C      X
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5281,7 +5281,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5302,7 +5302,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    Pass    
 
 
@@ -5322,7 +5322,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -5342,7 +5342,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -5363,7 +5363,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5384,7 +5384,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -5404,7 +5404,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -5426,7 +5426,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -5443,12 +5443,12 @@ Pass    Pass    Pass
 {HCP 11 12 16 1}
 {TP 13 15 16 3}
 {Losers 6 5 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5468,7 +5468,7 @@ Pass    Pass    3C      Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -5489,7 +5489,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5510,7 +5510,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5531,7 +5531,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -5551,7 +5551,7 @@ Pass    Pass    Pass
 [Contract "4D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    Pass    
 
 
@@ -5571,7 +5571,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5592,7 +5592,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5613,7 +5613,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -5633,7 +5633,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5654,7 +5654,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5675,7 +5675,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5696,7 +5696,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -5717,7 +5717,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5735,11 +5735,11 @@ Pass    Pass
 {HCP 11 13 15 1}
 {TP 11 16 15 2}
 {Losers 8 5 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5759,7 +5759,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -5777,12 +5777,12 @@ Pass    Pass
 {HCP 9 15 16 0}
 {TP 10 16 16 1}
 {Losers 8 5 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      2S
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5802,7 +5802,7 @@ Pass    Pass    2NT     Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    4D      Pass
 4H      Pass    Pass    Pass
 
@@ -5821,11 +5821,11 @@ X       Pass    4D      Pass
 {HCP 18 1 15 6}
 {TP 18 4 15 9}
 {Losers 7 8 7 7}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5842,11 +5842,11 @@ Pass    Pass
 {HCP 9 16 15 0}
 {TP 10 16 15 1}
 {Losers 9 6 6 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    2NT     Pass
+1N     Pass    2C      X
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5866,7 +5866,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5887,7 +5887,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -5908,7 +5908,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -5929,7 +5929,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -5949,7 +5949,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -5967,11 +5967,11 @@ Pass    Pass
 {HCP 13 6 15 6}
 {TP 13 8 15 7}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    3NT     Pass
+1N     Pass    2C      X
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5991,7 +5991,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6012,7 +6012,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -6033,7 +6033,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -6055,7 +6055,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -6077,7 +6077,7 @@ Pass    Pass    3S      Pass
 [Contract "6C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    6C      Pass
 Pass    Pass    
 
@@ -6098,7 +6098,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6119,7 +6119,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6140,7 +6140,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4S
+1N     Pass    2C      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -6161,7 +6161,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    2S      Pass
 3D      Pass    Pass    Pass
 
@@ -6180,12 +6180,12 @@ Pass    Pass
 {HCP 8 12 16 4}
 {TP 9 14 16 6}
 {Losers 9 6 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6205,7 +6205,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    2S      Pass
 Pass    Pass    
 
@@ -6226,7 +6226,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -6248,7 +6248,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6269,7 +6269,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -6290,7 +6290,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -6311,7 +6311,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6329,11 +6329,11 @@ Pass    Pass
 {HCP 12 7 15 6}
 {TP 14 10 15 8}
 {Losers 7 7 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    3NT     Pass
+1N     Pass    2C      X
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6353,7 +6353,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -6373,7 +6373,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -6391,11 +6391,11 @@ Pass    Pass
 {HCP 14 8 17 1}
 {TP 14 11 17 4}
 {Losers 6 6 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6415,7 +6415,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6436,7 +6436,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6457,7 +6457,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -6477,7 +6477,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6498,7 +6498,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -6519,7 +6519,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -6536,11 +6536,11 @@ Pass    Pass    Pass
 {HCP 11 7 15 7}
 {TP 11 10 16 8}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    3NT     Pass
+1N     Pass    2C      X
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6560,7 +6560,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -6581,7 +6581,7 @@ Pass    Pass
 [Contract "2HX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -6602,7 +6602,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -6623,7 +6623,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -6643,7 +6643,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -6663,7 +6663,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6684,7 +6684,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6702,12 +6702,12 @@ Pass    Pass
 {HCP 8 10 17 5}
 {TP 10 11 17 5}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      X
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6727,7 +6727,7 @@ Pass    Pass    2NT     Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -6748,7 +6748,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6769,7 +6769,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -6789,7 +6789,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -6810,7 +6810,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6831,7 +6831,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -6851,7 +6851,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -6872,9 +6872,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3H      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 5D      Pass    5H      Pass
 6S      Pass    Pass    Pass
 
@@ -6893,11 +6893,11 @@ Pass    Pass
 {HCP 14 9 15 2}
 {TP 14 12 15 5}
 {Losers 7 5 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3D
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3D
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6917,7 +6917,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -6935,11 +6935,11 @@ Pass    Pass
 {HCP 9 12 15 4}
 {TP 9 15 15 6}
 {Losers 10 5 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
-2S      Pass    2NT     Pass
+1N     Pass    2C      2D
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6959,7 +6959,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -6979,7 +6979,7 @@ Pass    Pass    Pass
 [Contract "6C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    6C      Pass
 Pass    Pass    
 
@@ -6997,11 +6997,11 @@ Pass    Pass
 {HCP 8 13 16 3}
 {TP 10 15 16 7}
 {Losers 8 5 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7021,7 +7021,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -7041,7 +7041,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -7062,7 +7062,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -7083,7 +7083,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -7103,7 +7103,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -7124,7 +7124,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7145,7 +7145,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -7165,7 +7165,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -7185,7 +7185,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -7207,7 +7207,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -7228,7 +7228,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -7249,7 +7249,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -7270,7 +7270,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -7291,7 +7291,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -7311,7 +7311,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -7331,7 +7331,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -7351,7 +7351,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    4S      Pass
 Pass    Pass    
 
@@ -7372,7 +7372,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -7392,7 +7392,7 @@ Pass    Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -7413,7 +7413,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    4S      Pass
 Pass    Pass    
 
@@ -7434,7 +7434,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -7455,7 +7455,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -7476,9 +7476,9 @@ Pass    Pass
 [Contract "5S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      4C      4S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    Pass    Pass
 
 
@@ -7499,7 +7499,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -7516,12 +7516,12 @@ Pass    Pass    Pass
 {HCP 8 8 16 8}
 {TP 10 10 16 8}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7541,8 +7541,8 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2H      Pass    3NT     Pass
+1N     Pass    2C      X
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -7563,7 +7563,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -7581,12 +7581,12 @@ Pass    Pass
 {HCP 11 11 15 3}
 {TP 14 12 16 5}
 {Losers 6 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7606,7 +7606,7 @@ Pass    Pass    3D      Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4C      Pass
 5C      X       XX      Pass
 5D      Pass    6S      Pass
@@ -7629,7 +7629,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -7647,12 +7647,12 @@ Pass    Pass
 {HCP 10 10 15 5}
 {TP 12 11 15 5}
 {Losers 7 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7669,11 +7669,11 @@ Pass    Pass
 {HCP 10 11 15 4}
 {TP 10 12 15 5}
 {Losers 9 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    3NT     Pass
+1N     Pass    2C      X
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7693,7 +7693,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -7713,9 +7713,9 @@ Pass    Pass    Pass
 [Contract "5H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -7736,7 +7736,7 @@ Pass    Pass    4H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7757,7 +7757,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7778,7 +7778,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -7798,7 +7798,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -7819,7 +7819,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 4S      Pass    Pass    Pass
 
@@ -7841,7 +7841,7 @@ Pass    Pass    X       Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -7862,11 +7862,11 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3H      Pass
 4D      Pass    4H      Pass
-4NT     Pass    5C      Pass
-5D      Pass    5NT     Pass
+4N     Pass    5C      Pass
+5D      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -7887,7 +7887,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7908,7 +7908,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 3C      Pass    3D      Pass
 4D      Pass    5D      Pass
@@ -7931,7 +7931,7 @@ Pass    Pass
 [Contract "2HX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -7952,7 +7952,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -7973,7 +7973,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -7994,7 +7994,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -8015,7 +8015,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -8033,12 +8033,12 @@ Pass    Pass
 {HCP 9 6 16 9}
 {TP 10 7 16 9}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8055,11 +8055,11 @@ Pass    Pass
 {HCP 12 11 15 2}
 {TP 14 11 15 3}
 {Losers 6 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2H      Pass    3NT     Pass
+1N     Pass    2C      X
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8079,7 +8079,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8100,8 +8100,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    3NT     Pass
+1N     Pass    2C      X
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -8122,7 +8122,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -8143,7 +8143,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8161,11 +8161,11 @@ Pass    Pass
 {HCP 10 7 16 7}
 {TP 11 10 17 8}
 {Losers 8 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    3NT     Pass
+1N     Pass    2C      X
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8185,9 +8185,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
-4NT     Pass    6D      Pass
+4N     Pass    6D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -8208,7 +8208,7 @@ Pass    Pass    4S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8226,11 +8226,11 @@ Pass    Pass
 {HCP 11 7 16 6}
 {TP 11 9 16 8}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2H      Pass    3NT     Pass
+1N     Pass    2C      X
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8250,7 +8250,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -8272,7 +8272,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    Pass    
 
 
@@ -8292,7 +8292,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -8313,7 +8313,7 @@ Pass    Pass
 [Contract "6C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    6C      Pass
 Pass    Pass    
 
@@ -8331,11 +8331,11 @@ Pass    Pass
 {HCP 9 12 15 4}
 {TP 9 15 15 6}
 {Losers 9 5 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
-Pass    Pass    2NT     Pass
+1N     Pass    2C      2D
+Pass    Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8355,7 +8355,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 X       Pass    4S      Pass
 Pass    Pass    
 
@@ -8376,7 +8376,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -8397,7 +8397,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -8417,7 +8417,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -8438,7 +8438,7 @@ Pass    Pass
 [Contract "3HX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 X       Pass    Pass    Pass
 
 
@@ -8459,7 +8459,7 @@ X       Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    Pass    
 
 
@@ -8479,7 +8479,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -8497,11 +8497,11 @@ Pass    Pass
 {HCP 15 4 16 5}
 {TP 15 8 16 8}
 {Losers 6 7 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8521,7 +8521,7 @@ Pass    Pass
 [Contract "6C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 X       Pass    6C      Pass
 Pass    Pass    
 
@@ -8542,7 +8542,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -8563,7 +8563,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -8581,11 +8581,11 @@ Pass    Pass
 {HCP 8 10 15 7}
 {TP 9 10 15 7}
 {Losers 8 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    2NT     Pass
+1N     Pass    2C      X
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8605,7 +8605,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -8622,11 +8622,11 @@ Pass    Pass    Pass
 {HCP 15 6 15 4}
 {TP 15 10 15 7}
 {Losers 7 6 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8646,7 +8646,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -8667,7 +8667,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -8688,7 +8688,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -8709,9 +8709,9 @@ Pass    Pass
 [Contract "6C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3C      Pass
-3NT     Pass    6C      Pass
+3N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -8731,7 +8731,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -8749,11 +8749,11 @@ Pass    Pass
 {HCP 12 9 15 4}
 {TP 14 10 15 5}
 {Losers 7 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2H      Pass    3NT     Pass
+1N     Pass    2C      X
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8773,7 +8773,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8794,7 +8794,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -8811,11 +8811,11 @@ Pass    Pass    Pass
 {HCP 11 14 15 0}
 {TP 11 15 15 0}
 {Losers 8 7 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2H      Pass    3NT     Pass
+1N     Pass    2C      X
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8835,7 +8835,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    4S      Pass
 Pass    Pass    
 
@@ -8853,11 +8853,11 @@ Pass    Pass
 {HCP 17 6 15 2}
 {TP 17 8 15 3}
 {Losers 7 8 7 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2H      Pass    4NT     Pass
+1N     Pass    2C      X
+2H      Pass    4N     Pass
 Pass    Pass    
 
 
@@ -8877,7 +8877,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -8898,7 +8898,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -8917,11 +8917,11 @@ Pass    Pass
 {HCP 12 9 17 2}
 {TP 12 12 18 4}
 {Losers 7 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3S
-X       Pass    3NT     Pass
+1N     Pass    2C      3S
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8941,7 +8941,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -8962,7 +8962,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -8983,9 +8983,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -9006,7 +9006,7 @@ Pass    Pass    4S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9027,7 +9027,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 3D      Pass    3S      Pass
 4D      Pass    5D      Pass
@@ -9050,7 +9050,7 @@ Pass    Pass
 [Contract "2DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 X       Pass    Pass    Pass
 
 
@@ -9071,7 +9071,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9092,7 +9092,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    4H      Pass
 Pass    Pass    
 
@@ -9113,7 +9113,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    2S      Pass
 3D      Pass    Pass    Pass
 
@@ -9132,13 +9132,13 @@ Pass    Pass
 {HCP 8 14 15 3}
 {TP 9 16 15 5}
 {Losers 9 5 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9155,11 +9155,11 @@ Pass    Pass    2S      Pass
 {HCP 13 4 16 7}
 {TP 14 7 16 10}
 {Losers 7 7 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9179,7 +9179,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -9200,7 +9200,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -9221,7 +9221,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 X       Pass    4H      Pass
 Pass    Pass    
 
@@ -9242,7 +9242,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -9263,7 +9263,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    4S      Pass
 Pass    Pass    
 
@@ -9281,13 +9281,13 @@ Pass    Pass
 {HCP 8 13 15 4}
 {TP 9 16 15 5}
 {Losers 9 5 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9304,11 +9304,11 @@ Pass    Pass    2S      Pass
 {HCP 9 14 15 2}
 {TP 9 16 15 3}
 {Losers 9 6 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    2NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    2N     Pass
 Pass    Pass    
 
 
@@ -9325,11 +9325,11 @@ Pass    Pass
 {HCP 13 11 16 0}
 {TP 13 11 16 0}
 {Losers 7 8 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    3NT     Pass
+1N     Pass    2C      X
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9349,7 +9349,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -9370,7 +9370,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9391,7 +9391,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9409,11 +9409,11 @@ Pass    Pass
 {HCP 15 6 15 4}
 {TP 15 8 15 6}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2H      Pass    3NT     Pass
+1N     Pass    2C      X
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9433,7 +9433,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9454,7 +9454,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9475,7 +9475,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9496,7 +9496,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9514,11 +9514,11 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 11 9 16 5}
 {Losers 9 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    3NT     Pass
+1N     Pass    2C      X
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9538,7 +9538,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -9559,7 +9559,7 @@ Pass    Pass
 [Contract "2SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -9580,9 +9580,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -9603,7 +9603,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9624,7 +9624,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9645,7 +9645,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 X       Pass    Pass    Pass
 
 
@@ -9666,7 +9666,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9687,7 +9687,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 X       Pass    5C      Pass
 Pass    Pass    
 
@@ -9708,8 +9708,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    3NT     Pass
+1N     Pass    2C      X
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -9730,7 +9730,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -9751,9 +9751,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    3D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -9774,7 +9774,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -9795,7 +9795,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -9816,7 +9816,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 X       Pass    4C      Pass
 4H      Pass    Pass    Pass
 
@@ -9835,12 +9835,12 @@ X       Pass    4C      Pass
 {HCP 9 8 15 8}
 {TP 11 9 16 9}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      X
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9860,7 +9860,7 @@ Pass    Pass    2NT     Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9878,12 +9878,12 @@ Pass    Pass
 {HCP 9 14 17 0}
 {TP 10 14 17 0}
 {Losers 8 7 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9903,7 +9903,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -9924,7 +9924,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -9945,7 +9945,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9966,7 +9966,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9987,7 +9987,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -10008,7 +10008,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -10029,7 +10029,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    5D      Pass
 Pass    Pass    
 
@@ -10050,7 +10050,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -10071,7 +10071,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10092,7 +10092,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -10109,11 +10109,11 @@ Pass    Pass    Pass
 {HCP 11 13 16 0}
 {TP 11 15 17 2}
 {Losers 9 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10133,7 +10133,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -10155,7 +10155,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10176,7 +10176,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -10197,7 +10197,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -10215,12 +10215,12 @@ Pass    Pass
 {HCP 9 14 16 1}
 {TP 9 16 16 2}
 {Losers 10 5 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      2S
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10237,11 +10237,11 @@ Pass    Pass    2NT     Pass
 {HCP 10 9 16 5}
 {TP 11 10 17 5}
 {Losers 8 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    3NT     Pass
+1N     Pass    2C      X
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10261,10 +10261,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3S      Pass
-4C      X       4NT     Pass
-5C      Pass    5NT     Pass
+4C      X       4N     Pass
+5C      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -10285,7 +10285,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -10306,7 +10306,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -10326,7 +10326,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10344,11 +10344,11 @@ Pass    Pass
 {HCP 10 7 17 6}
 {TP 10 8 17 6}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    3NT     Pass
+1N     Pass    2C      X
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10365,11 +10365,11 @@ Pass    Pass
 {HCP 10 11 15 4}
 {TP 11 12 15 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-Pass    Pass    3NT     Pass
+1N     Pass    2C      X
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10389,7 +10389,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10410,7 +10410,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10428,12 +10428,12 @@ Pass    Pass
 {HCP 9 14 17 0}
 {TP 9 16 17 2}
 {Losers 9 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      2D
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10453,7 +10453,7 @@ Pass    Pass
 [Contract "2SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 X       Pass    Pass    Pass
 
 
@@ -10474,7 +10474,7 @@ X       Pass    Pass    Pass
 [Contract "6D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3H
+1N     Pass    2C      3H
 Pass    Pass    6D      Pass
 Pass    Pass    
 
@@ -10495,7 +10495,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    Pass    
 
 
@@ -10515,7 +10515,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -10536,6 +10536,6 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4H
+1N     Pass    2C      4H
 Pass    Pass    Pass    
 

--- a/GIB/GIB_1N-P-2C-X
+++ b/GIB/GIB_1N-P-2C-X
@@ -4,10 +4,10 @@
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AT94.QJ87.KQ84.7 .642.JT2.KQJT964 K32.A93.A975.A53 QJ8765.KT5.63.82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    3NT     Pass
+1N     Pass    2C      Db
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -18,7 +18,7 @@ Pass    Pass
 [Deal "N:AQ95.KQ876.T7.96 643.T9.432.KQJ53 KJT.A43.KJ85.AT2 872.J52.AQ96.874"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -31,7 +31,7 @@ Pass    Pass
 [Deal "N:KT97.KQ52.QT82.4 Q2.J93.53.AQT762 A6543.A7.AK9.985 J8.T864.J764.KJ3"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -43,7 +43,7 @@ Pass    Pass
 [Deal "N:KJT87.AK75.Q63.9 Q64.962.4.QJT854 A53.Q4.AJ9.A7632 92.JT83.KT8752.K"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 Pass    Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -54,11 +54,11 @@ Pass    Pass    3S      Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:8532.KQ983.A54.9 QJ6.J76.T6.AQT74 A9.AT2.KQJ7.K862 KT74.54.9832.J53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -69,8 +69,8 @@ Pass    Pass    2NT     Pass
 [Deal "N:A653.J2.JT53.A75 874.A8.72.KJT983 KQ92.Q964.AQ8.Q4 JT.KT753.K964.62"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2H      Pass    3NT     Pass
+1N     Pass    2C      Db
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -82,7 +82,7 @@ Pass    Pass    2NT     Pass
 [Deal "N:QT74.K752.T874.K J65.QT.65.AJT872 K98.A983.AK92.Q3 A32.J64.QJ3.9654"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -94,7 +94,7 @@ Pass    Pass
 [Deal "N:J752.KT952.AJT2. 86.J6.76.KQJ7653 AQT3.AQ.KQ5.9842 K94.8743.9843.AT"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -104,10 +104,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KQT.KT83.K85.953 62.654.AT2.KQJ42 AJ5.A72.Q9763.AT 98743.QJ9.J4.876"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    3NT     Pass
+1N     Pass    2C      Db
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -118,7 +118,7 @@ Pass    Pass
 [Deal "N:T843.AT973.KQ.72 652.65.AT7.AKQJ4 AKQ.KQJ8.J3.T963 J97.42.986542.85"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -130,7 +130,7 @@ Pass    Pass
 [Deal "N:QT74.QJ743.KQ7.5 A2.92.T63.KJT643 8653.AK85.A52.A2 KJ9.T6.J984.Q987"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -142,7 +142,7 @@ Pass    Pass
 [Deal "N:A98.KQT5.J865.72 QT6.J98.4.KQT965 K52.63.AKQ.AJ843 J743.A742.T9732."]
 [Contract "2CX"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 Pass    Pass    Pass    
 
 
@@ -153,7 +153,7 @@ Pass    Pass    Pass
 [Deal "N:Q865.K874.AT63.Q 4.JT3.J52.KJT875 AJT2.AQ5.KQ87.94 K973.962.94.A632"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -163,10 +163,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:T982.AKQ8.K932.4 AJ3.952.7.QJT987 K65.J6.AJ864.AK2 Q74.T743.QT5.653"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    3NT     Pass
+1N     Pass    2C      Db
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -177,7 +177,7 @@ Pass    Pass
 [Deal "N:Q854.AJ96.A98.T6 76.T54.T64.AQJ42 AJ.KQ732.Q72.K75 KT932.8.KJ53.983"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -187,10 +187,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T62.KQ86.QJ5.A97 984.A7.32.KJT865 AKQ.J32.K8764.Q4 J753.T954.AT9.32"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    3NT     Pass
+1N     Pass    2C      Db
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -199,11 +199,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJ642.J942.QT6.9 QT3.K6.953.KQJ84 K95.AQ3.KJ7.AT72 87.T875.A842.653"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -214,7 +214,7 @@ Pass    Pass    2NT     Pass
 [Deal "N:Q973.KQJ8.KT75.9 J54.95.Q63.AQJ63 AKT2.642.AJ.KT82 86.AT73.9842.754"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -226,7 +226,7 @@ Pass    Pass
 [Deal "N:QJ52.AJ65.QJ8.A2 83.K97.T2.KJT763 A4.Q832.AK765.Q5 KT976.T4.943.984"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -238,7 +238,7 @@ Pass    Pass
 [Deal "N:AQJ75.9632.KT6.6 T4.K87.2.KJT9874 K863.AQ4.J94.AQ3 92.JT5.AQ8753.52"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -248,10 +248,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K652.KQT.J9842.2 97.J54.K7.KJT843 JT4.A98.AQT5.A76 AQ83.7632.63.Q95"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    2NT     Pass
+1N     Pass    2C      Db
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -262,7 +262,7 @@ Pass    Pass
 [Deal "N:AT86.QJ72.AJT5.8 53.T86.74.KQT943 KJ.AK54.KQ8.J765 Q9742.93.9632.A2"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -272,11 +272,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A82.A964.AQ642.7 543.T5.K9.QJT653 KQT.KJ.JT85.AK42 J976.Q8732.73.98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 Rd      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -285,10 +285,10 @@ Rd      Pass    3D      Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T7.KQJ5.QT83.754 J62.83.92.KQT863 Q984.A96.AJ74.A9 AK53.T742.K65.J2"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2S      Pass    2NT     Pass
+1N     Pass    2C      Db
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -299,7 +299,7 @@ Pass    Pass
 [Deal "N:AQ54.QT73.T4.Q62 982.92.532.AKT87 63.AK86.AKQ8.543 KJT7.J54.J976.J9"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -311,7 +311,7 @@ Pass    Pass
 [Deal "N:KJ83.A852.KJ42.3 T74.764.86.AQT54 AQ65.Q93.AT97.K6 92.KJT.Q53.J9872"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      4C      4S      Pass
 Pass    Pass    
 
@@ -321,10 +321,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KT97.Q5.KQJ9.832 6.932.T63.AQT764 AQ8.AKJ8.8752.K9 J5432.T764.A4.J5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2H      Pass    3NT     Pass
+1N     Pass    2C      Db
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -335,7 +335,7 @@ Pass    Pass
 [Deal "N:KQ642.QT97.Q982. 9.KJ.763.KJT9543 AT3.A6532.JT.AQ6 J875.84.AK54.872"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -347,7 +347,7 @@ Pass    Pass
 [Deal "N:QJT86.QT64.QT8.9 953.J.542.AKT643 AK4.K85.KJ6.QJ72 72.A9732.A973.85"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -359,7 +359,7 @@ Pass    Pass
 [Deal "N:J876.AKJ74.QT6.4 T42.853.87.AQJ32 AK53.T92.AK9.K98 Q9.Q6.J5432.T765"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -369,11 +369,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:7532.KQ862.K764. QJT.954.5.QJT985 AK6.AT.J83.A7632 984.J73.AQT92.K4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -384,7 +384,7 @@ Pass    Pass    2NT     Pass
 [Deal "N:AJT2.AQ754.97.84 Q43.KT.JT.KJT652 K6.982.AQ654.AQ3 9875.J63.K832.97"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -397,7 +397,7 @@ Pass    Pass    2NT     Pass
 [Deal "N:JT65.KJT2.A63.A8 843.853.75.KQJ63 AKQ9.A76.Q92.T75 72.Q94.KJT84.942"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -407,10 +407,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AKT8.J92.QT753.6 763.T43.98.KQJ82 Q92.AKQ.AJ42.954 J54.8765.K6.AT73"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    3NT     Pass
+1N     Pass    2C      Db
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -419,10 +419,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:65.AK72.KQ92.J82 J.T84.T63.AKT543 AQ94.Q65.AJ75.Q7 KT8732.J93.84.96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2S      Pass    3NT     Pass
+1N     Pass    2C      Db
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -431,11 +431,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QJT7.J932.QJ3.Q9 854.Q8.98.AJT753 K93.AKT.KT6.K862 A62.7654.A7542.4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -446,7 +446,7 @@ Pass    Pass    2NT     Pass
 [Deal "N:AT62.KQJ52.763.9 97.T74.84.KQT873 QJ853.63.AKJ.A52 K4.A98.QT952.J64"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -458,7 +458,7 @@ Pass    Pass
 [Deal "N:KJ8.AJ53.KJ732.5 T97.T87.6.KQT984 A53.KQ9.AQ54.732 Q642.642.T98.AJ6"]
 [Contract "5D"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2D      Pass    3D      Pass
 4D      Pass    5D      Pass
 Pass    Pass    
@@ -471,7 +471,7 @@ Pass    Pass
 [Deal "N:AK6.KQ63.J642.82 J87.987.A9.KQJ63 Q942.AJ54.KQ8.AT T53.T2.T753.9754"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -483,7 +483,7 @@ Pass    Pass
 [Deal "N:KT42.AKQ93.932.3 73.4.854.KJT9642 AJ98.JT2.AJ.AQ75 Q65.8765.KQT76.8"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -495,7 +495,7 @@ Pass    Pass
 [Deal "N:Q6.AJ64.KQJ4.K42 T93.Q7.87.AJT973 AK87.K952.A3.Q86 J542.T83.T9652.5"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    3S      Pass
 4D      Pass    5D      Pass
 6H      Pass    Pass    Pass
@@ -507,11 +507,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q872.AJ82.Q6.732 43.T65.872.KQJ64 A96.KQ.AT543.A98 KJT5.9743.KJ9.T5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -522,7 +522,7 @@ Pass    Pass
 [Deal "N:KJ94.A53.A7632.9 872.72.QJ.KQJ732 AQT63.Q64.KT4.A8 5.KJT98.985.T654"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -532,10 +532,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AJ2.K865.T9532.6 75.732.Q7.AKT987 K93.AJ9.AK86.543 QT864.QT4.J4.QJ2"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    2NT     Pass
+1N     Pass    2C      Db
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -546,7 +546,7 @@ Pass    Pass
 [Deal "N:A765.T842.AQ75.2 943.K96.J2.AKQ85 KQ.AQJ53.K98.974 JT82.7.T643.JT63"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -556,10 +556,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KT96.74.QJT64.A8 43.JT6.87.KJT654 AQ8.KQ532.A53.72 J752.A98.K92.Q93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2H      Pass    3NT     Pass
+1N     Pass    2C      Db
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -570,7 +570,7 @@ Pass    Pass
 [Deal "N:KQ63.QJ982.A92.3 542.K.Q64.QJT974 AJ97.A64.J3.AK85 T8.T753.KT875.62"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -580,10 +580,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQ84.J.Q7532.K96 J96.542.9.AQJ873 K72.AKQT3.K86.T5 T53.9876.AJT4.42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2H      Pass    3NT     Pass
+1N     Pass    2C      Db
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -592,10 +592,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T85.AKQJ.5.98762 A97.974.43.AQJT4 KJ4.T82.AKJT.K53 Q632.653.Q98762."]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    3NT     Pass
+1N     Pass    2C      Db
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -604,11 +604,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K752.KQ2.73.6532 T3.764.A52.AQJT4 AQ4.A53.QJ86.K97 J986.JT98.KT94.8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -619,7 +619,7 @@ Pass    Pass
 [Deal "N:K954.AJ8.K763.T8 QJT.K2.JT8.AQJ63 A762.Q63.AQ.K754 83.T9754.9542.92"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -631,7 +631,7 @@ Pass    Pass
 [Deal "N:KJT5.J6.A954.J95 843.T54.72.AKQT8 AQ76.AQ2.KJ6.632 92.K9873.QT83.74"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -641,10 +641,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AKQ2.K872.Q54.64 JT7.AT.JT.KJT983 84.Q64.AK932.AQ2 9653.J953.876.75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    3NT     Pass
+1N     Pass    2C      Db
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -653,10 +653,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K75.KT32.KQ76.98 T2.974.T98.AKJ52 AQJ9.A8.AJ32.T64 8643.QJ65.54.Q73"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2S      Pass    3NT     Pass
+1N     Pass    2C      Db
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -665,10 +665,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A52.KT96.QJ2.T72 K6.742.93.KQJ853 QJ7.AQ8.K754.A64 T9843.J53.AT86.9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    3NT     Pass
+1N     Pass    2C      Db
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -679,7 +679,7 @@ Pass    Pass
 [Deal "N:97.KQ74.KT74.T73 84.J82.852.AQJ92 KT5.AT93.AQJ.K65 AQJ632.65.963.84"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -692,7 +692,7 @@ Pass    Pass
 [Deal "N:A642.AQT9.J64.A6 T9.J6.Q83.QJT753 KQ83.K52.AK52.82 J75.8743.T97.K94"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -704,7 +704,7 @@ Pass    Pass
 [Deal "N:KQ98.KT64.KQJ43. JT6.98.92.KQT986 A73.Q752.AT6.AJ5 542.AJ3.875.7432"]
 [Contract "5H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4C      Pass
 4D      Pass    5C      Pass
 5H      Pass    Pass    Pass
@@ -716,10 +716,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T65.AKQ2.T642.T2 J73.85.953.KQJ94 AKQ94.94.KQJ.876 82.JT763.A87.A53"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2S      Pass    2NT     Pass
+1N     Pass    2C      Db
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -728,10 +728,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQ83.KT8.Q93.A73 J4.5.K82.KJT8652 AT9.AQJ74.AJ4.94 7652.9632.T765.Q"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2H      Pass    3NT     Pass
+1N     Pass    2C      Db
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -740,11 +740,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:763.K874.AJ982.3 J2.952.Q6.KQJ865 A984.AQ.K43.AT92 KQT5.JT63.T75.74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -755,7 +755,7 @@ Pass    Pass
 [Deal "N:AQJT4.7543.742.2 85.K82.AT5.KQJ63 K2.AQJ9.KQ83.985 9763.T6.J96.AT74"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -767,7 +767,7 @@ Pass    Pass
 [Deal "N:K865.AQJT5.Q8.43 74.94.54.AKT9865 AQ93.K72.KT3.QJ7 JT2.863.AJ9762.2"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -777,11 +777,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:96.KJ74.KQJ52.52 JT5.95.T8.KQT843 A74.A2.A743.AJ97 KQ832.QT863.96.6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 Rd      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -792,7 +792,7 @@ Rd      Pass    3D      Pass
 [Deal "N:K8543.AK53.T.532 A7.974.863.KQJT6 QJT.QT6.AQJ92.A8 962.J82.K754.974"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -803,10 +803,10 @@ Rd      Pass    3D      Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K732.K42.A976.52 T96.QJT.J5.AKT64 AJ.A9753.KQ8.J73 Q854.86.T432.Q98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2H      Pass    3NT     Pass
+1N     Pass    2C      Db
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -817,7 +817,7 @@ Pass    Pass
 [Deal "N:K965.AT62.QJ742. J8.98.T93.KQT764 A43.K743.K5.AJ92 QT72.QJ5.A86.853"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -827,11 +827,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQT7.T3.AQT73.63 42.762.K65.AQJ95 KJ5.AKQ.984.K742 9863.J9854.J2.T8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 Pass    Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -842,7 +842,7 @@ Pass    Pass    3D      Pass
 [Deal "N:KJ93.AKJT.J653.8 T82.83.K7.AJT974 AQ76.Q95.AQT4.K2 54.7642.982.Q653"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -854,7 +854,7 @@ Pass    Pass
 [Deal "N:QJ53.63.AT985.J2 AT.T72.J72.AKT63 976.AKQJ8.KQ6.54 K842.954.43.Q987"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    2S      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
@@ -867,7 +867,7 @@ Pass    Pass
 [Deal "N:AQJ86.QJ96.K8.54 92.AT.732.QJT982 74.K843.AQT65.AK KT53.752.J94.763"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -879,7 +879,7 @@ Pass    Pass
 [Deal "N:32.AQ63.JT9.J973 KJ7.52.Q43.AKT85 AT6.KT74.AK72.Q2 Q9854.J98.865.64"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -891,7 +891,7 @@ Pass    Pass
 [Deal "N:K4.AT76.QT842.64 T62.J32.AJ.AKT85 AQJ9.KQ98.K7.Q97 8753.54.9653.J32"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -901,10 +901,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJT2.QT64.653.KT 743.32.QJ9.AQJ97 A65.AK9.A8.85432 Q98.J875.KT742.6"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-Pass    Pass    2NT     Pass
+1N     Pass    2C      Db
+Pass    Pass    2N     Pass
 Pass    Pass    
 
 
@@ -913,10 +913,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AT3.KT93.QJ732.2 85.J42.94.KQT743 KJ7.AQ6.A865.J86 Q9642.875.KT.A95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    3NT     Pass
+1N     Pass    2C      Db
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -927,7 +927,7 @@ Pass    Pass
 [Deal "N:9642.A832.A8762. 875.T.T93.AKJ763 AJT.KQJ97.KQ.T52 KQ3.654.J54.Q984"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -939,7 +939,7 @@ Pass    Pass
 [Deal "N:Q965.QJT65.AQ4.4 T4.943.J8.AKJ865 AKJ83.AK8.95.732 72.72.KT7632.QT9"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -949,10 +949,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K63.KT32.A73.Q76 JT5.J76.Q.AJT852 A972.AQ5.K94.K43 Q84.984.JT8652.9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2S      Pass    3NT     Pass
+1N     Pass    2C      Db
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -963,7 +963,7 @@ Pass    Pass
 [Deal "N:AK63.J7542.J5.T2 T5.KT8.T63.AQJ84 Q9874.AQ9.AK8.63 J2.63.Q9742.K975"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -973,11 +973,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:83.KT83.K642.K97 6.962.953.AQJT43 AKQJ9.A75.Q87.85 T7542.QJ4.AJT.62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -988,7 +988,7 @@ Pass    Pass
 [Deal "N:JT8.A432.Q2.Q982 53.QT7.A75.AKJT5 AK64.KJ95.KJ8.43 Q972.86.T9643.76"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -998,11 +998,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A643.AJT43.T74.9 T5.876.Q53.KQJT6 KQJ.Q9.A82.A8543 9872.K52.KJ96.72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1013,7 +1013,7 @@ Pass    Pass    2NT     Pass
 [Deal "N:AJT5.KQ84.K95.54 K7.62.764.KQJ973 82.AT75.AQJT.A82 Q9643.J93.832.T6"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1023,11 +1023,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T632.AKT2.J.T972 Q95.986.86.AKQ86 K7.QJ3.AKQT7.J53 AJ84.754.95432.4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1036,11 +1036,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:8742.A9432.AJ4.8 65.K5.985.KQT762 AKQ.J8.QT73.AJ95 JT93.QT76.K62.43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 Rd      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1051,7 +1051,7 @@ Rd      Pass    3H      Pass
 [Deal "N:KQJT.K9732..T652 986.J8.T62.AKJ84 A543.AQ6.A754.Q7 72.T54.KQJ983.93"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1061,11 +1061,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:4.AKJ3.98643.875 QT6.972.J2.AKJT4 K932.Q8.AKQ7.Q92 AJ875.T654.T5.63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1074,11 +1074,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AJ83.K865.84.653 9.J74.Q76.QJT842 Q54.QT2.AKJT5.A9 KT762.A93.932.K7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Db
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1089,7 +1089,7 @@ Pass    Pass
 [Deal "N:KQ93.KJ72.K9642. J6.Q5.T7.KJT8742 T854.A9.AQ5.AQ65 A72.T8643.J83.93"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1101,7 +1101,7 @@ Pass    Pass
 [Deal "N:KQJ.AJ64.Q762.86 T62.92.53.AKT942 97.KQ5.AKJ9.QJ53 A8543.T873.T84.7"]
 [Contract "2CX"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 Pass    Pass    Pass    
 
 
@@ -1112,7 +1112,7 @@ Pass    Pass    Pass
 [Deal "N:KJ53.J64.A642.T2 84.T82.T83.AKJ96 AT92.A3.KQ95.Q74 Q76.KQ975.J7.853"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1124,7 +1124,7 @@ Pass    Pass
 [Deal "N:QJ3.AKT6.654.J65 A92.J2.JT9.AQT87 K8.Q754.AK72.K94 T7654.983.Q83.32"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1134,10 +1134,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KT8.AQJ6.6432.76 973.975.87.KQJ43 A52.32.AKJT5.A95 QJ64.KT84.Q9.T82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    3NT     Pass
+1N     Pass    2C      Db
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1148,7 +1148,7 @@ Pass    Pass
 [Deal "N:A72.KQ84.K54.942 JT3.52.83.AQJ873 Q954.AJT7.AJ9.KT K86.963.QT762.65"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1160,7 +1160,7 @@ Pass    Pass
 [Deal "N:KT93.KQJ76.Q8.43 J84.32.J75.AKJ52 AQ2.AT4.KT64.QT9 765.985.A932.876"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1173,7 +1173,7 @@ Pass    Pass
 [Deal "N:J962.AT76.AQ953. K75.J3.T2.KJT432 AT3.K985.KJ7.AQ6 Q84.Q42.864.9875"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1185,7 +1185,7 @@ Pass    Pass
 [Deal "N:K32.KQT8.QJT65.A QJ.975.93.KQT843 A985.A642.AK.962 T764.J3.8742.J75"]
 [Contract "5H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4C      Pass
 4D      Pass    5C      Pass
 5D      Pass    5H      Pass
@@ -1197,10 +1197,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J96.K762.KQ54.52 T72.Q95.7.KJT983 A543.A8.AJ83.Q64 KQ8.JT43.T962.A7"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2S      Pass    2NT     Pass
+1N     Pass    2C      Db
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1211,7 +1211,7 @@ Pass    Pass
 [Deal "N:AT842.AK76.4.872 Q7.J5.QJ2.QJT543 96.QT43.AKT63.AK KJ53.982.9875.96"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1221,9 +1221,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:86.A942.KQJ97.73 Q95.Q86.2.QJT842 AKT3.JT.543.AK65 J742.K753.AT86.9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2S      Pass    3NT     Pass
+1N     Pass    2C      Db
+2S      Pass    3N     Pass
 Pass    Pass    
 

--- a/GIB/GIB_1N-P-2C.pbn
+++ b/GIB/GIB_1N-P-2C.pbn
@@ -12,11 +12,11 @@
 {HCP 10 8 15 7}
 {TP 10 11 15 8}
 {Losers 9 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -36,7 +36,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -57,7 +57,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -75,11 +75,11 @@ Pass    Pass
 {HCP 12 10 16 2}
 {TP 13 11 17 2}
 {Losers 6 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
-2S      Pass    3NT     Pass
+1N     Pass    2C      2H
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -96,11 +96,11 @@ Pass    Pass
 {HCP 13 3 17 7}
 {TP 14 5 17 7}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -120,7 +120,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -138,11 +138,11 @@ Pass    Pass
 {HCP 11 7 17 5}
 {TP 12 9 17 6}
 {Losers 8 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -159,11 +159,11 @@ Pass    Pass
 {HCP 8 11 15 6}
 {TP 9 12 15 6}
 {Losers 8 8 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -180,11 +180,11 @@ Pass    Pass
 {HCP 12 11 15 2}
 {TP 13 13 15 4}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -204,7 +204,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -222,11 +222,11 @@ Pass    Pass
 {HCP 13 12 15 0}
 {TP 14 13 15 1}
 {Losers 6 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -243,11 +243,11 @@ Pass    Pass
 {HCP 11 8 17 4}
 {TP 12 8 17 6}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -264,11 +264,11 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 12 9 15 8}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -285,12 +285,12 @@ Pass    Pass
 {HCP 13 8 16 3}
 {TP 15 9 16 4}
 {Losers 6 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -310,7 +310,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -331,7 +331,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -349,11 +349,11 @@ Pass    Pass
 {HCP 10 10 15 5}
 {TP 12 12 15 6}
 {Losers 7 6 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -370,11 +370,11 @@ Pass    Pass
 {HCP 14 3 17 6}
 {TP 14 4 17 7}
 {Losers 7 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -394,7 +394,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -412,11 +412,11 @@ Pass    Pass
 {HCP 16 8 15 1}
 {TP 17 8 15 1}
 {Losers 7 10 6 12}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    4NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    4N     Pass
 Pass    Pass    
 
 
@@ -433,11 +433,11 @@ Pass    Pass
 {HCP 9 11 15 5}
 {TP 11 12 15 6}
 {Losers 7 6 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -454,11 +454,11 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 11 6 15 10}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -478,7 +478,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -496,11 +496,11 @@ Pass    Pass
 {HCP 9 12 15 4}
 {TP 10 12 15 5}
 {Losers 9 8 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -520,7 +520,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -541,7 +541,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -562,7 +562,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -581,11 +581,11 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 10 11 15 6}
 {Losers 8 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -602,12 +602,12 @@ Pass    Pass
 {HCP 9 5 17 9}
 {TP 10 6 17 9}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -624,11 +624,11 @@ Pass    Pass
 {HCP 11 11 17 1}
 {TP 11 11 17 1}
 {Losers 8 9 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -648,8 +648,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -667,12 +667,12 @@ Pass    Pass
 {HCP 9 8 17 6}
 {TP 10 9 17 6}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -689,12 +689,12 @@ Pass    Pass
 {HCP 9 8 15 8}
 {TP 10 9 16 8}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -714,7 +714,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3S      Pass
 4H      Pass    5C      Pass
 5H      Pass    6H      Pass
@@ -737,7 +737,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -755,12 +755,12 @@ Pass    Pass
 {HCP 8 6 17 9}
 {TP 10 7 17 9}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -777,10 +777,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 7 16 10}
 {Losers 8 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -800,7 +800,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -821,7 +821,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -842,7 +842,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -863,7 +863,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -884,7 +884,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -902,11 +902,11 @@ Pass    Pass
 {HCP 15 7 15 3}
 {TP 15 8 15 4}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -926,7 +926,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -947,7 +947,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -966,12 +966,12 @@ Pass    Pass
 {HCP 8 13 16 3}
 {TP 9 14 16 6}
 {Losers 9 6 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -991,7 +991,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1012,7 +1012,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1030,11 +1030,11 @@ Pass    Pass
 {HCP 10 10 16 4}
 {TP 10 10 16 4}
 {Losers 8 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1051,11 +1051,11 @@ Pass    Pass
 {HCP 12 8 16 4}
 {TP 12 11 16 5}
 {Losers 8 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1072,11 +1072,11 @@ Pass    Pass
 {HCP 15 6 15 4}
 {TP 15 6 15 5}
 {Losers 8 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1093,12 +1093,12 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 10 12 15 8}
 {Losers 7 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1118,7 +1118,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1136,12 +1136,12 @@ Pass    Pass
 {HCP 13 7 15 5}
 {TP 15 7 16 5}
 {Losers 6 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1158,11 +1158,11 @@ Pass    Pass
 {HCP 11 6 16 7}
 {TP 11 7 16 7}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1182,7 +1182,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1200,11 +1200,11 @@ Pass    Pass
 {HCP 9 13 15 3}
 {TP 9 13 15 4}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1221,11 +1221,11 @@ Pass    Pass
 {HCP 14 8 16 2}
 {TP 14 8 16 3}
 {Losers 8 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1245,7 +1245,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1263,11 +1263,11 @@ Pass    Pass
 {HCP 12 10 15 3}
 {TP 12 11 15 5}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1284,11 +1284,11 @@ Pass    Pass
 {HCP 12 8 15 5}
 {TP 12 9 15 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1308,7 +1308,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1329,7 +1329,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -1348,12 +1348,12 @@ Pass    Pass
 {HCP 9 8 17 6}
 {TP 9 8 17 6}
 {Losers 9 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1370,11 +1370,11 @@ Pass    Pass
 {HCP 12 10 15 3}
 {TP 13 10 15 4}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1391,11 +1391,11 @@ Pass    Pass
 {HCP 12 2 17 9}
 {TP 13 2 17 9}
 {Losers 8 12 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1412,12 +1412,12 @@ Pass    Pass
 {HCP 17 6 15 2}
 {TP 18 7 15 3}
 {Losers 6 8 7 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3C      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -1437,7 +1437,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -1459,7 +1459,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3S      Pass
 4C      Pass    4D      Pass
 4S      Pass    6H      Pass
@@ -1482,7 +1482,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1500,11 +1500,11 @@ Pass    Pass
 {HCP 11 9 15 5}
 {TP 11 9 15 5}
 {Losers 9 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1521,11 +1521,11 @@ Pass    Pass
 {HCP 13 3 16 8}
 {TP 13 6 16 8}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1545,7 +1545,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -1566,7 +1566,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1584,11 +1584,11 @@ Pass    Pass
 {HCP 17 8 15 0}
 {TP 17 8 16 0}
 {Losers 6 10 6 12}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -1605,12 +1605,12 @@ Pass    Pass
 {HCP 9 7 16 8}
 {TP 10 7 16 8}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1627,12 +1627,12 @@ Pass    Pass
 {HCP 9 9 17 5}
 {TP 11 9 17 5}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1649,12 +1649,12 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 12 9 15 8}
 {Losers 6 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1674,7 +1674,7 @@ Pass    Pass    3D      Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -1692,11 +1692,11 @@ Pass    Pass
 {HCP 9 7 15 9}
 {TP 9 7 15 9}
 {Losers 9 8 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1713,11 +1713,11 @@ Pass    Pass
 {HCP 11 3 17 9}
 {TP 11 3 17 9}
 {Losers 8 11 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1734,11 +1734,11 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 11 8 16 7}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1755,11 +1755,11 @@ Pass    Pass
 {HCP 12 6 17 5}
 {TP 12 7 17 5}
 {Losers 7 10 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1779,7 +1779,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1797,11 +1797,11 @@ Pass    Pass
 {HCP 13 5 16 6}
 {TP 13 6 16 6}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1821,7 +1821,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1842,7 +1842,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    3S      Pass    Pass
 Pass    
 
@@ -1860,11 +1860,11 @@ Pass
 {HCP 12 10 16 2}
 {TP 12 10 17 3}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1881,11 +1881,11 @@ Pass    Pass
 {HCP 14 4 15 7}
 {TP 14 5 15 7}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1905,7 +1905,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1923,12 +1923,12 @@ Pass    Pass
 {HCP 12 6 15 7}
 {TP 13 6 16 7}
 {Losers 7 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1945,11 +1945,11 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 10 10 15 6}
 {Losers 8 10 6 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1966,11 +1966,11 @@ Pass    Pass
 {HCP 12 7 16 5}
 {TP 12 8 16 5}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1987,11 +1987,11 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 11 8 15 7}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2011,7 +2011,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2029,11 +2029,11 @@ Pass    Pass
 {HCP 15 9 15 1}
 {TP 15 10 16 1}
 {Losers 6 8 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2050,11 +2050,11 @@ Pass    Pass
 {HCP 8 11 15 6}
 {TP 9 11 15 7}
 {Losers 9 7 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2074,7 +2074,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -2096,7 +2096,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -2116,7 +2116,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2134,11 +2134,11 @@ Pass    Pass
 {HCP 15 7 17 1}
 {TP 15 7 17 2}
 {Losers 8 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2158,7 +2158,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    2S      Pass
 3C      Pass    3D      Pass
 3H      Pass    4H      Pass
@@ -2178,11 +2178,11 @@ Pass    Pass
 {HCP 11 11 16 2}
 {TP 11 12 16 3}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2199,12 +2199,12 @@ Pass    Pass
 {HCP 14 3 16 7}
 {TP 15 4 16 8}
 {Losers 6 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2224,7 +2224,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2245,8 +2245,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -2264,13 +2264,13 @@ Pass    Pass
 {HCP 9 9 16 6}
 {TP 11 12 17 6}
 {Losers 8 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2287,11 +2287,11 @@ Pass    Pass    2S      Pass
 {HCP 10 9 15 6}
 {TP 10 10 15 6}
 {Losers 9 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2308,11 +2308,11 @@ Pass    Pass
 {HCP 12 8 16 4}
 {TP 13 8 17 5}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2332,7 +2332,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      3H      4S      Pass
 Pass    Pass    
 
@@ -2350,12 +2350,12 @@ Pass    Pass
 {HCP 8 12 16 4}
 {TP 10 13 16 4}
 {Losers 8 7 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2372,11 +2372,11 @@ Pass    Pass
 {HCP 12 10 15 3}
 {TP 12 10 15 4}
 {Losers 9 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2396,7 +2396,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2417,7 +2417,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      4D
+1N     Pass    2C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -2438,7 +2438,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2456,11 +2456,11 @@ Pass    Pass
 {HCP 9 7 15 9}
 {TP 9 7 15 10}
 {Losers 10 10 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2480,7 +2480,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    Pass    
 
 
@@ -2497,11 +2497,11 @@ Pass    Pass    Pass
 {HCP 10 10 15 5}
 {TP 11 13 15 6}
 {Losers 8 6 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2521,7 +2521,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2539,11 +2539,11 @@ Pass    Pass
 {HCP 9 7 15 9}
 {TP 9 7 15 9}
 {Losers 9 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2560,11 +2560,11 @@ Pass    Pass
 {HCP 12 6 16 6}
 {TP 12 6 16 6}
 {Losers 7 11 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2584,7 +2584,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2605,7 +2605,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -2623,12 +2623,12 @@ Pass    Pass
 {HCP 9 9 16 6}
 {TP 10 12 16 7}
 {Losers 9 6 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2645,11 +2645,11 @@ Pass    Pass
 {HCP 8 15 15 2}
 {TP 9 17 16 2}
 {Losers 9 4 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2666,12 +2666,12 @@ Pass    Pass
 {HCP 8 6 17 9}
 {TP 9 6 17 9}
 {Losers 9 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2688,11 +2688,11 @@ Pass    Pass
 {HCP 13 10 16 1}
 {TP 13 10 16 2}
 {Losers 7 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2712,7 +2712,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -2733,7 +2733,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -2753,7 +2753,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2774,7 +2774,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    Pass    3D
+1N     Pass    Pass    3D
 Pass    Pass    Pass    
 
 
@@ -2794,9 +2794,9 @@ Pass    Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3S      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6H      Pass
 Pass    Pass    
 
@@ -2814,11 +2814,11 @@ Pass    Pass
 {HCP 12 5 17 6}
 {TP 13 6 17 6}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2835,11 +2835,11 @@ Pass    Pass
 {HCP 14 1 17 8}
 {TP 14 2 17 8}
 {Losers 7 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2859,7 +2859,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -2878,11 +2878,11 @@ Pass    Pass
 {HCP 11 4 15 10}
 {TP 11 4 15 10}
 {Losers 7 11 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2899,11 +2899,11 @@ Pass    Pass
 {HCP 10 14 15 1}
 {TP 10 14 15 2}
 {Losers 10 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2923,7 +2923,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2941,11 +2941,11 @@ Pass    Pass
 {HCP 12 4 15 9}
 {TP 13 5 15 9}
 {Losers 8 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2962,11 +2962,11 @@ Pass    Pass
 {HCP 12 4 16 8}
 {TP 12 5 16 8}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2986,7 +2986,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3004,11 +3004,11 @@ Pass    Pass
 {HCP 9 11 15 5}
 {TP 11 13 15 6}
 {Losers 7 7 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3028,9 +3028,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3S      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    5D      Pass
 6C      Pass    6H      Pass
 Pass    Pass    
@@ -3049,11 +3049,11 @@ Pass    Pass
 {HCP 14 5 16 5}
 {TP 14 7 16 6}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3073,7 +3073,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3094,7 +3094,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3112,11 +3112,11 @@ Pass    Pass
 {HCP 18 3 15 4}
 {TP 18 3 15 5}
 {Losers 6 10 8 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -3133,11 +3133,11 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 10 7 15 9}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3154,11 +3154,11 @@ Pass    Pass
 {HCP 17 4 15 4}
 {TP 17 4 15 6}
 {Losers 7 11 7 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -3175,12 +3175,12 @@ Pass    Pass
 {HCP 9 7 17 7}
 {TP 11 8 18 7}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3200,7 +3200,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -3218,11 +3218,11 @@ Pass    Pass
 {HCP 14 9 15 2}
 {TP 14 9 15 3}
 {Losers 7 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3239,11 +3239,11 @@ Pass    Pass
 {HCP 8 10 15 7}
 {TP 9 11 15 7}
 {Losers 8 8 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3260,11 +3260,11 @@ Pass    Pass
 {HCP 9 12 15 4}
 {TP 9 12 15 4}
 {Losers 9 9 7 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3284,7 +3284,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3305,7 +3305,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3326,7 +3326,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2H      Pass
 Pass    Pass    
 
@@ -3344,11 +3344,11 @@ Pass    Pass
 {HCP 13 5 15 7}
 {TP 13 6 15 8}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3365,11 +3365,11 @@ Pass    Pass
 {HCP 14 8 15 3}
 {TP 14 10 16 5}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3386,11 +3386,11 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 10 9 15 7}
 {Losers 10 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3407,11 +3407,11 @@ Pass    Pass
 {HCP 12 6 15 7}
 {TP 14 7 15 7}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3428,12 +3428,12 @@ Pass    Pass
 {HCP 18 2 15 5}
 {TP 19 3 15 5}
 {Losers 5 10 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -3453,7 +3453,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3474,7 +3474,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -3492,11 +3492,11 @@ Pass    Pass
 {HCP 12 7 17 4}
 {TP 13 7 17 4}
 {Losers 8 10 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3513,11 +3513,11 @@ Pass    Pass
 {HCP 13 6 16 5}
 {TP 14 6 16 6}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3537,7 +3537,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3558,7 +3558,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3579,7 +3579,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3597,12 +3597,12 @@ Pass    Pass
 {HCP 9 9 16 6}
 {TP 11 11 17 6}
 {Losers 8 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3619,11 +3619,11 @@ Pass    Pass
 {HCP 12 8 16 4}
 {TP 12 8 16 5}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3643,7 +3643,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3665,7 +3665,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3683,11 +3683,11 @@ Pass    Pass
 {HCP 16 4 15 5}
 {TP 17 7 15 5}
 {Losers 6 8 6 9}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    4NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    4N     Pass
 Pass    Pass    
 
 
@@ -3704,11 +3704,11 @@ Pass    Pass
 {HCP 11 6 16 7}
 {TP 11 7 17 7}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3725,11 +3725,11 @@ Pass    Pass
 {HCP 14 6 17 3}
 {TP 16 6 18 4}
 {Losers 5 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3746,11 +3746,11 @@ Pass    Pass
 {HCP 11 11 15 3}
 {TP 12 11 15 4}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3770,7 +3770,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3788,12 +3788,12 @@ Pass    Pass
 {HCP 9 11 16 4}
 {TP 10 11 16 5}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3813,7 +3813,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3831,11 +3831,11 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 9 10 15 7}
 {Losers 9 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3852,11 +3852,11 @@ Pass    Pass
 {HCP 13 8 17 2}
 {TP 13 8 17 3}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3876,7 +3876,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -3897,7 +3897,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3915,11 +3915,11 @@ Pass    Pass
 {HCP 13 9 16 2}
 {TP 14 10 16 4}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3939,7 +3939,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3957,12 +3957,12 @@ Pass    Pass
 {HCP 9 9 16 6}
 {TP 10 11 16 7}
 {Losers 8 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3979,11 +3979,11 @@ Pass    Pass
 {HCP 9 8 15 8}
 {TP 10 9 15 8}
 {Losers 8 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4003,7 +4003,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -4022,12 +4022,12 @@ Pass    Pass
 {HCP 11 8 17 4}
 {TP 12 8 17 4}
 {Losers 8 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4047,7 +4047,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4065,11 +4065,11 @@ Pass    Pass
 {HCP 12 5 15 8}
 {TP 12 5 15 8}
 {Losers 7 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4089,7 +4089,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3S      Pass
 4D      Pass    6H      Pass
 Pass    Pass    
@@ -4111,7 +4111,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -4129,11 +4129,11 @@ Pass    Pass
 {HCP 15 6 16 3}
 {TP 15 7 16 3}
 {Losers 7 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4153,7 +4153,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -4172,11 +4172,11 @@ Pass    Pass
 {HCP 13 7 16 4}
 {TP 13 9 16 6}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4196,7 +4196,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -4214,11 +4214,11 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 12 9 15 6}
 {Losers 7 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4235,11 +4235,11 @@ Pass    Pass
 {HCP 10 6 17 7}
 {TP 10 6 17 8}
 {Losers 9 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4256,12 +4256,12 @@ Pass    Pass
 {HCP 9 12 16 3}
 {TP 10 14 16 3}
 {Losers 8 6 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4281,7 +4281,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 Pass    Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -4303,7 +4303,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4321,12 +4321,12 @@ Pass    Pass
 {HCP 15 4 15 6}
 {TP 15 6 15 7}
 {Losers 6 8 8 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -4343,11 +4343,11 @@ Pass    Pass
 {HCP 13 10 15 2}
 {TP 14 10 15 3}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4364,11 +4364,11 @@ Pass    Pass
 {HCP 12 8 16 4}
 {TP 12 9 16 4}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4388,11 +4388,11 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5C      Pass
-5D      Pass    5NT     Pass
+4N     Pass    5C      Pass
+5D      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -4410,11 +4410,11 @@ Pass    Pass
 {HCP 11 13 16 0}
 {TP 11 13 17 1}
 {Losers 8 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4431,12 +4431,12 @@ Pass    Pass
 {HCP 11 8 17 4}
 {TP 12 9 17 5}
 {Losers 7 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4453,11 +4453,11 @@ Pass    Pass
 {HCP 12 9 17 2}
 {TP 12 10 17 2}
 {Losers 8 8 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4474,11 +4474,11 @@ Pass    Pass
 {HCP 9 9 15 7}
 {TP 9 9 15 7}
 {Losers 9 10 6 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4495,11 +4495,11 @@ Pass    Pass
 {HCP 14 8 15 3}
 {TP 14 9 15 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4516,12 +4516,12 @@ Pass    Pass
 {HCP 9 5 16 10}
 {TP 10 7 17 10}
 {Losers 8 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4541,7 +4541,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    2S      Pass
 3D      Pass    5D      Pass
 Pass    Pass    
@@ -4563,7 +4563,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4584,7 +4584,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -4603,11 +4603,11 @@ Pass    Pass
 {HCP 12 5 15 8}
 {TP 13 7 16 8}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4624,12 +4624,12 @@ Pass    Pass
 {HCP 17 6 15 2}
 {TP 17 6 15 3}
 {Losers 5 10 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3D      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -4646,11 +4646,11 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 13 9 15 7}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4670,7 +4670,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4691,7 +4691,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -4710,11 +4710,11 @@ Pass    Pass
 {HCP 17 4 15 4}
 {TP 17 4 15 5}
 {Losers 7 10 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -4734,7 +4734,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -4753,11 +4753,11 @@ Pass    Pass
 {HCP 13 6 16 5}
 {TP 14 6 16 6}
 {Losers 7 11 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4777,7 +4777,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4795,12 +4795,12 @@ Pass    Pass
 {HCP 9 10 16 5}
 {TP 10 11 16 6}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4817,11 +4817,11 @@ Pass    Pass
 {HCP 11 5 17 7}
 {TP 12 5 17 7}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4838,11 +4838,11 @@ Pass    Pass
 {HCP 10 4 17 9}
 {TP 10 4 17 10}
 {Losers 9 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4859,12 +4859,12 @@ Pass    Pass
 {HCP 9 13 16 2}
 {TP 9 13 17 3}
 {Losers 10 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4884,7 +4884,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4906,7 +4906,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -4925,11 +4925,11 @@ Pass    Pass
 {HCP 12 6 15 7}
 {TP 12 6 15 8}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4946,11 +4946,11 @@ Pass    Pass
 {HCP 10 9 16 5}
 {TP 10 10 16 5}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4967,11 +4967,11 @@ Pass    Pass
 {HCP 10 3 17 10}
 {TP 11 3 17 11}
 {Losers 8 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4988,12 +4988,12 @@ Pass    Pass
 {HCP 8 9 16 7}
 {TP 9 9 16 7}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5013,7 +5013,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5031,12 +5031,12 @@ Pass    Pass
 {HCP 17 6 15 2}
 {TP 18 7 15 4}
 {Losers 6 8 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5056,7 +5056,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3S      Pass
 4S      Pass    6H      Pass
 Pass    Pass    
@@ -5078,7 +5078,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5097,12 +5097,12 @@ Pass    Pass
 {HCP 12 7 15 6}
 {TP 12 7 15 6}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5122,7 +5122,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5143,7 +5143,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -5164,7 +5164,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5182,11 +5182,11 @@ Pass    Pass
 {HCP 12 3 15 10}
 {TP 12 3 15 10}
 {Losers 9 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5206,7 +5206,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5224,12 +5224,12 @@ Pass    Pass
 {HCP 17 5 15 3}
 {TP 17 6 15 5}
 {Losers 5 10 7 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5246,11 +5246,11 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 11 5 15 10}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5270,7 +5270,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5288,12 +5288,12 @@ Pass    Pass
 {HCP 16 4 15 5}
 {TP 17 5 15 5}
 {Losers 6 10 7 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -5313,7 +5313,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5335,7 +5335,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5353,11 +5353,11 @@ Pass    Pass
 {HCP 17 4 15 4}
 {TP 17 5 16 4}
 {Losers 7 10 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5374,11 +5374,11 @@ Pass    Pass
 {HCP 10 7 17 6}
 {TP 10 7 17 7}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5395,11 +5395,11 @@ Pass    Pass
 {HCP 9 6 15 10}
 {TP 9 7 15 10}
 {Losers 9 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5419,7 +5419,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5437,11 +5437,11 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 11 10 15 6}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5458,11 +5458,11 @@ Pass    Pass
 {HCP 13 3 17 7}
 {TP 13 4 17 8}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5479,11 +5479,11 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 9 12 15 6}
 {Losers 9 7 6 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5503,7 +5503,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5521,12 +5521,12 @@ Pass    Pass
 {HCP 16 0 17 7}
 {TP 16 0 17 7}
 {Losers 6 12 7 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2S      Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -5543,11 +5543,11 @@ Pass    Pass
 {HCP 12 4 16 8}
 {TP 13 4 16 8}
 {Losers 7 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5567,7 +5567,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5585,11 +5585,11 @@ Pass    Pass
 {HCP 12 4 17 7}
 {TP 13 4 17 7}
 {Losers 7 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5606,11 +5606,11 @@ Pass    Pass
 {HCP 11 4 17 8}
 {TP 11 5 17 9}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5627,11 +5627,11 @@ Pass    Pass
 {HCP 14 7 15 4}
 {TP 15 7 15 6}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5651,8 +5651,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -5670,11 +5670,11 @@ Pass    Pass
 {HCP 10 12 16 2}
 {TP 10 13 16 2}
 {Losers 9 7 5 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5691,12 +5691,12 @@ Pass    Pass
 {HCP 14 2 15 9}
 {TP 15 3 16 9}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5713,11 +5713,11 @@ Pass    Pass
 {HCP 13 10 16 1}
 {TP 13 12 16 3}
 {Losers 8 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2H
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5734,11 +5734,11 @@ Pass    Pass
 {HCP 11 9 16 4}
 {TP 11 10 16 6}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5755,11 +5755,11 @@ Pass    Pass
 {HCP 15 7 16 2}
 {TP 15 9 16 4}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5776,11 +5776,11 @@ Pass    Pass
 {HCP 10 10 15 5}
 {TP 11 11 16 6}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5797,12 +5797,12 @@ Pass    Pass
 {HCP 9 6 16 9}
 {TP 11 7 16 9}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5819,11 +5819,11 @@ Pass    Pass
 {HCP 9 12 15 4}
 {TP 10 13 16 6}
 {Losers 9 6 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5843,7 +5843,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5864,7 +5864,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5885,7 +5885,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5903,11 +5903,11 @@ Pass    Pass
 {HCP 12 8 16 4}
 {TP 12 9 16 4}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5924,11 +5924,11 @@ Pass    Pass
 {HCP 15 6 17 2}
 {TP 15 7 17 3}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5945,12 +5945,12 @@ Pass    Pass
 {HCP 17 3 15 5}
 {TP 18 5 16 5}
 {Losers 6 9 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3C      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5970,7 +5970,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2H      Pass
 4H      Pass    Pass    Pass
 
@@ -5992,7 +5992,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -6010,12 +6010,12 @@ Pass    Pass
 {HCP 9 6 16 9}
 {TP 9 6 17 9}
 {Losers 9 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6032,11 +6032,11 @@ Pass    Pass
 {HCP 9 13 15 3}
 {TP 11 13 15 4}
 {Losers 7 7 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6053,11 +6053,11 @@ Pass    Pass
 {HCP 11 7 17 5}
 {TP 12 8 17 6}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6074,11 +6074,11 @@ Pass    Pass
 {HCP 12 7 16 5}
 {TP 14 7 16 6}
 {Losers 6 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6095,11 +6095,11 @@ Pass    Pass
 {HCP 11 7 17 5}
 {TP 11 9 17 6}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6116,12 +6116,12 @@ Pass    Pass
 {HCP 9 6 16 9}
 {TP 9 6 16 10}
 {Losers 9 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6141,7 +6141,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6162,7 +6162,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6180,11 +6180,11 @@ Pass    Pass
 {HCP 10 9 16 5}
 {TP 10 11 16 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6201,11 +6201,11 @@ Pass    Pass
 {HCP 10 10 16 4}
 {TP 11 10 16 5}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6225,7 +6225,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6244,11 +6244,11 @@ Pass    Pass
 {HCP 10 8 16 6}
 {TP 10 9 17 7}
 {Losers 9 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6268,7 +6268,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    X       3D
 Pass    Pass    3H      Pass
 4H      Pass    Pass    Pass
@@ -6288,11 +6288,11 @@ Pass    Pass    3H      Pass
 {HCP 10 3 17 10}
 {TP 11 3 18 10}
 {Losers 9 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6309,11 +6309,11 @@ Pass    Pass
 {HCP 12 3 17 8}
 {TP 12 3 17 8}
 {Losers 8 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6333,7 +6333,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -6351,12 +6351,12 @@ Pass    Pass
 {HCP 13 10 16 1}
 {TP 15 10 16 2}
 {Losers 6 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6376,7 +6376,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6394,11 +6394,11 @@ Pass    Pass
 {HCP 14 5 17 4}
 {TP 14 5 17 5}
 {Losers 9 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6415,11 +6415,11 @@ Pass    Pass
 {HCP 10 15 15 0}
 {TP 10 15 15 2}
 {Losers 9 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6436,11 +6436,11 @@ Pass    Pass
 {HCP 15 6 15 4}
 {TP 15 8 16 5}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6457,11 +6457,11 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 13 10 15 7}
 {Losers 7 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6481,7 +6481,7 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4C      Pass
 4D      Pass    4S      Pass
 5H      Pass    Pass    Pass
@@ -6501,12 +6501,12 @@ Pass    Pass
 {HCP 17 0 16 7}
 {TP 17 1 16 7}
 {Losers 5 11 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -6523,11 +6523,11 @@ Pass    Pass
 {HCP 11 11 15 3}
 {TP 11 11 16 4}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6547,7 +6547,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 X       Pass    5C      Pass
 Pass    Pass    
 
@@ -6565,11 +6565,11 @@ Pass    Pass
 {HCP 13 7 16 4}
 {TP 13 8 17 4}
 {Losers 8 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6589,7 +6589,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -6608,10 +6608,10 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 10 16 9}
 {Losers 8 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6628,11 +6628,11 @@ Pass    Pass
 {HCP 15 4 17 4}
 {TP 15 6 17 5}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6652,7 +6652,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6670,11 +6670,11 @@ Pass    Pass
 {HCP 10 11 16 3}
 {TP 10 12 16 4}
 {Losers 8 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6694,7 +6694,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6712,12 +6712,12 @@ Pass    Pass
 {HCP 9 9 15 7}
 {TP 9 9 15 8}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6734,11 +6734,11 @@ Pass    Pass
 {HCP 13 7 15 5}
 {TP 13 8 16 5}
 {Losers 8 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6755,12 +6755,12 @@ Pass    Pass
 {HCP 12 7 17 4}
 {TP 14 7 17 4}
 {Losers 6 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6780,7 +6780,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -6801,7 +6801,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -6822,7 +6822,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4C      Pass
 4D      Pass    6S      Pass
 Pass    Pass    
@@ -6844,7 +6844,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6865,7 +6865,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -6885,7 +6885,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -6906,7 +6906,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6924,11 +6924,11 @@ Pass    Pass
 {HCP 13 7 15 5}
 {TP 13 8 15 5}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6948,7 +6948,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6969,8 +6969,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -6988,12 +6988,12 @@ Pass    Pass
 {HCP 8 10 17 5}
 {TP 9 11 17 6}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7010,11 +7010,11 @@ Pass    Pass
 {HCP 14 8 15 3}
 {TP 14 9 15 4}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7034,7 +7034,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7055,7 +7055,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7073,11 +7073,11 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 11 10 15 6}
 {Losers 7 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7097,7 +7097,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -7115,11 +7115,11 @@ Pass    Pass
 {HCP 14 4 15 7}
 {TP 15 4 15 8}
 {Losers 5 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7136,12 +7136,12 @@ Pass    Pass
 {HCP 13 4 17 6}
 {TP 14 5 17 6}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7161,7 +7161,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -7179,12 +7179,12 @@ Pass    Pass
 {HCP 8 10 17 5}
 {TP 10 11 18 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7204,7 +7204,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2H      Pass
 4H      Pass    Pass    Pass
 
@@ -7223,12 +7223,12 @@ Pass    Pass
 {HCP 13 10 15 2}
 {TP 15 12 15 4}
 {Losers 6 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7245,11 +7245,11 @@ Pass    Pass
 {HCP 13 11 16 0}
 {TP 13 11 16 0}
 {Losers 7 9 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7266,11 +7266,11 @@ Pass    Pass
 {HCP 13 9 16 2}
 {TP 13 9 17 2}
 {Losers 8 9 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7287,11 +7287,11 @@ Pass    Pass
 {HCP 9 8 15 8}
 {TP 9 8 15 9}
 {Losers 9 9 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7308,11 +7308,11 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 11 6 15 9}
 {Losers 8 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7332,7 +7332,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7353,7 +7353,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -7374,9 +7374,9 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    6D      Pass
+3N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -7396,7 +7396,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7414,11 +7414,11 @@ Pass    Pass
 {HCP 11 11 16 2}
 {TP 12 12 16 2}
 {Losers 8 7 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7435,12 +7435,12 @@ Pass    Pass
 {HCP 8 10 16 6}
 {TP 9 10 16 6}
 {Losers 9 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7457,11 +7457,11 @@ Pass    Pass
 {HCP 10 10 17 3}
 {TP 10 10 17 4}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7478,11 +7478,11 @@ Pass    Pass
 {HCP 9 6 15 10}
 {TP 9 7 15 10}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7502,7 +7502,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4D      Pass
 5D      Pass    5H      Pass
 6C      Pass    6S      Pass
@@ -7525,7 +7525,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3S      Pass
 4S      Pass    6H      Pass
 Pass    Pass    
@@ -7547,7 +7547,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -7565,11 +7565,11 @@ Pass    Pass
 {HCP 10 10 15 5}
 {TP 12 11 16 7}
 {Losers 7 8 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
-2H      Pass    3NT     Pass
+1N     Pass    2C      2D
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7586,11 +7586,11 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 12 7 15 8}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7607,11 +7607,11 @@ Pass    Pass
 {HCP 14 5 15 6}
 {TP 14 5 15 8}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7631,7 +7631,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7652,7 +7652,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -7670,11 +7670,11 @@ Pass    Pass
 {HCP 14 8 15 3}
 {TP 14 9 15 4}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7691,11 +7691,11 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 11 10 15 6}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7712,11 +7712,11 @@ Pass    Pass
 {HCP 14 4 17 5}
 {TP 15 4 17 5}
 {Losers 7 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7736,7 +7736,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -7754,11 +7754,11 @@ Pass    Pass
 {HCP 8 10 15 7}
 {TP 9 11 15 9}
 {Losers 9 7 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7775,11 +7775,11 @@ Pass    Pass
 {HCP 10 5 17 8}
 {TP 11 5 17 8}
 {Losers 8 10 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7799,7 +7799,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -7818,11 +7818,11 @@ Pass    Pass
 {HCP 10 10 17 3}
 {TP 11 10 17 3}
 {Losers 8 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7842,7 +7842,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7861,11 +7861,11 @@ Pass    Pass
 {HCP 14 10 15 1}
 {TP 14 12 15 2}
 {Losers 8 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7882,11 +7882,11 @@ Pass    Pass
 {HCP 13 8 15 4}
 {TP 13 9 16 4}
 {Losers 7 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7903,11 +7903,11 @@ Pass    Pass
 {HCP 15 2 15 8}
 {TP 15 2 15 9}
 {Losers 6 12 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7924,11 +7924,11 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 11 9 15 9}
 {Losers 7 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7945,11 +7945,11 @@ Pass    Pass
 {HCP 9 11 15 5}
 {TP 9 11 15 6}
 {Losers 10 8 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7966,11 +7966,11 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 11 10 15 6}
 {Losers 7 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7987,10 +7987,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 7 17 9}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8007,12 +8007,12 @@ Pass    Pass
 {HCP 9 8 17 6}
 {TP 9 10 18 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      X
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8029,12 +8029,12 @@ Pass    Pass
 {HCP 9 8 16 7}
 {TP 10 9 16 7}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8054,8 +8054,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -8076,7 +8076,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8097,7 +8097,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -8116,11 +8116,11 @@ Pass    Pass
 {HCP 10 11 17 2}
 {TP 11 12 17 4}
 {Losers 7 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8140,7 +8140,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -8161,7 +8161,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -8179,11 +8179,11 @@ Pass    Pass
 {HCP 17 0 16 7}
 {TP 18 1 16 7}
 {Losers 6 11 7 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -8200,11 +8200,11 @@ Pass    Pass
 {HCP 12 5 16 7}
 {TP 12 5 16 7}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8221,12 +8221,12 @@ Pass    Pass
 {HCP 9 8 15 8}
 {TP 11 8 15 8}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8246,7 +8246,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -8264,11 +8264,11 @@ Pass    Pass
 {HCP 10 12 15 3}
 {TP 10 13 15 5}
 {Losers 9 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8285,11 +8285,11 @@ Pass    Pass
 {HCP 13 6 17 4}
 {TP 13 6 17 5}
 {Losers 8 10 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8306,11 +8306,11 @@ Pass    Pass
 {HCP 12 1 17 10}
 {TP 12 2 17 11}
 {Losers 8 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8327,11 +8327,11 @@ Pass    Pass
 {HCP 9 11 15 5}
 {TP 9 11 15 5}
 {Losers 9 8 6 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8351,7 +8351,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8369,11 +8369,11 @@ Pass    Pass
 {HCP 9 13 15 3}
 {TP 9 13 15 4}
 {Losers 9 6 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8390,11 +8390,11 @@ Pass    Pass
 {HCP 11 9 17 3}
 {TP 11 10 17 4}
 {Losers 9 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8414,7 +8414,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8433,11 +8433,11 @@ Pass    Pass
 {HCP 10 12 15 3}
 {TP 10 12 16 4}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8454,11 +8454,11 @@ Pass    Pass
 {HCP 14 9 15 2}
 {TP 14 11 15 4}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8475,12 +8475,12 @@ Pass    Pass
 {HCP 9 14 17 0}
 {TP 9 15 17 1}
 {Losers 9 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8497,11 +8497,11 @@ Pass    Pass
 {HCP 13 3 15 9}
 {TP 14 4 15 9}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8518,12 +8518,12 @@ Pass    Pass
 {HCP 9 9 16 6}
 {TP 10 11 17 7}
 {Losers 7 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8540,11 +8540,11 @@ Pass    Pass
 {HCP 10 8 16 6}
 {TP 11 9 16 6}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8561,11 +8561,11 @@ Pass    Pass
 {HCP 14 10 16 0}
 {TP 14 13 16 2}
 {Losers 7 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8582,12 +8582,12 @@ Pass    Pass
 {HCP 10 8 16 6}
 {TP 12 8 16 7}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8607,7 +8607,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -8629,7 +8629,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -8650,7 +8650,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8669,11 +8669,11 @@ Pass    Pass
 {HCP 8 11 15 6}
 {TP 9 13 15 7}
 {Losers 8 7 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8690,12 +8690,12 @@ Pass    Pass
 {HCP 9 7 17 7}
 {TP 10 10 17 7}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8712,11 +8712,11 @@ Pass    Pass
 {HCP 11 8 17 4}
 {TP 12 8 17 4}
 {Losers 8 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8733,11 +8733,11 @@ Pass    Pass
 {HCP 14 7 15 4}
 {TP 14 8 15 4}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8754,11 +8754,11 @@ Pass    Pass
 {HCP 13 7 15 5}
 {TP 14 8 16 6}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8775,12 +8775,12 @@ Pass    Pass
 {HCP 9 8 16 7}
 {TP 10 10 17 8}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8800,7 +8800,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8818,11 +8818,11 @@ Pass    Pass
 {HCP 10 15 15 0}
 {TP 10 16 15 1}
 {Losers 8 6 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8839,12 +8839,12 @@ Pass    Pass
 {HCP 14 8 16 2}
 {TP 15 9 16 4}
 {Losers 6 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8861,11 +8861,11 @@ Pass    Pass
 {HCP 12 6 15 7}
 {TP 12 6 15 9}
 {Losers 8 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8882,11 +8882,11 @@ Pass    Pass
 {HCP 13 7 16 4}
 {TP 13 9 16 6}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8906,7 +8906,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8924,12 +8924,12 @@ Pass    Pass
 {HCP 9 11 16 4}
 {TP 9 11 16 4}
 {Losers 9 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8946,12 +8946,12 @@ Pass    Pass
 {HCP 9 5 16 10}
 {TP 9 5 16 10}
 {Losers 9 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8968,11 +8968,11 @@ Pass    Pass
 {HCP 10 9 16 5}
 {TP 10 9 16 5}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8992,7 +8992,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9014,7 +9014,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9032,11 +9032,11 @@ Pass    Pass
 {HCP 12 8 15 5}
 {TP 12 9 16 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9056,7 +9056,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9074,11 +9074,11 @@ Pass    Pass
 {HCP 12 12 15 1}
 {TP 12 12 15 3}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9095,12 +9095,12 @@ Pass    Pass
 {HCP 9 8 16 7}
 {TP 9 8 16 7}
 {Losers 9 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9120,9 +9120,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4C      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    5H      Pass
 6H      Pass    Pass    Pass
 
@@ -9144,7 +9144,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 X       Pass    4S      Pass
 Pass    Pass    
 
@@ -9165,7 +9165,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9186,7 +9186,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9207,7 +9207,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9228,7 +9228,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    6H      Pass
 Pass    Pass    
 
@@ -9249,7 +9249,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -9268,11 +9268,11 @@ Pass    Pass
 {HCP 14 9 17 0}
 {TP 14 10 17 1}
 {Losers 8 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9289,12 +9289,12 @@ Pass    Pass
 {HCP 9 5 16 10}
 {TP 9 5 16 10}
 {Losers 10 11 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9311,11 +9311,11 @@ Pass    Pass
 {HCP 16 9 15 0}
 {TP 17 10 15 0}
 {Losers 7 8 7 12}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    4NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    4N     Pass
 Pass    Pass    
 
 
@@ -9332,11 +9332,11 @@ Pass    Pass
 {HCP 12 5 17 6}
 {TP 12 6 17 8}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9353,11 +9353,11 @@ Pass    Pass
 {HCP 9 8 15 8}
 {TP 10 9 15 9}
 {Losers 7 8 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -9377,7 +9377,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9395,11 +9395,11 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 13 9 16 7}
 {Losers 7 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9419,7 +9419,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9437,11 +9437,11 @@ Pass    Pass
 {HCP 15 4 16 5}
 {TP 15 4 16 5}
 {Losers 7 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9458,11 +9458,11 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 11 10 16 8}
 {Losers 9 7 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9482,7 +9482,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9500,11 +9500,11 @@ Pass    Pass
 {HCP 17 3 15 5}
 {TP 19 4 16 7}
 {Losers 5 10 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -9521,11 +9521,11 @@ Pass    Pass
 {HCP 12 12 15 1}
 {TP 12 14 15 2}
 {Losers 8 6 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9545,7 +9545,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -9563,12 +9563,12 @@ Pass    Pass
 {HCP 9 8 16 7}
 {TP 9 8 16 7}
 {Losers 9 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9585,11 +9585,11 @@ Pass    Pass
 {HCP 17 5 16 2}
 {TP 17 6 16 3}
 {Losers 7 9 8 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -9606,12 +9606,12 @@ Pass    Pass
 {HCP 10 8 16 6}
 {TP 11 10 16 8}
 {Losers 7 7 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9631,7 +9631,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4D      Pass
 5D      Pass    6H      Pass
 Pass    Pass    
@@ -9650,12 +9650,12 @@ Pass    Pass
 {HCP 16 1 17 6}
 {TP 16 1 18 6}
 {Losers 7 12 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -9675,7 +9675,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9693,11 +9693,11 @@ Pass    Pass
 {HCP 10 7 15 8}
 {TP 12 7 15 8}
 {Losers 7 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9714,11 +9714,11 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 11 9 16 5}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9735,11 +9735,11 @@ Pass    Pass
 {HCP 10 7 17 6}
 {TP 11 7 17 7}
 {Losers 8 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9756,12 +9756,12 @@ Pass    Pass
 {HCP 10 9 17 4}
 {TP 12 9 17 5}
 {Losers 6 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9778,11 +9778,11 @@ Pass    Pass
 {HCP 10 7 15 8}
 {TP 11 7 15 9}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9799,12 +9799,12 @@ Pass    Pass
 {HCP 8 7 16 9}
 {TP 9 9 16 9}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9821,11 +9821,11 @@ Pass    Pass
 {HCP 13 4 16 7}
 {TP 13 6 16 7}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9842,12 +9842,12 @@ Pass    Pass
 {HCP 9 6 16 9}
 {TP 11 8 16 9}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9867,7 +9867,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9888,7 +9888,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -9909,7 +9909,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3C
+1N     Pass    2C      3C
 X       Pass    4C      Pass
 4H      Pass    Pass    Pass
 
@@ -9928,11 +9928,11 @@ X       Pass    4C      Pass
 {HCP 11 7 15 7}
 {TP 13 9 16 8}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9949,11 +9949,11 @@ Pass    Pass
 {HCP 11 2 17 10}
 {TP 11 3 17 10}
 {Losers 9 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9973,7 +9973,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -9994,8 +9994,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -10016,7 +10016,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10035,12 +10035,12 @@ Pass    Pass
 {HCP 14 4 15 7}
 {TP 15 5 15 8}
 {Losers 6 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10057,11 +10057,11 @@ Pass    Pass
 {HCP 12 9 15 4}
 {TP 13 10 15 6}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10078,11 +10078,11 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 12 7 15 9}
 {Losers 7 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10099,11 +10099,11 @@ Pass    Pass
 {HCP 17 7 15 1}
 {TP 17 9 15 3}
 {Losers 6 8 8 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -10120,11 +10120,11 @@ Pass    Pass
 {HCP 13 5 16 6}
 {TP 13 6 16 6}
 {Losers 8 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10141,11 +10141,11 @@ Pass    Pass
 {HCP 14 7 15 4}
 {TP 14 7 15 4}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10165,9 +10165,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4C      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    6D      Pass
 6H      Pass    Pass    Pass
 
@@ -10189,7 +10189,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -10211,7 +10211,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10232,7 +10232,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10250,11 +10250,11 @@ Pass    Pass
 {HCP 13 8 16 3}
 {TP 13 9 17 5}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10271,11 +10271,11 @@ Pass    Pass
 {HCP 12 9 16 3}
 {TP 12 11 16 4}
 {Losers 9 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10292,12 +10292,12 @@ Pass    Pass
 {HCP 9 6 15 10}
 {TP 9 7 15 10}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10317,7 +10317,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10335,11 +10335,11 @@ Pass    Pass
 {HCP 9 11 15 5}
 {TP 9 11 16 7}
 {Losers 8 7 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -10356,11 +10356,11 @@ Pass    Pass
 {HCP 10 10 15 5}
 {TP 12 10 15 6}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10377,13 +10377,13 @@ Pass    Pass
 {HCP 15 7 15 3}
 {TP 16 7 15 5}
 {Losers 7 10 7 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    4NT     Pass
-6NT     Pass    Pass    Pass
+3N     Pass    4N     Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -10400,11 +10400,11 @@ Pass    Pass
 {HCP 10 10 15 5}
 {TP 10 10 15 5}
 {Losers 8 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10424,7 +10424,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -10442,12 +10442,12 @@ Pass    Pass
 {HCP 9 7 16 8}
 {TP 11 10 16 8}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10464,12 +10464,12 @@ Pass    Pass
 {HCP 8 9 16 7}
 {TP 10 10 16 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10486,11 +10486,11 @@ Pass    Pass
 {HCP 10 9 16 5}
 {TP 11 9 17 7}
 {Losers 9 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10507,11 +10507,11 @@ Pass    Pass
 {HCP 12 7 16 5}
 {TP 13 7 16 6}
 {Losers 8 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10528,11 +10528,11 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 12 10 15 8}
 {Losers 8 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10549,11 +10549,11 @@ Pass    Pass
 {HCP 16 7 15 2}
 {TP 16 7 15 2}
 {Losers 7 11 6 11}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    4NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    4N     Pass
 Pass    Pass    
 
 
@@ -10570,11 +10570,11 @@ Pass    Pass
 {HCP 10 14 15 1}
 {TP 11 15 16 1}
 {Losers 8 6 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10594,7 +10594,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10612,11 +10612,11 @@ Pass    Pass
 {HCP 14 6 16 4}
 {TP 14 9 16 5}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2H      Pass    3NT     Pass
+1N     Pass    2C      X
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10636,7 +10636,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 

--- a/GIB/GIB_1N.pbn
+++ b/GIB/GIB_1N.pbn
@@ -7,7 +7,7 @@
 [Deal "N:J6542.76.QJ6.KT8 T.AJT53.A85.A653 AQ8.K982.K932.QJ K973.Q4.T74.9742"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 2S      Pass    Pass    Db
 Pass    3C      3D      Pass
 3S      Pass    Pass    Pass
@@ -19,10 +19,10 @@ Pass    3C      3D      Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J754.K63.QJ96.AT 863.T9542..K9832 A9.AQJ8.K84.J754 KQT2.7.AT7532.Q6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2S      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -33,7 +33,7 @@ Pass    Pass
 [Deal "N:8764.732.Q7.QT84 AT93.T96.K85.K62 KQJ.KQ854.J4.A75 52.AJ.AT9632.J93"]
 [Contract "2D"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    Pass    Pass    
 
 
@@ -44,7 +44,7 @@ Pass    Pass    Pass
 [Deal "N:K97.QT732.83.J92 J8.K954.QT6.KQT3 AQ.AJ6.J54.A8754 T65432.8.AK972.6"]
 [Contract "3H"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -56,8 +56,8 @@ Pass    Pass
 [Deal "N:AQ754.Q5.J94.Q74 J6.KT874.K3.J832 T92.AJ6.AQ76.AT6 K83.932.T852.K95"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -69,7 +69,7 @@ Pass    Pass
 [Deal "N:QT8742.AKT8.97.9 65.9742.JT6.8653 J93.53.AK53.AQJ7 AK.QJ6.Q842.KT42"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -81,7 +81,7 @@ Pass    Pass
 [Deal "N:KT765.KT42.K54.9 A984.Q653.Q7.Q63 J2.AJ.AJT63.AJT2 Q3.987.982.K8754"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -91,9 +91,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:.J84.754.AKT8752 T854.KQT73.KJ98. KJ76.A652.AQ2.J3 AQ932.9.T63.Q964"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -102,10 +102,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:8542.K832.AT5.KQ Q973.QJ754.3.J53 AKT.T6.KQ764.A87 J6.A9.J982.T9642"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -116,7 +116,7 @@ Pass    Pass
 [Deal "N:4.QT62.KT753.842 Q53.543.J92.QJT3 A98.AJ8.Q4.A9765 KJT762.K97.A86.K"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -128,8 +128,8 @@ Pass
 [Deal "N:KQ873.J4.T985.A4 J.T96.Q63.KQ9862 A542.AK3.KJ.T753 T96.Q8752.A742.J"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -139,10 +139,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AJ9.KT.85432.JT4 K765.QJ93.QJ9.82 Q8.8542.A6.AKQ95 T432.A76.KT7.763"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -153,7 +153,7 @@ Pass    Pass
 [Deal "N:A97.9532.AT84.J9 T3.K86.K32.T7542 K2.JT74.Q97.AKQ8 QJ8654.AQ.J65.63"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -165,7 +165,7 @@ Pass    Pass
 [Deal "N:Q9.AJT7.9742.K95 AJ542.8.83.QJ843 K76.Q653.AQ6.A72 T83.K942.KJT5.T6"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    3S      Pass    Pass
 Pass    
 
@@ -177,7 +177,7 @@ Pass
 [Deal "N:A72.Q864.AQJ8.94 T63.95.T432.K876 QJ9.AKJ2.K9.Q532 K854.T73.765.AJT"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -189,7 +189,7 @@ Pass    Pass
 [Deal "N:JT973.9.AJ5.T972 A542.AK762.8.J63 KQ6.J4.Q973.AK84 8.QT853.KT642.Q5"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 2S      4H      Pass    Pass
 Pass    
 
@@ -201,8 +201,8 @@ Pass
 [Deal "N:942.Q7642.K83.A8 AQ3.JT5.9752.QT6 K65.A98.AQJ64.K2 JT87.K3.T.J97543"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    2N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -212,10 +212,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KT2.K732.7.K9876 QJ73.T64.A6.Q543 A86.AJ9.Q8532.AT 954.Q85.KJT94.J2"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -226,7 +226,7 @@ Pass    Pass
 [Deal "N:AQT95.742.87.972 J642.T953.KQT9.5 87.AKJ6.A652.KT8 K3.Q8.J43.AQJ643"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -236,10 +236,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AT9.AJ7.Q93.J943 432.654.KJ42.T75 K8.KT.A8765.KQ86 QJ765.Q9832.T.A2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2D      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2D      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -248,9 +248,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:862.A932.T84.A85 QT9.KT64.Q5.KT94 AJ74.J8.AK96.QJ3 K53.Q75.J732.762"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -259,10 +259,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K872.T5.KJT42.A4 AT4.K8432.3.JT96 Q6.AQJ7.AQ875.87 J953.96.96.KQ532"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -273,7 +273,7 @@ Pass    Pass
 [Deal "N:K4.K7.J97652.T94 73.QJ2.KT83.KQ63 AJT8.8543.AQ4.A7 Q9652.AT96..J852"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -285,7 +285,7 @@ Pass    Pass
 [Deal "N:.T942.AJ53.T9832 953.AJ83.T74.AJ6 KT84.KQ6.K96.KQ4 AQJ762.75.Q82.75"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -295,9 +295,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:86.QJ6.T9742.A95 JT.AK742.863.J74 AK3.85.KQJ.QT632 Q97542.T93.A5.K8"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -308,7 +308,7 @@ Pass
 [Deal "N:A9.763.98632.T83 KQT8.Q9852.AJ4.7 6532.AKT.KQ5.KQ9 J74.J4.T7.AJ6542"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -320,7 +320,7 @@ Pass
 [Deal "N:QJT642.Q5.7.JT96 93.JT8.AJ96.K542 AK5.K76.Q8532.A7 87.A9432.KT4.Q83"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -330,9 +330,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KT.J.T9865.T9864 QJ85.A75.A72.Q72 62.KQ82.KQJ3.KJ5 A9743.T9643.4.A3"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -343,7 +343,7 @@ Pass
 [Deal "N:952.J52.K98543.A AT3.KT7.J6.J7642 KJ7.A98.AQ72.K95 Q864.Q643.T.QT83"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -353,9 +353,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J92.97.765.J9652 QT64.KJ6.84.KQT4 A75.Q8432.KQ2.A7 K83.AT5.AJT93.83"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -364,9 +364,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A74.AQ.7532.AT74 Q65.7432.A86.Q96 K2.KJ5.KQJ.KJ532 JT983.T986.T94.8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -377,7 +377,7 @@ Pass    Pass
 [Deal "N:A54.85.T8752.763 762.JT.AQ9.QJ982 KJ.K432.J43.AKT5 QT983.AQ976.K6.4"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -386,10 +386,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQJ2.763.64.QT74 83.985.KJ9.AK932 A76.KQT.AQT5.865 T954.AJ42.8732.J"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -398,9 +398,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K3.K4.J752.KT543 QJ6.QJT985.T86.9 A752.A73.AK.Q872 T984.62.Q943.AJ6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -409,10 +409,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K2.QT542.JT82.A7 T63.J987.Q5.QJ42 Q98.AK.A94.KT986 AJ754.63.K763.53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -421,9 +421,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:983.865.Q872.Q72 A75.T932.94.A953 Q6.AQ7.AT63.KT86 KJT42.KJ4.KJ5.J4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -434,7 +434,7 @@ Pass    Pass
 [Deal "N:AK9643.KJ2.43.Q4 Q87.873.KT6.8753 T5.QT9.AQJ52.AK2 J2.A654.987.JT96"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -446,7 +446,7 @@ Pass    Pass
 [Deal "N:Q6.K53.97543.962 T9432.872.AJ6.T3 AK87.T64.KQT.KQ7 J5.AQJ9.82.AJ854"]
 [Contract "2H"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -457,7 +457,7 @@ Pass
 [Deal "N:9843.AKT96.76.J9 2.J8752.K8532.KT AKQ.Q4.AT4.85432 JT765.3.QJ9.AQ76"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2H      Pass
 Pass    Pass    
 
@@ -469,7 +469,7 @@ Pass    Pass
 [Deal "N:T876.K94..JT9843 A53.JT82.KT543.7 K42.76.QJ8.AKQ62 QJ9.AQ53.A9762.5"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2H      2NT     3H
+1N     2H      2N     3H
 Pass    4H      Pass    Pass
 Pass    
 
@@ -481,7 +481,7 @@ Pass
 [Deal "N:752.86.A864.T985 JT83.T972.KT52.Q KQ96.AJ.Q73.K642 A4.KQ543.J9.AJ73"]
 [Contract "2H"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -490,9 +490,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:T85.K54.7643.QJ5 9.Q862.K82.T7432 AJ764.J73.AQJ.K6 KQ32.AT9.T95.A98"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -503,7 +503,7 @@ Pass
 [Deal "N:AT98.Q86532.62.K Q6.JT7.8743.A654 K743.K9.AQJ.Q982 J52.A4.KT95.JT73"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -515,7 +515,7 @@ Pass
 [Deal "N:KT.QJT862.K95.KJ 7654..J87642.543 AJ98.AK4.Q3.QT82 Q32.9753.AT.A976"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -525,9 +525,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J5.A842.9872.J85 A987.J.Q543.T932 QT42.Q9.AKT6.KQ6 K63.KT7653.J.A74"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -536,9 +536,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:764.QJT2.9532.A2 KT82.96.KJ4.KJ43 AQJ9.87.AQ7.Q976 53.AK543.T86.T85"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -549,7 +549,7 @@ Pass
 [Deal "N:K9874.KQT4.32.72 AT2.J65.T64.T983 63.A872.AK85.KQJ QJ5.93.QJ97.A654"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -561,7 +561,7 @@ Pass    Pass
 [Deal "N:A9854.J42.973.K7 T7.AK97.AQJ2.843 KQ.Q53.K65.AJ962 J632.T86.T84.QT5"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Db
 Pass    3C      Pass    Pass
 Pass    
@@ -572,9 +572,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J53.T43.Q752.T74 KT96.AQ8.J94.532 Q8.K65.AT3.AQJ96 A742.J972.K86.K8"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -585,7 +585,7 @@ Pass
 [Deal "N:J7.Q983.AK853.83 K98.AJ4.742.7654 A32.KT75.QJT.AQ9 QT654.62.96.KJT2"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -595,10 +595,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K96.KQ85.Q.QT862 J.A7432.J9842.A3 AQ542.T9.AK7.K94 T873.J6.T653.J75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -609,8 +609,8 @@ Pass    Pass
 [Deal "N:A975.9.J87.AQ987 Q43.A87.QT643.J3 T862.KQ62.AK9.K5 KJ.JT543.52.T642"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -622,7 +622,7 @@ Pass    Pass
 [Deal "N:QT732.KJ4.6.KQ43 A.952.QT95.T9865 K96.T87.AK74.AJ7 J854.AQ63.J832.2"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3C      Pass
 4S      Pass    Pass    Pass
 
@@ -633,9 +633,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J6.K863.AT75.764 T8543.92.963.Q83 AKQ7.AT54.84.KJT 92.QJ7.KQJ2.A952"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -644,9 +644,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A964.82.J8643.42 JT32.QT43.A.QJT7 Q87.A75.Q2.AK986 K5.KJ96.KT975.53"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -657,7 +657,7 @@ Pass    Pass
 [Deal "N:K862.JT64.862.J4 AJ973.K853.94.T2 Q5.AQ92.AKT3.973 T4.7.QJ75.AKQ865"]
 [Contract "3C"]
 [Auction "S"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -666,9 +666,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J98.Q97.A8732.K7 75432.JT53.Q.T62 AKT6.A42.KJ6.Q94 Q.K86.T954.AJ853"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -679,7 +679,7 @@ Pass    Pass
 [Deal "N:75.K9732.864.KQT AK2.5.J973.87532 Q4.AJT4.KQT.AJ96 JT9863.Q86.A52.4"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    3D      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
@@ -692,8 +692,8 @@ Pass    Pass
 [Deal "N:J9842.63.K53.Q72 T.Q9854.J9.A8643 AQ73.A72.A62.KT5 K65.KJT.QT874.J9"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2NT     Pass    3H      Pass
+1N     Pass    2H      Pass
+2N     Pass    3H      Pass
 3S      Pass    Pass    Pass
 
 
@@ -703,9 +703,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T7.JT54.75.Q8742 KJ94.2.QJT9.KT96 A82.A763.K84.A53 Q653.KQ98.A632.J"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -716,7 +716,7 @@ Pass    Pass
 [Deal "N:T93.94.A98765.K5 AK752.JT52..JT98 J4.AKQ7.KT4.Q742 Q86.863.QJ32.A63"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -728,7 +728,7 @@ Pass    Pass
 [Deal "N:A6542.J742.J.KQ3 83.T9865.8765.J8 QJ9.AKQ.T92.A974 KT7.3.AKQ43.T652"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Db      3S      Pass
 4S      Pass    Pass    Pass
 
@@ -741,7 +741,7 @@ Pass    Pass
 [Deal "N:Q6.J97432.A.T853 7432.Q865.K7.J72 JT95.AKT.52.AKQ6 AK8..QJT98643.94"]
 [Contract "3D"]
 [Auction "S"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -752,7 +752,7 @@ Pass
 [Deal "N:A965.K964.T52.J3 K72.QJT752.943.K T3.A83.AK6.AQ542 QJ84..QJ87.T9876"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Db      Pass    Pass    2H
 Pass    Pass    Pass    
 
@@ -764,7 +764,7 @@ Pass    Pass    Pass
 [Deal "N:J.J8642.654.K754 KT942.QT.AKQ82.6 AQ6.AK7.J7.QJ982 8753.953.T93.AT3"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2D      Db
+1N     Pass    2D      Db
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -776,7 +776,7 @@ Pass    Pass    Pass
 [Deal "N:5.AQ3.KJT8.J9842 JT76.T92.943.Q53 A82.54.AQ762.AK6 KQ943.KJ876.5.T7"]
 [Contract "5C"]
 [Auction "S"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 3S      Pass    5C      Pass
 Pass    Pass    
 
@@ -786,10 +786,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:62.AK85.AJ762.J6 K9853.73.T4.T954 AT4.QJ9.K985.AK8 QJ7.T642.Q3.Q732"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -800,7 +800,7 @@ Pass    Pass
 [Deal "N:A32.J872.T5.KT54 QJ95.AT.KJ964.J6 KT.Q943.AQ.A8732 8764.K65.8732.Q9"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -812,7 +812,7 @@ Pass    Pass
 [Deal "N:AQ8.JT9653.Q8.T9 6432.Q82.T543.J6 J97.K74.KJ7.AKQ4 KT5.A.A962.87532"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -822,11 +822,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:6.QJT.KQT43.QJ92 K974.K5.J9.KT843 AT32.A76.A762.A5 QJ85.98432.85.76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2S      Pass
+1N     Pass    2S      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -837,7 +837,7 @@ Pass    Pass
 [Deal "N:K.98754.KQT9.T43 T876.AT.A62.K852 AJ954.KJ6.87.AQ7 Q32.Q32.J543.J96"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -847,9 +847,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QJT3.4.T872.J985 954.AK97.65.A762 A72.T532.AKJ3.K3 K86.QJ86.Q94.QT4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -860,7 +860,7 @@ Pass    Pass
 [Deal "N:T972.AJ72.K5.K53 J3.963.QT72.T762 AK85.Q85.A96.A98 Q64.KT4.J843.QJ4"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -872,7 +872,7 @@ Pass    Pass
 [Deal "N:AQT.AJ65.8543.92 K74.T94.Q2.KJ753 J852.K732.AK.A86 963.Q8.JT976.QT4"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -884,7 +884,7 @@ Pass    Pass
 [Deal "N:K84.QT85.T92.Q42 Q96.J2.KQJ875.J9 AJ72.A94.43.AKT6 T53.K763.A6.8753"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      2H      Pass
 Pass    Pass    
 
@@ -894,9 +894,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T5.J742.T6.T9862 92.K85.KQ974.K43 KQJ7.A96.8532.AQ A8643.QT3.AJ.J75"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -905,10 +905,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJ.63.QT432.AQ96 T52.8754.75.JT54 A864.AK2.K6.K732 Q973.QJT9.AJ98.8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2S      Pass
-3C      Pass    3NT     Pass
+1N     Pass    2S      Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -917,9 +917,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:743.QJ7.A76.KQJ5 K962.K96.854.732 AQJ.AT82.932.AT6 T85.543.KQJT.984"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -928,10 +928,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T643.KQ.J6.KJ764 QJ9.A4.KQT872.32 A2.J8732.A93.AQT K875.T965.54.985"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      2D
-2H      Pass    3NT     Pass
+1N     Pass    2C      2D
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -942,7 +942,7 @@ Pass    Pass
 [Deal "N:A2.KQJT852.T76.9 KJ83.7.K842.8742 T964.A6.AJ3.AKJ3 Q75.943.Q95.QT65"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -954,7 +954,7 @@ Pass    Pass
 [Deal "N:T97532.A84.32.Q4 86.JT.AJT984.AK5 AK4.KQ.Q76.JT762 QJ.976532.K5.983"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    3D
 Pass    Pass    Pass    
 
@@ -966,7 +966,7 @@ Pass    Pass    Pass
 [Deal "N:82.J842.AK952.J7 Q64.T.T643.AKQ98 AJT.AKQ5.QJ87.T3 K9753.9763..6542"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -978,7 +978,7 @@ Pass    Pass
 [Deal "N:8765.K7.AKT93.T9 4.T98543.762.J43 AQJT3.AJ2.85.A72 K92.Q6.QJ4.KQ865"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -990,7 +990,7 @@ Pass    Pass
 [Deal "N:A762.QT86.A9.K95 J84.543.Q7.J8763 KQT3.AJ2.K642.Q4 95.K97.JT853.AT2"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1002,7 +1002,7 @@ Pass    Pass
 [Deal "N:T75.JT943.K7.J95 J4.75.A642.QT874 AK98.AQ86.T83.A3 Q632.K2.QJ95.K62"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 3C      Pass    3D      Pass
 3H      Pass    Pass    Pass
 
@@ -1013,9 +1013,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:JT.9753.KQT8.972 8752.KQ2.62.KT65 K963.AJT.AJ.QJ43 AQ4.864.97543.A8"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1026,7 +1026,7 @@ Pass    Pass
 [Deal "N:T875.KJ8753..J84 A943.Q2.98743.Q3 Q2.AT94.AQJ6.K52 KJ6.6.KT52.AT976"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1036,10 +1036,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:7.KQ54.Q653.AT85 QJT642.93.T2.974 A9.A76.K984.KJ32 K853.JT82.AJ7.Q6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3S      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1050,7 +1050,7 @@ Pass    Pass
 [Deal "N:T3.KJT93.7.K9864 A98654.75.T85.Q3 KJ2.Q642.KQ4.AJ2 Q7.A8.AJ9632.T75"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    3C      Pass
 4H      Pass    Pass    Pass
 
@@ -1063,7 +1063,7 @@ Pass    Pass
 [Deal "N:932.J8542.T43.J5 8764.A.A92.K9642 QJT.KQT73.Q76.AQ AK5.96.KJ85.T873"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1073,9 +1073,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A72.Q92.9754.T65 Q85.AKT85.QJ.K87 KT943.J6.A62.AQJ J6.743.KT83.9432"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1084,11 +1084,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QT86.K53.532.A32 A97.QJT.KT974.87 K53.A4.AQJ86.K96 J42.98762..QJT54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1097,10 +1097,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J9.K83.AT7.JT742 T8652.JT.Q9854.Q A7.AQ975.J32.A98 KQ43.642.K6.K653"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1109,9 +1109,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:74.762.T862.JT87 KQ9.T843.A95.K64 AT63.KQJ.QJ7.Q53 J852.A95.K43.A92"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1120,10 +1120,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQ2.AKQ7.A43.862 9863.984.75.JT53 AJT4.JT2.T62.AKQ 75.653.KQJ98.974"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -1132,9 +1132,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QJ9.T8.J8752.Q83 T654.J975.AT9.76 872.AQ.Q63.AKT54 AK3.K6432.K4.J92"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1143,11 +1143,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q8754.65.876.864 KJ96.9.T3.KQJT72 AT2.AQT82.J42.A9 3.KJ743.AKQ95.53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2H      Pass    3C
+1N     2H      Pass    3C
 Pass    3D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1158,7 +1158,7 @@ Pass
 [Deal "N:Q652.973.72.K543 4.KQT842.AKJ.T82 AJ73.A65.T85.AQ9 KT98.J.Q9643.J76"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      2S      Pass
 Pass    Pass    
 
@@ -1170,7 +1170,7 @@ Pass    Pass
 [Deal "N:AT92.QJ954.2.983 Q654.3.A853.JT64 K8.8762.KQ94.AK7 J73.AKT.JT76.Q52"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -1180,9 +1180,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:9765.543.J4.A653 QT2.T62.K5.QJ987 AKJ.KJ87.Q973.K2 843.AQ9.AT862.T4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1193,7 +1193,7 @@ Pass    Pass
 [Deal "N:963.KT985.AQ3.63 K52.732.875.AT85 AQJ8.AQ64.K42.J4 T74.J.JT96.KQ972"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 3C      Pass    3D      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
@@ -1206,9 +1206,9 @@ Pass    Pass
 [Deal "N:.KT7654.K9.AKQ63 JT632.QJ93.T.952 AKQ7.A82.A753.T8 9854..QJ8642.J74"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -1220,7 +1220,7 @@ Pass    Pass
 [Deal "N:Q4.KQ98632.AT2.T AKJ872.T4.954.84 T6.AJ.J876.AKQ96 953.75.KQ3.J7532"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -1230,11 +1230,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QT3.T632.K82.AT8 952.J984..QJ9542 KJ87.AK5.AQ9.763 A64.Q7.JT76543.K"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2C      Db      Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2C      Db      Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1243,10 +1243,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:97.AKQ8.T972.532 QJ652.653.865.86 KT83.J9.KQ43.AQ7 A4.T742.AJ.KJT94"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1257,7 +1257,7 @@ Pass    Pass
 [Deal "N:864.97.J82.Q9543 75.AKJT64.75.A86 AKQ.83.A9643.KJ2 JT932.Q52.KQT.T7"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    Pass    3H
+1N     Pass    Pass    3H
 Pass    Pass    Pass    
 
 
@@ -1268,8 +1268,8 @@ Pass    Pass    Pass
 [Deal "N:AQ76.62.AJ74.QJ5 854.AJ954.Q.9876 JT32.KQT7.KT.AK3 K9.83.986532.T42"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -1281,11 +1281,11 @@ Pass    Pass    Pass
 [Deal "N:A87.AKQT4.J762.9 Q94.9765.84.KJ76 KT63.J82.AQT.AQT J52.3.K953.85432"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3D      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5C      Pass
-5D      Pass    5NT     Pass
+4N     Pass    5C      Pass
+5D      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -1295,10 +1295,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K4.K765.AJ8632.J 9765.Q984..KQ874 AQT8.A32.K7.A632 J32.JT.QT954.T95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1307,9 +1307,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T764.92.T4.98743 Q.AQJ7.J876.AT52 A9852.K53.KQ2.KJ KJ3.T864.A953.Q6"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1318,9 +1318,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J65.8654.J75.842 A732.AK3.QT43.63 KQ4.J97.AK98.A95 T98.QT2.62.KQJT7"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1329,9 +1329,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T95.T94.Q754.J43 AJ2.K8765.A8.T65 K7643.AQJ.JT6.KQ Q8.32.K932.A9872"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1340,9 +1340,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T62.K42.QJ86.Q97 873.9.AK972.J852 AQJ.AT65.543.AT4 K954.QJ873.T.K63"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1351,11 +1351,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:3.653.KJT.KQ9863 KT742.AK9.72.752 AJ5.J42.A9864.AJ Q986.QT87.Q53.T4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1364,11 +1364,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:96.K4.KQT85.9643 Q75432.T9652.J9. AT8.J83.A62.AKT5 KJ.AQ7.743.QJ872"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1379,8 +1379,8 @@ Pass    Pass
 [Deal "N:Q542.J98.KQJ52.A JT7.AK4.T84.QJ42 AK96.QT53.A63.K6 83.762.97.T98753"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -1392,7 +1392,7 @@ Pass    Pass
 [Deal "N:6.Q53.T93.AJT876 9853.92.KJ764.95 K72.JT6.AQ2.KQ42 AQJT4.AK874.85.3"]
 [Contract "3S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3S
 Pass    Pass    Pass    
 
@@ -1402,11 +1402,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:9874.Q432.84.873 QT652.J6.AK975.T AK3.K975.62.AJ62 J.AT8.QJT3.KQ954"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    Pass    2S
-Pass    2NT     Pass    3D
-Pass    3NT     Pass    Pass
+1N     Pass    Pass    2S
+Pass    2N     Pass    3D
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1415,9 +1415,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:9.93.AQJT9875.75 Q65432.764..Q432 KT.KQT52.K43.AT6 AJ87.AJ8.62.KJ98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1428,7 +1428,7 @@ Pass    Pass
 [Deal "N:KT43.QT8763.J5.K 7652.4.72.AJ8762 AJ8.AJ9.AQ843.T4 Q9.K52.KT96.Q953"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -1438,11 +1438,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q532.A4.95.Q9832 AK9.763.Q832.T64 T84.KJ2.AJ76.AK5 J76.QT985.KT4.J7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1453,7 +1453,7 @@ Pass    Pass
 [Deal "N:A62.9763.AQ9542. T875.QJ.3.AQT732 KQJ43.A52.KJT.J8 9.KT84.876.K9654"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      4C      4S      Pass
 Pass    Pass    
 
@@ -1465,7 +1465,7 @@ Pass    Pass
 [Deal "N:532.KJ86542.J5.8 JT97.Q.KQ764.K74 AK8.AT9.T9.AJT32 Q64.73.A832.Q965"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2D      Db
+1N     Pass    2D      Db
 2H      Pass    Pass    2S
 Pass    3D      Pass    Pass
 Pass    
@@ -1476,11 +1476,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A4.6.AQ75.QT9865 KJT95.J3.J642.A2 Q2.AKQ95.K83.J73 8763.T8742.T9.K4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2S      Pass
-2NT     Pass    3H      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2S      Pass
+2N     Pass    3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1491,8 +1491,8 @@ Pass
 [Deal "N:QT643.QJ.J87.A75 J52.42.AKT.JT983 AK9.AK65.943.Q62 87.T9873.Q652.K4"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -1504,7 +1504,7 @@ Pass
 [Deal "N:5.T652.AKJT872.8 JT32.KQJ.95.7432 A8.A987.63.AQJ96 KQ9764.43.Q4.KT5"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2C      Db      Pass
+1N     2C      Db      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1514,9 +1514,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J93.63.AQ65.Q752 KT652.A87.K72.J3 Q4.KQJ9.J83.AK84 A87.T542.T94.T96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1527,7 +1527,7 @@ Pass    Pass
 [Deal "N:K74.KJT72.93.T87 Q82.3.J65.Q95432 J6.Q986.KQ842.AK AT953.A54.AT7.J6"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1539,7 +1539,7 @@ Pass    Pass
 [Deal "N:Q.97.KQT8432.Q98 954.AKQ653.J7.T7 AK.T842.A95.A653 JT87632.J.6.KJ42"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    3C      3H
+1N     Pass    3C      3H
 Pass    4S      Pass    Pass
 Pass    
 
@@ -1551,7 +1551,7 @@ Pass
 [Deal "N:A864.QT98.AJT2.T T75.K76.Q97.8652 KQ92.AJ5.K65.QJ9 J3.432.843.AK743"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1561,10 +1561,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K6.65.AK2.QJT753 AJ73.983.965.K94 Q92.AKQ2.T743.A6 T854.JT74.QJ8.82"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
-3C      Pass    3NT     Pass
+1N     Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1573,9 +1573,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A95.T73.Q542.Q97 T6432.98.AK3.862 KJ8.AQ.987.AKT53 Q7.KJ6542.JT6.J4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1584,10 +1584,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJT5.K.K62.J9642 Q4.QJ9.QT87543.T A62.8753.A9.AKQ7 9873.AT642.J.853"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1596,9 +1596,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AT.T94.J652.AQ76 K87432.J8.A98.32 J5.AK5.KQT74.KT4 Q96.Q7632.3.J985"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1607,10 +1607,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:84.KQJ2.QT52.T92 AJ765.T7.K84.K43 T93.A65.A96.AQJ7 KQ2.9843.J73.865"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1619,10 +1619,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJT4.AK3.T843.93 9652.T987.K6.J64 KQ7.QJ5.A2.AT752 83.642.QJ975.KQ8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1633,9 +1633,9 @@ Pass    Pass
 [Deal "N:AKJT53.JT72.AQ.3 642.6.JT9.KJT982 Q8.AK53.82.AQ764 97.Q984.K76543.5"]
 [Contract "6S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
-4S      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+1N     Pass    4H      Pass
+4S      Pass    4N     Pass
+5S      Pass    5N     Pass
 6H      Pass    6S      Pass
 Pass    Pass    
 
@@ -1647,7 +1647,7 @@ Pass    Pass
 [Deal "N:763.T7632.Q8.T72 J.AJ9.A7532.KQ63 AKQ54.K8.T94.A84 T982.Q54.KJ6.J95"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1659,7 +1659,7 @@ Pass    Pass
 [Deal "N:A9843.832.JT2.93 K.JT965.8743.AQT T2.AK4.AQ65.K852 QJ765.Q7.K9.J764"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1671,7 +1671,7 @@ Pass    Pass
 [Deal "N:A6.AJ76.9863.T94 J832.953.Q52.AJ8 KQ74.T842.AK4.K3 T95.KQ.JT7.Q7652"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -1683,7 +1683,7 @@ Pass    Pass
 [Deal "N:T9865.KT83.K75.4 732.762.A4.Q8765 QJ4.AQJ95.Q3.AT3 AK.4.JT9862.KJ92"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1695,7 +1695,7 @@ Pass    Pass
 [Deal "N:JT7.A732.AQ52.93 A9.98.973.J76542 Q43.KQJ54.KT.KQ8 K8652.T6.J864.AT"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1705,9 +1705,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:8763.AQ6.Q5.9864 Q942.83.AK982.K2 AKJT.KJ2.T63.QJ7 5.T9754.J74.AT53"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1716,10 +1716,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KT65.QJ5.75.KJ42 A987.T9.J943.T98 J4.K63.AKT86.A75 Q32.A8742.Q2.Q63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1730,7 +1730,7 @@ Pass    Pass
 [Deal "N:K.QT8.JT9852.QT9 AQ962.964.A74.J3 T74.A73.KQ.AK862 J853.KJ52.63.754"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1742,7 +1742,7 @@ Pass    Pass
 [Deal "N:J7652.T876.K2.43 94.K42.T97654.K8 AK83.AJ53.Q3.J52 QT.Q9.AJ8.AQT976"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1752,10 +1752,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:JT93.Q5.Q75.A876 K652.9873.943.K3 Q4.KJ6.AKJT2.J92 A87.AT42.86.QT54"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1764,9 +1764,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K983.J842.J3.K73 754.K9.KT952.Q54 AT62.A76.AQ7.J62 QJ.QT53.864.AT98"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1775,10 +1775,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T7.AJ632.AT.KJ98 96.QT5.K6543.Q73 AKQJ5.K7.QJ2.642 8432.984.987.AT5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1787,11 +1787,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K92.7.KT876.KJT7 6.AT8543.J4.9852 A54.QJ92.Q53.AQ6 QJT873.K6.A92.43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2C      2S      Pass
-2NT     Pass    3H      Pass
-3NT     Pass    Pass    Pass
+1N     2C      2S      Pass
+2N     Pass    3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1802,7 +1802,7 @@ Pass    Pass
 [Deal "N:T2.Q97532.82.AK4 AQ743.A8.T764.65 K86.KJ.AKJ53.732 J95.T64.Q9.QJT98"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -1814,8 +1814,8 @@ Pass    Pass
 [Deal "N:J53.AQ962.J3.Q65 92.43.AT75.A9843 AT876.K75.KQ2.KT KQ4.JT8.9864.J72"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -1825,9 +1825,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T972.Q952.QT3.J5 A86.AJ63.865.873 Q5.T87.AKJ74.AK4 KJ43.K4.92.QT962"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1836,10 +1836,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJT7.85.A42.KJ97 5.AQT763.J65.A85 A43.KJ9.KQT83.Q6 Q9862.42.97.T432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1850,7 +1850,7 @@ Pass    Pass
 [Deal "N:J97632.64.T5.J32 KQT4.T752.K82.54 A8.KQ3.QJ76.KQ76 5.AJ98.A943.AT98"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Db      Pass    3H
 Pass    Pass    Pass    
 
@@ -1862,9 +1862,9 @@ Pass    Pass    Pass
 [Deal "N:KT2.AJT875.A865. 53.642.KQT.AT872 AJ87.KQ.J74.KQ53 Q964.93.932.J964"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3D      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 4S      Pass    6H      Pass
 Pass    Pass    
 
@@ -1876,7 +1876,7 @@ Pass    Pass
 [Deal "N:QT75.A52.753.A74 986.T43.KQJ2.KQ8 AKJ42.Q8.AT6.J63 3.KJ976.984.T952"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1888,7 +1888,7 @@ Pass    Pass
 [Deal "N:KJT95.J72.97.QT7 A8.KT.KJT842.965 Q6.Q943.AQ3.AJ82 7432.A865.65.K43"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    3D
 Pass    Pass    Pass    
 
@@ -1898,11 +1898,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:87.KJ753.KT4.Q95 43.A986.987.J762 AKQT.T4.A53.AT84 J9652.Q2.QJ62.K3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2D      Pass
+2H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1911,9 +1911,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T2.K8.JT62.JT864 8754.Q9732.AQ.Q5 AKQ.T654.K984.A3 J963.AJ.753.K972"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1924,7 +1924,7 @@ Pass    Pass    Pass
 [Deal "N:T983.853.854.KT5 AJ64.6.AJ2.AJ843 K75.AK42.KT97.Q9 Q2.QJT97.Q63.762"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2S
+1N     Pass    Pass    2S
 Pass    Pass    Pass    
 
 
@@ -1935,7 +1935,7 @@ Pass    Pass    Pass
 [Deal "N:KT74.Q52.62.A954 J.9764.KJ743.JT2 AQ98.AJT.95.KQ73 6532.K83.AQT8.86"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1947,7 +1947,7 @@ Pass    Pass
 [Deal "N:KJ943.J98432.J.K 82.K65.KQT86.A32 AQT.AT7.A42.J965 765.Q.9753.QT874"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1958,9 +1958,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q82.J.A742.98532 T3.QT98764.T95.A A76.A5.KQ863.QJ6 KJ954.K32.J.KT74"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1971,7 +1971,7 @@ Pass    Pass
 [Deal "N:T92.Q9.32.KQJ975 4.T875.KQT964.43 K87.A42.AJ87.A62 AQJ653.KJ63.5.T8"]
 [Contract "4HX"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3S      Pass    4H
 Pass    Pass    Db      Pass
 Pass    Pass    
@@ -1984,8 +1984,8 @@ Pass    Pass
 [Deal "N:A53.K9652.QJ6.54 KT2.T87.74.KQ872 Q94.AJ4.A32.AT63 J876.Q3.KT985.J9"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -1995,9 +1995,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:976.QJ2.A8742.JT A854.9863.Q.A864 KQJ2.K7.J96.KQ53 T3.AT54.KT53.972"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2008,7 +2008,7 @@ Pass    Pass
 [Deal "N:T65.73.QT2.KQ985 742.K4.A853.7432 A9.AJ62.KJ74.AT6 KQJ83.QT985.96.J"]
 [Contract "3C"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2018,9 +2018,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:52.A97.AJ8.Q9763 T873.Q.65432.J85 KJ9.KJT65.K7.AT4 AQ64.8432.QT9.K2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2031,7 +2031,7 @@ Pass    Pass
 [Deal "N:A96.KQT5.Q843.87 7543.J6.92.KQ653 K8.9732.AKT5.AJ9 QJT2.A84.J76.T42"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2043,7 +2043,7 @@ Pass    Pass
 [Deal "N:JT953.T6.5.QJT76 76.AQ9752.AK763. AK.KJ43.QT8.A854 Q842.8.J942.K932"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 Pass    Pass    3C      Db
 Pass    3D      Pass    Pass
 Pass    
@@ -2054,10 +2054,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AKJ2.KQ83.AJ.984 T9873.T75.763.Q3 Q6.A94.Q982.AK62 54.J62.KT54.JT75"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -2066,9 +2066,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J8.KT6.J873.9542 9.J75.K654.KQ863 AQ643.A84.AT9.J7 KT752.Q932.Q2.AT"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2077,10 +2077,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ4.QJT8.QJ.AQJ9 T75.74.T9643.T83 AJ93.A5.AK72.652 862.K9632.85.K74"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -2089,11 +2089,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:JT.K.KQJ872.T854 K873.T84.943.AJ3 AQ54.J53.AT5.KQ7 962.AQ9762.6.962"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2S      Pass
-2NT     Pass    3H      Pass
-3S      Pass    3NT     Pass
+1N     Pass    2S      Pass
+2N     Pass    3H      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2104,7 +2104,7 @@ Pass    Pass
 [Deal "N:.86.KQT3.QJ86432 A632.3.J86542.K5 QJ975.AKJ.A97.T7 KT84.QT97542..A9"]
 [Contract "3C"]
 [Auction "S"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2114,10 +2114,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AT54.Q92.KQJ54.J KQ6.AK4.83.T8643 J32.J6.A972.AKQ9 987.T8753.T6.752"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2126,9 +2126,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:972.JT5.AKQ5.J63 Q853.97.T83.8542 J64.AKQ.742.AKT9 AKT.86432.J96.Q7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2139,7 +2139,7 @@ Pass    Pass
 [Deal "N:QJ85.J743.J62.73 KT43.Q95.KT98.T5 A72.A862.A53.AJ4 96.KT.Q74.KQ9862"]
 [Contract "3C"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    3C      Pass    Pass
 Pass    
 
@@ -2149,9 +2149,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K75.76.J52.JT953 AJ.KJT9.986.8764 Q984.A843.Q3.AKQ T632.Q52.AKT74.2"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2162,7 +2162,7 @@ Pass
 [Deal "N:J63.93.AT864.873 K9752.AT62.Q93.4 Q8.KJ.KJ752.AJ92 AT4.Q8754..KQT65"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2H      Pass    3H
+1N     2H      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
 
@@ -2172,10 +2172,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KQJ3.QT2.K954.94 A9.J9.T8762.QJ52 762.K543.AQJ.AK6 T854.A876.3.T873"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2186,8 +2186,8 @@ Pass    Pass
 [Deal "N:KQT87.95.Q9.QJ84 94.Q72.JT763.AT5 A63.AK83.K5.K976 J52.JT64.A842.32"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 4H      Pass    4S      Pass
 Pass    Pass    
 
@@ -2199,7 +2199,7 @@ Pass    Pass
 [Deal "N:J8642.Q96.QJ96.4 Q3.54.K742.AQ832 AK7.AT.AT85.JT76 T95.KJ8732.3.K95"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -2211,7 +2211,7 @@ Pass    Pass
 [Deal "N:75.73.AT874.K952 .AQJ98.9632.AQ76 AQ4.KT4.KQ5.J843 KJT98632.652.J.T"]
 [Contract "4S"]
 [Auction "S"]
-1NT     4S      Pass    Pass
+1N     4S      Pass    Pass
 Pass    
 
 
@@ -2220,10 +2220,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K843.KJT4.87.A82 Q9.8652.KQT93.T9 A2.AQ7.652.KQJ43 JT765.93.AJ4.765"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2234,7 +2234,7 @@ Pass    Pass
 [Deal "N:K9852.A.K73.9732 7.J754.QT84.AQT5 AJT3.K832.AJ2.KJ Q64.QT96.965.864"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 3C      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -2245,11 +2245,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AK97.QT72.82.986 532.A86.743.K753 Q6.K53.AQ6.AQT42 JT84.J94.KJT95.J"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2258,10 +2258,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A53.A962.QJT9.76 KQT72.Q85.84.J84 J984.KT4.A65.AK3 6.J73.K732.QT952"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2270,9 +2270,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AT4.932.QT54.AJ4 96.QJ8765.K62.KT KQ75.A4.AJ7.Q752 J832.KT.983.9863"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2281,11 +2281,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJT7.K74.T.AQ853 9642.Q98.KQ984.J A3.A63.AJ752.K62 Q85.JT52.63.T974"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2294,9 +2294,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A32.QJ63.T87.J52 KT54.987.J9.Q963 Q7.A2.Q5432.AKT4 J986.KT54.AK6.87"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2307,7 +2307,7 @@ Pass    Pass
 [Deal "N:AJ642.4.Q52.QJ95 985.J73.974.AK83 KQT73.AQT.A63.72 .K98652.KJT8.T64"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3C      Pass
 4S      Pass    Pass    Pass
 
@@ -2320,7 +2320,7 @@ Pass    Pass
 [Deal "N:AKJ872.K876..643 9653.A4.9876.A75 Q4.QJ5.AKT4.KJ98 T.T932.QJ532.QT2"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    4D      Pass
 4S      Pass    Pass    Pass
 
@@ -2333,7 +2333,7 @@ Pass    Pass
 [Deal "N:QT9873.A5.7.J932 4.T9762.QT43.KT8 AK6.KQ43.K982.76 J52.J8.AJ65.AQ54"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -2344,9 +2344,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:T432.T63.42.A932 7.J875.AQ8.J7654 AQ98.KQ.JT65.KQT KJ65.A942.K973.8"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2355,9 +2355,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT7.72.T9852.652 K852.953.AKQJ6.T Q963.AQ6.73.AK83 J4.KJT84.4.QJ974"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2366,9 +2366,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q3.652.KQ7.QJ974 A4.JT.AT8432.532 KJ92.AKQ8.J65.K8 T8765.9743.9.AT6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2379,7 +2379,7 @@ Pass    Pass
 [Deal "N:A98732.94.Q2.AQ4 T4.AKJ85.T643.T8 K5.Q7.AK95.KJ932 QJ6.T632.J87.765"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Db
+1N     Pass    4H      Db
 4S      Pass    Pass    Pass
 
 
@@ -2391,7 +2391,7 @@ Pass    Pass
 [Deal "N:J5.J986.Q2.KQJ97 K932.A7.KT965.32 AQ4.KQT4.87.A654 T876.532.AJ43.T8"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2401,9 +2401,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KQ3.A9.J9862.Q95 T98542.K75.AK.63 AJ6.QJ6.Q73.AJ82 7.T8432.T54.KT74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2414,7 +2414,7 @@ Pass    Pass
 [Deal "N:AKJ96.2.53.KJT53 QT.KQJ984.QJ98.9 8543.AT.AK74.AQ2 72.7653.T62.8764"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 3H      Pass    4H      Pass
 4S      Pass    Pass    Pass
 
@@ -2427,8 +2427,8 @@ Pass    Pass
 [Deal "N:QJT85.AT2.K75.J9 K6.873.J982.7632 A94.KJ9.AQ43.QT4 732.Q654.T6.AK85"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -2440,7 +2440,7 @@ Pass    Pass
 [Deal "N:J8742.5.T84.Q982 Q63.Q98.AQ532.74 KT95.J4.KJ96.AKT A.AKT7632.7.J653"]
 [Contract "5H"]
 [Auction "S"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Db      Pass    4S      Db
 Pass    5H      Pass    Pass
 Pass    
@@ -2453,7 +2453,7 @@ Pass
 [Deal "N:9.K9764.AT94.A92 AQJ7.J8.K85.T754 K42.AQ532.QJ7.K3 T8653.T.632.QJ86"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3D      Pass
 4H      Pass    Pass    Pass
 
@@ -2464,10 +2464,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ965.T2.KT95.Q7 T843.KQ976.6.JT8 AJ.AJ85.AJ8.6542 72.43.Q7432.AK93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2476,9 +2476,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:63.T7.J9764.KT65 KQ85.K652.Q5.A42 AT7.AQ4.AT8.QJ83 J942.J983.K32.97"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2489,7 +2489,7 @@ Pass    Pass
 [Deal "N:QJT9.A7.T82.AJ98 75.942.964.KQT72 AK62.J83.AKJ7.64 843.KQT65.Q53.53"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2501,7 +2501,7 @@ Pass    Pass
 [Deal "N:Q72.QT9654.T.K98 963.3.Q632.QT654 KJT.AKJ2.9874.A3 A854.87.AKJ5.J72"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Db      3H      Pass
 4H      Pass    Pass    Pass
 
@@ -2514,7 +2514,7 @@ Pass    Pass
 [Deal "N:42.J9.T643.Q9752 AT96.865.KQ8.JT3 875.AT4.A72.AK84 KQJ3.KQ732.J95.6"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -2523,10 +2523,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J943.AJT9.Q7.Q86 KT52.873.T85.T52 Q8.K64.AKJ32.KJ3 A76.Q52.964.A974"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2537,7 +2537,7 @@ Pass    Pass
 [Deal "N:KQJ6.T82.A54.K92 T43.KJ54.KJ86.T8 A985.AQ.Q73.AJ65 72.9763.T92.Q743"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2549,7 +2549,7 @@ Pass    Pass
 [Deal "N:KJ964.T8542.2.63 Q75.KJ3.AT987.K8 A2.A96.KJ4.AT972 T83.Q7.Q653.QJ54"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -2559,10 +2559,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A.KJ98.Q98742.32 KQ765.752.KT3.T5 T2.QT4.A65.AKQJ8 J9843.A63.J.9764"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2571,10 +2571,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q4.AQ732.QJ.J942 653.J85.AT98.KT7 AK7.K9.6532.AQ86 JT982.T64.K74.53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2583,10 +2583,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ.76.T874.QT765 KJ8764.Q8432.QJ. T52.KJ9.K9.AKJ83 93.AT5.A6532.942"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2597,7 +2597,7 @@ Pass    Pass
 [Deal "N:AT852.93.QJT9.65 Q93.AQ87.543.JT9 J74.KJ62.A6.AQ83 K6.T54.K872.K742"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -2607,9 +2607,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQ8.84.J32.87532 965.72.AQT7.AJ64 AT74.AQ53.K95.Q9 J32.KJT96.864.KT"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2618,9 +2618,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QJ.643.8652.QJ64 A3.8752.AT73.K87 K64.KQT.QJ4.AT93 T98752.AJ9.K9.52"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2629,9 +2629,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:7543.843.KJ.QT73 K9.Q92.T8632.A92 AQ.KJT76.A97.J65 JT862.A5.Q54.K84"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2642,8 +2642,8 @@ Pass    Pass
 [Deal "N:K85.Q94.532.T854 T3.KJT53.AT87.Q2 A742.A862.K4.A63 QJ96.7.QJ96.KJ97"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    Pass    2H
-Pass    2NT     Pass    3D
+1N     Pass    Pass    2H
+Pass    2N     Pass    3D
 Pass    3S      Pass    4H
 Pass    Pass    Pass    
 
@@ -2655,8 +2655,8 @@ Pass    Pass    Pass
 [Deal "N:K8765.Q54.K9.KT9 9.9832.Q85.Q7654 AJ42.A6.JT43.AJ2 QT3.KJT7.A762.83"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -2666,10 +2666,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQ83.KQ5.72.KT62 65.8732.9854.J85 942.AT4.AJT63.AQ AJT7.J96.KQ.9743"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2680,7 +2680,7 @@ Pass    Pass
 [Deal "N:AT96.AKT9.J5.K75 K3.82.KT9842.J96 QJ754.Q43.A6.AQ3 82.J765.Q73.T842"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2692,7 +2692,7 @@ Pass    Pass
 [Deal "N:QJ32.643.A.KQJ65 4.K952.JT9876.T7 A965.A8.KQ54.A93 KT87.QJT7.32.842"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2702,9 +2702,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KT5.97.Q53.AKQJ5 7.J2.AT8742.9873 AQ32.AK5.KJ96.T6 J9864.QT8643..42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2715,7 +2715,7 @@ Pass    Pass
 [Deal "N:A9.JT94.Q632.K52 KQ84.865.T75.J98 JT53.AK72.K4.A73 762.Q3.AJ98.QT64"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2727,8 +2727,8 @@ Pass    Pass
 [Deal "N:AKT98.J5.J63.JT8 Q5.A8732.87.6543 J76.KT96.KQ.AK92 432.Q4.AT9542.Q7"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -2740,8 +2740,8 @@ Pass    Pass
 [Deal "N:653.9.K8753.J754 K74.KJ7432.Q4.83 AQJT9.T6.JT6.AK2 82.AQ85.A92.QT96"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    Pass    2C
-Pass    2NT     Pass    3H
+1N     Pass    Pass    2C
+Pass    2N     Pass    3H
 Pass    Pass    Pass    
 
 
@@ -2752,8 +2752,8 @@ Pass    Pass    Pass
 [Deal "N:JT9872.8.KJ6.A86 Q6543.Q72.84.942 AK.KT63.QT753.K3 .AJ954.A92.QJT75"]
 [Contract "4S"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    4S      Pass
+1N     2H      3S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -2764,7 +2764,7 @@ Pass    Pass
 [Deal "N:85.AJT8543.865.9 J94.Q2.K2.K87532 AQT.K7.QJ93.QJT4 K7632.96.AT74.A6"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -2776,7 +2776,7 @@ Pass    Pass
 [Deal "N:98542.A.J9732.97 AJ6.QJ.84.KJT852 KQ73.K4.AK65.643 T.T9876532.QT.AQ"]
 [Contract "3C"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    3C
 Pass    Pass    Pass    
 
@@ -2788,7 +2788,7 @@ Pass    Pass    Pass
 [Deal "N:Q8.AT654.QT.J964 K7632.87.85.KT73 JT.KJ2.A64.AQ852 A954.Q93.KJ9732."]
 [Contract "4H"]
 [Auction "S"]
-1NT     2S      4H      Pass
+1N     2S      4H      Pass
 Pass    Pass    
 
 
@@ -2797,11 +2797,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q95.Q8.A742.J942 J763.J75.J3.KQ65 A42.AK4.Q9865.A7 KT8.T9632.KT.T83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2810,10 +2810,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q85.AJ94.K8.J973 AJT643.52.7.8652 K7.QT6.AJT43.AK4 92.K873.Q9652.QT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2822,9 +2822,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q72.K95.QT76.T84 AT64.732.9.K9765 83.AQJ8.AJ43.QJ3 KJ95.T64.K852.A2"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2833,11 +2833,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:T642.KQ94.K9.J86 Q9873.52.J43.AT4 AK5.876.AQ765.K2 J.AJT3.T82.Q9753"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2846,10 +2846,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K6542.7543..A873 AJT3.9.JT94.JT94 Q97.QJ2.AK83.KQ2 8.AKT86.Q7652.65"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2858,11 +2858,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K9.9532.KQJ93.T5 QT86.AQ84.42.Q98 A42.KJ.AT8.AJ732 J753.T76.765.K64"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2871,9 +2871,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AKT.863.AJ62.T63 9743.T7542.T8.K2 Q5.AQJ9.Q93.A987 J862.K.K754.QJ54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2884,7 +2884,7 @@ Pass    Pass
 [Deal "N:Q543.JT642.T9.Q8 JT6.5.AQ8543.763 A972.AK3.J76.K42 K8.Q987.K2.AJT95"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Db
+1N     Pass    2D      Db
 2H      Pass    Pass    Pass
 
 
@@ -2896,7 +2896,7 @@ Pass    Pass
 [Deal "N:83.KQ964.42.KJT7 KJT654.A82.KQT.5 AQ7.73.A73.AQ863 92.JT5.J9865.942"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      2S
+1N     Pass    2D      2S
 Pass    Pass    3C      Pass
 3S      Pass    4H      Pass
 Pass    Pass    
@@ -2909,8 +2909,8 @@ Pass    Pass
 [Deal "N:T73.AK732.AJ.Q72 J92..KT8763.K963 AK54.QT8.Q542.AJ Q86.J9654.9.T854"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -2922,7 +2922,7 @@ Pass    Pass
 [Deal "N:T976432.52.6.A87 K8.JT983.QT874.3 AQJ5.Q74.J95.KQ5 .AK6.AK32.JT9642"]
 [Contract "5H"]
 [Auction "S"]
-1NT     Db      2H      2S
+1N     Db      2H      2S
 Db      3C      Pass    3H
 3S      4H      4S      Pass
 Pass    5H      Pass    Pass
@@ -2936,8 +2936,8 @@ Pass
 [Deal "N:Q2.AK865.974.K94 T98.QT9.KJ53.T75 K4.J42.AQ862.AQ6 AJ7653.73.T.J832"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -2947,9 +2947,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A32.82.AJ42.KQT3 JT976.AQJ75.95.6 KQ.K96.KT86.AJ82 854.T43.Q73.9754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2960,7 +2960,7 @@ Pass    Pass
 [Deal "N:Q983.KT42..AK732 AT765.5.A743.QT4 K42.AQ863.KQ8.J8 J.J97.JT9652.965"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    3D      Pass
+1N     Pass    3D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2972,7 +2972,7 @@ Pass    Pass
 [Deal "N:KQ9762.6.QJ2.985 T54.Q3.K9873.A43 J3.AJ54.A5.KQT76 A8.KT9872.T64.J2"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -2984,7 +2984,7 @@ Pass    Pass
 [Deal "N:6532.2.K97653.Q2 Q8.A74.842.A7653 KJT7.KQJ6.AQJ.T4 A94.T9853.T.KJ98"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2994,10 +2994,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q973.T4.AKQJ7.86 A6.Q975.96.97432 K5.AJ632.T85.AKT JT842.K8.432.QJ5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3006,10 +3006,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:64.AK86.K9543.94 Q93.J5432.Q86.T3 AK75.Q97.AJ7.K72 JT82.T.T2.AQJ865"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2C      Db      Pass
-2S      Pass    3NT     Pass
+1N     2C      Db      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3018,9 +3018,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T862.K.Q654.Q842 K53.JT9742.K9.J9 AQJ74.Q65.T8.AK7 9.A83.AJ732.T653"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3031,7 +3031,7 @@ Pass    Pass
 [Deal "N:J753.9.A86542.86 62.J5.QJT9.AQJT3 AKT.A642.K7.K974 Q984.KQT873.3.52"]
 [Contract "3D"]
 [Auction "S"]
-1NT     2C      3C      Db
+1N     2C      3C      Db
 3D      Pass    Pass    Pass
 
 
@@ -3043,9 +3043,9 @@ Pass    Pass
 [Deal "N:AKQ52.KJT8.2.K85 J973.97643.Q3.T3 T86.Q2.AK9.AQJ62 4.A5.JT87654.974"]
 [Contract "6S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -3057,7 +3057,7 @@ Pass    Pass
 [Deal "N:Q5.AT9532..JT874 J976.J.AJ86.Q963 T4.KQ7.KQ973.AK2 AK832.864.T542.5"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3069,7 +3069,7 @@ Pass    Pass
 [Deal "N:J8632.AJ752.J2.8 A74.Q.97.KQT6532 KT.K98.AQ43.AJ94 Q95.T643.KT865.7"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    2S      Pass
 4H      Pass    Pass    Pass
 
@@ -3080,10 +3080,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:8762.KJ5.KQJ52.T JT.Q8763.6.AK532 A94.AT4.A98.QJ86 KQ53.92.T743.974"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3094,7 +3094,7 @@ Pass    Pass
 [Deal "N:7.JT842.KT82.874 A93.653.975.K952 KQ86.A97.AQJ.JT6 JT542.KQ.643.AQ3"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -3106,7 +3106,7 @@ Pass    Pass
 [Deal "N:3.Q76543.J3.T982 K8754.J98.T864.Q AJ6.K2.A75.A7654 QT92.AT.KQ92.KJ3"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Db      Pass    2S
 Pass    Pass    Pass    
 
@@ -3116,10 +3116,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQ95.AQ.KT96.T74 J.J762.432.J8632 A42.KT83.AJ.KQ95 T8763.954.Q875.A"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3130,7 +3130,7 @@ Pass    Pass
 [Deal "N:752.J5.865.QJ643 JT863.93.AKJ4.72 AQ4.842.Q9732.AK K9.AKQT76.T.T985"]
 [Contract "4H"]
 [Auction "S"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -3139,9 +3139,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A84.A4.KJ5.QJ987 T932.976.984.K53 Q765.KQ5.AQT7.A6 KJ.JT832.632.T42"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3152,9 +3152,9 @@ Pass    Pass
 [Deal "N:.KJ9543.AJ75.A42 JT87.87.Q4.QT763 KQ542.A6.KT6.KJ5 A963.QT2.9832.98"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    4S      Pass
-4NT     Pass    6H      Pass
+4N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -3165,7 +3165,7 @@ Pass    Pass
 [Deal "N:J654.KT86.86.J96 72.AQJ953.93.AK5 A93.74.AKQJ4.Q32 KQT8.2.T752.T874"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      2H      Pass
 3D      Pass    Pass    Pass
 
@@ -3178,7 +3178,7 @@ Pass    2D      2H      Pass
 [Deal "N:9654.AT5.T53.KQT .98643.AQJ84.A87 KQJ73.KQJ.K96.93 AT82.72.72.J6542"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -3190,7 +3190,7 @@ Pass    Pass
 [Deal "N:93.K987.KQ97.T74 AQ742.Q3.T83.K96 K8.A542.A62.AQ53 JT65.JT6.J54.J82"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -3203,7 +3203,7 @@ Pass    Pass
 [Deal "N:A7643.8.7532.T87 8.AQ965.K864.964 KQ52.J42.QJ.AQ32 JT9.KT73.AT9.KJ5"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 2S      Pass    Pass    3H
 3S      Pass    Pass    Pass
 
@@ -3216,8 +3216,8 @@ Pass    Pass
 [Deal "N:Q8.KJT65.A972.83 K7642.Q8.T83.765 AT93.A43.KQ6.K94 J5.972.J54.AQJT2"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -3229,7 +3229,7 @@ Pass    Pass
 [Deal "N:9.QT764.KJT8.KT5 K762.83.Q763.A73 AJ53.AK92.A95.82 QT84.J5.42.QJ964"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3D      Pass
 4H      Pass    Pass    Pass
 
@@ -3240,10 +3240,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QJ654.A52.Q73.53 732.K43.9862.987 AT.QJ86.AJT.QJT2 K98.T97.K54.AK64"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3252,11 +3252,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J96.Q652.753.AQ8 T8742.84.AK86.96 AK3.KJ7.JT92.KJT Q5.AT93.Q4.75432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3265,10 +3265,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQJ9.AT85.AJ4.T9 653.J742.K32.A76 K74.KQ.Q876.KQ42 T82.963.T95.J853"]
-[Contract "4NT"]
+[Contract "4N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    4NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    4N     Pass
 Pass    Pass    
 
 
@@ -3279,8 +3279,8 @@ Pass    Pass
 [Deal "N:965.2.AQ94.KJ952 QT83.6.KT65.T876 AKJ72.J95.J8.AQ3 4.AKQT8743.732.4"]
 [Contract "4S"]
 [Auction "S"]
-1NT     2C      2S      Pass
-2NT     3H      Pass    Pass
+1N     2C      2S      Pass
+2N     3H      Pass    Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3292,7 +3292,7 @@ Pass    Pass
 [Deal "N:J96.96.Q6542.T96 AQ73.2.A873.J852 KT2.K873.KJ.KQ73 854.AQJT54.T9.A4"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2H      Pass    2S
 Pass    4H      Pass    Pass
 Pass    
@@ -3303,10 +3303,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:75.AQ53.K764.J52 AQT6.86.QJT32.73 32.KT2.A95.AKQT8 KJ984.J974.8.964"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3317,8 +3317,8 @@ Pass    Pass
 [Deal "N:QJ953.K2.AQ43.72 76.T973.J76.K864 K42.AQ.KT982.QJ3 AT8.J8654.5.AT95"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -3330,7 +3330,7 @@ Pass    Pass
 [Deal "N:93.Q954.T9532.62 KQJT754.J.J.AJ54 A62.K7.AK876.Q93 8.AT8632.Q4.KT87"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      Pass    2S
+1N     2C      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -3339,9 +3339,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QT62.AJ5.T4.9752 K7.6432.AQ93.J84 AJ54.KQ7.KJ2.QT6 983.T98.8765.AK3"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3350,9 +3350,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:98.J654.T875.T43 QT6.A982.432.965 AK53.KQ.KJ96.J72 J742.T73.AQ.AKQ8"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "S"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -3361,9 +3361,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J7.J53.9632.JT97 A6543.QT94.J54.5 Q2.K87.AT8.AQ862 KT98.A62.KQ7.K43"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3372,10 +3372,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QT3.T432.Q6.AK87 KJ8.K7.KT4.T6532 A654.AQ6.AJ82.J4 972.J985.9753.Q9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3384,9 +3384,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AJ.QT9.9.T987642 T985.J543.KQ43.3 Q7.A86.AJ852.AJ5 K6432.K72.T76.KQ"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3395,10 +3395,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QJT.J732.AQ87.96 43.T64.43.KQT852 A2.AQ9.JT962.AJ7 K98765.K85.K5.43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Db
-2D      Pass    3NT     Pass
+1N     Pass    2C      Db
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3407,11 +3407,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:982.Q.542.AKT652 T74.K852.KJ76.Q8 AKJ5.A764.A83.43 Q63.JT93.QT9.J97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3420,10 +3420,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K6.QT75.K8532.Q8 QJ7.AJ643.Q9.932 A52.K82.AJT4.AT5 T9843.9.76.KJ764"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3434,7 +3434,7 @@ Pass    Pass
 [Deal "N:KQ9652.32.A2.AQ9 874.J9.T9653.T87 J3.AK875.K74.KJ5 AT.QT64.QJ8.6432"]
 [Contract "5S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    5C      Pass
 5H      Pass    5S      Pass
 Pass    Pass    
@@ -3445,10 +3445,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K97.Q752.9.A7532 QJ854.AT.K8642.J AT6.KJ8.AQJ.T986 32.9643.T753.KQ4"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3459,7 +3459,7 @@ Pass    Pass
 [Deal "N:J974.QT965.T54.T AQ62.873.62.K843 KT53.AK42.AJ9.Q7 8.J.KQ873.AJ9652"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 3C      Db      Pass    Pass
 3S      Pass    4H      Pass
 Pass    Pass    
@@ -3472,7 +3472,7 @@ Pass    Pass
 [Deal "N:K5.JT432.KQ864.J AJT8.A9.9.AQ9865 Q6.KQ76.AJT53.K3 97432.85.72.T742"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3D      Db
 4H      Pass    Pass    Pass
 
@@ -3483,9 +3483,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:2.93.Q8752.KT742 J8.J86542.KJT.J5 Q9754.KQ7.A4.A83 AKT63.AT.963.Q96"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3496,7 +3496,7 @@ Pass    Pass
 [Deal "N:AQ2.KJ98765.A42. KT84.QT.K965.Q97 J95.A43.QJT.AK32 763.2.873.JT8654"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    6H      Pass
 Pass    Pass    
 
@@ -3508,7 +3508,7 @@ Pass    Pass
 [Deal "N:J9654.T.A972.J94 T72.875.QT5.AT32 AK83.Q9.K643.K65 Q.AKJ6432.J8.Q87"]
 [Contract "3H"]
 [Auction "S"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -3519,8 +3519,8 @@ Pass
 [Deal "N:J963.JT3.QJ.Q864 AQ874.74.K3.KJ95 KT2.KQ65.AT85.AT 5.A982.97642.732"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    Pass    2S
-Pass    2NT     Pass    3C
+1N     Pass    Pass    2S
+Pass    2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -3531,7 +3531,7 @@ Pass    Pass    Pass
 [Deal "N:T854.J5.T4.KQJT3 62.AQT742.Q762.2 KJ3.K86.AJ853.A6 AQ97.93.K9.98754"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      2S      Pass
 Pass    Pass    
 
@@ -3541,9 +3541,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:T4.A7.AQJ763.932 Q8732.J952.8.T54 AKJ9.QT3.92.AQ87 65.K864.KT54.KJ6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3554,7 +3554,7 @@ Pass    Pass
 [Deal "N:J75.874.A432.T65 T86.T652.Q87.A82 KQ2.AJ3.KJT65.Q4 A943.KQ9.9.KJ973"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3565,7 +3565,7 @@ Pass
 [Deal "N:64.T96.KQT742.82 JT973.J7.65.Q976 KQ8.K832.AJ8.A53 A52.AQ54.93.KJT4"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3577,8 +3577,8 @@ Pass
 [Deal "N:K9752.J3.KT4.QJ8 QJT.Q865.J72.T62 A643.942.A86.AK4 8.AKT7.Q953.9753"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -3588,10 +3588,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:62.A975.AQT5.643 8543.Q632.92.K85 AJ7.KT.K8743.A92 KQT9.J84.J6.QJT7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3600,9 +3600,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QJ5.T642.K.T8754 74.QJ973.Q7643.2 A8.A8.JT98.AK963 KT9632.K5.A52.QJ"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3613,7 +3613,7 @@ Pass    Pass
 [Deal "N:3.K8654.J85.K654 Q752.QJT92.T3.83 K94.A73.AQ2.QJT7 AJT86..K9764.A92"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2S      4H      Pass
+1N     2S      4H      Pass
 Pass    Pass    
 
 
@@ -3622,10 +3622,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:742.A976.A9.Q875 JT8.T5.QT532.JT3 AK653.J32.764.AK Q9.KQ84.KJ8.9642"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3636,7 +3636,7 @@ Pass    Pass
 [Deal "N:84.953.T753.Q742 J.AKJT7.KJ982.J6 AT32.Q84.AQ.A953 KQ9765.62.64.KT8"]
 [Contract "4S"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    3H
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
@@ -3647,9 +3647,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:963.J.K9832.K765 75.Q76543.J4.843 Q82.AT9.AQ7.QJT9 AKJT4.K82.T65.A2"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3658,10 +3658,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:987.AK42.QJ7.JT3 K5.J8653.63.9762 A42.QT9.AK842.A5 QJT63.7.T95.KQ84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3670,9 +3670,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T42.T73.J32.8632 963.AK94.KQ64.T4 KQJ8.QJ5.T5.AKJ5 A75.862.A987.Q97"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3683,7 +3683,7 @@ Pass    Pass
 [Deal "N:A7642.A73.T3.976 J98.JT962.A5.Q53 T53.KQ4.KQ4.AK82 KQ.85.J98762.JT4"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -3693,9 +3693,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QJ83.83.T983.T53 754.JT6.KJ.J9876 AT.A9754.A42.K42 K962.KQ2.Q765.AQ"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "S"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -3704,11 +3704,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QT8.AQJ3.8.T8432 43.642.AT742.975 AK65.T8.Q93.AKJ6 J972.K975.KJ65.Q"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3717,9 +3717,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:862.Q43.A8.A9874 973.AK875.96.632 AQT.JT9.KJ75.KJT KJ54.62.QT432.Q5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3730,7 +3730,7 @@ Pass    Pass
 [Deal "N:A5.J853.942.KQT3 J8732.T.Q875.652 K9.K962.AJ63.A87 QT64.AQ74.KT.J94"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3742,7 +3742,7 @@ Pass    Pass
 [Deal "N:832.T8.532.JT763 J7.Q9765.T7.Q985 KT64.AK42.K4.A42 AQ95.J3.AQJ986.K"]
 [Contract "2C"]
 [Auction "S"]
-1NT     Db      Rd      Pass
+1N     Db      Rd      Pass
 2C      Pass    Pass    Pass
 
 
@@ -3752,9 +3752,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T832.A3.A8.T7653 AQ54.8.K9732.KQJ KJ7.KQT9.QT5.A42 96.J76542.J64.98"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3763,10 +3763,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QJ2.QT84.AK92.73 8.K76532.Q63.KT4 A3.AJ.T874.AQ852 KT97654.9.J5.J96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3777,7 +3777,7 @@ Pass    Pass
 [Deal "N:AJ953.J.J543.K82 T2.KQ432.6.JT975 KQ4.AT876.KQ.Q64 876.95.AT9872.A3"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 2S      Pass    3D      Pass
 4S      Pass    Pass    Pass
 
@@ -3790,7 +3790,7 @@ Pass    Pass
 [Deal "N:8753.QT654.93.82 AKJ.AJ93..AQ7543 Q62.K72.AQ6.KJ96 T94.8.KJT87542.T"]
 [Contract "4D"]
 [Auction "S"]
-1NT     4D      Pass    Pass
+1N     4D      Pass    Pass
 Pass    
 
 
@@ -3799,9 +3799,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:874.7542.QJ9.J53 KQJ2.T83.A3.9864 AT6.K6.KT875.AQ2 953.AQJ9.642.KT7"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3812,7 +3812,7 @@ Pass
 [Deal "N:JT72.3.K542.9862 A.KQJ764.J97.J54 Q85.A92.AQ86.K73 K9643.T85.T3.AQT"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      Pass    2H
 Pass    Pass    2S      Pass
 Pass    3H      Pass    Pass
@@ -3826,7 +3826,7 @@ Pass
 [Deal "N:A3.9432.AQT5.K86 85.A65.J94.J9532 K962.QJ87.K7.AQ4 QJT74.KT.8632.T7"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3838,7 +3838,7 @@ Pass    Pass
 [Deal "N:AK92.Q2.JT54.KJ5 T64.A85.86.98732 Q873.K3.AQ92.AQT J5.JT9764.K73.64"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3850,7 +3850,7 @@ Pass    Pass
 [Deal "N:Q2.QJ842.T653.76 A63.T65.J984.AK9 K94.AK97.K72.Q82 JT875.3.AQ.JT543"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -3862,7 +3862,7 @@ Pass    Pass
 [Deal "N:K9764.Q65.97.KT9 T5.AT7.K86432.J3 A8.J432.AQ5.A852 QJ32.K98.JT.Q764"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -3872,9 +3872,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A32.984.QJT7.742 T876.62.K42.T653 K94.QJT3.A5.KQJ8 QJ5.AK75.9863.A9"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3885,9 +3885,9 @@ Pass    Pass
 [Deal "N:3.AK8.AK8743.T87 T94.965.QJ2.QJ52 AKQJ6.Q32.T5.K64 8752.JT74.96.A93"]
 [Contract "5D"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -3899,7 +3899,7 @@ Pass    Pass
 [Deal "N:AJ842.Q93.J93.74 Q.KT75.K8754.T96 K65.64.AQ2.AK532 T973.AJ82.T6.QJ8"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -3911,7 +3911,7 @@ Pass    Pass
 [Deal "N:976.K97.J9765.T7 32.5.KT32.AQJ963 KQ84.JT8.AQ8.K82 AJT5.AQ6432.4.54"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -3922,7 +3922,7 @@ Pass    Pass    Pass
 [Deal "N:9874.62.Q9642.96 T32.T9874.87.T32 AQJ6.Q3.K53.KQ75 K5.AKJ5.AJT.AJ84"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Db      Rd      2H
+1N     Db      Rd      2H
 Pass    Pass    Pass    
 
 
@@ -3933,7 +3933,7 @@ Pass    Pass    Pass
 [Deal "N:AJ7.JT76.QJT54.7 8532.3.A93.AK862 QT6.AKQ85.K76.Q9 K94.942.82.JT543"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3943,9 +3943,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T875.QJ2.42.A653 A9.KT987.KJ87.84 K3.A65.AQT65.Q97 QJ642.43.93.KJT2"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3954,10 +3954,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AJ94.K74.J752.63 KQ65.J93.KT6.QJ9 T32.AQT.Q94.AKT2 87.8652.A83.8754"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3966,9 +3966,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K85.K32.AQJ.A854 JT94.AJ95.986.73 AQ2.T86.K72.KQJ6 763.Q74.T543.T92"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
-1NT     Pass    6NT     Pass
+1N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -3977,9 +3977,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT62.985.9542.T8 Q93.AQ62.J3.K652 K754.K3.AKQ7.743 J8.JT74.T86.AQJ9"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3988,9 +3988,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J5.543.KQT63.KJ5 K8743.KQ6.J75.A4 AQT6.AJ8.A92.Q73 92.T972.84.T9862"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4001,7 +4001,7 @@ Pass    Pass
 [Deal "N:QT43.J973.986.52 .Q654.KJ73.KT963 A86.K82.AQ54.A87 KJ9752.AT.T2.QJ4"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -4011,9 +4011,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT93.32.T6.T9865 J642.KQ854.KQ8.J KQ.A7.AJ975.Q432 875.JT96.432.AK7"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4024,7 +4024,7 @@ Pass
 [Deal "N:Q987.AJ863.98.65 643.K4.T7632.972 KJT5.T52.AK.AJT8 A2.Q97.QJ54.KQ43"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Db      4S      Pass
 Pass    Pass    
 
@@ -4034,9 +4034,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K932.9652.32.JT2 Q86.KQ84.K.Q8643 J74.AT7.AJT85.AK AT5.J3.Q9764.975"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4047,7 +4047,7 @@ Pass    Pass
 [Deal "N:AT64.AKQ9652..K9 8.87.Q532.QJ8654 K952.JT.AK86.A73 QJ73.43.JT974.T2"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    6H      Pass
 Pass    Pass    
 
@@ -4057,10 +4057,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J4.J43.42.AQ6543 Q7632.65.AQT87.9 A8.AT87.KJ96.KT2 KT95.KQ92.53.J87"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4071,8 +4071,8 @@ Pass    Pass
 [Deal "N:AJT4.Q98.T6.A972 75.KT7.KQ94.T643 KQ96.A642.AJ7.Q8 832.J53.8532.KJ5"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -4084,7 +4084,7 @@ Pass    Pass
 [Deal "N:T4.T983.AT984.QT Q96532.KQJ4.Q.K5 AKJ7.76.KJ6.A874 8.A52.7532.J9632"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -4094,10 +4094,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:4.KQ85.K953.K932 AQ3.97432.J76.Q7 KJT75.AT6.AT2.AT 9862.J.Q84.J8654"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3S      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4108,7 +4108,7 @@ Pass
 [Deal "N:JT42.Q53.J52.Q64 Q75.T7.T3.J87532 AK83.K9.Q987.KT9 96.AJ8642.AK64.A"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Db      Pass    2C
+1N     Db      Pass    2C
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -4120,7 +4120,7 @@ Pass    Pass
 [Deal "N:5.QJ9854.AT83.KT J86432.K32.4.843 AKQT9.AT.K62.765 7.76.QJ975.AQJ92"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4132,7 +4132,7 @@ Pass    Pass
 [Deal "N:842.T9862.976.K6 AT9.753.KT52.A42 KJ76.A4.AJ43.Q53 Q53.KQJ.Q8.JT987"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4144,7 +4144,7 @@ Pass    Pass
 [Deal "N:KQ943.976.KJ53.7 872.T.A864.KJT93 A65.AQ43.972.AQ5 JT.KJ852.QT.8642"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3D      Pass
 4S      Pass    Pass    Pass
 
@@ -4155,9 +4155,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K932.Q7.965.8732 Q74.KT5.KT72.JT5 AJ6.9832.AQ83.KQ T85.AJ64.J4.A964"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4168,7 +4168,7 @@ Pass    Pass
 [Deal "N:QT8743.J95.T3.A9 6.Q432.A984.QJ82 A952.AK.KQJ7.T74 KJ.T876.652.K653"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 3H      Pass    4H      Pass
 4S      Pass    Pass    Pass
 
@@ -4179,9 +4179,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q74.63.AKT.J8643 JT85.AQ4.653.QT7 K3.KJT8.Q984.AK5 A962.9752.J72.92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4192,7 +4192,7 @@ Pass    Pass
 [Deal "N:A432..87652.T975 KQT8.KJ6532..K86 75.AT94.AK4.AQ43 J96.Q87.QJT93.J2"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -4202,9 +4202,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJ84.854.T962.K2 QT7.73.KJ843.AQ4 A632.AKJ6.A7.T73 95.QT92.Q5.J9865"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4215,7 +4215,7 @@ Pass
 [Deal "N:87.KJT9.A543.843 KJ4.832.762.K752 A652.A654.QJ.A96 QT93.Q7.KT98.QJT"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -4225,11 +4225,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QT8.AT93.Q76.J93 J9632.76.KJ3.T72 AK74.QJ2.94.AQ84 5.K854.AT852.K65"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4240,7 +4240,7 @@ Pass    Pass
 [Deal "N:AT85.642.J5.AT42 632.87.KQT63.J87 J9.AJ5.A974.KQ53 KQ74.KQT93.82.96"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2D      Db      2S
+1N     2D      Db      2S
 Pass    Pass    Pass    
 
 
@@ -4249,10 +4249,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:85.9863.A92.KJ62 T42.J542.QJ54.87 A9.AQT.K87.QT954 KQJ763.K7.T63.A3"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     2C      Db      Pass
-2D      2S      2NT     Pass
+1N     2C      Db      Pass
+2D      2S      2N     Pass
 Pass    Pass    
 
 
@@ -4261,9 +4261,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:JT83.87.AQ98.932 Q94.963.K65.8764 AK6.A54.T743.AQ5 752.KQJT2.J2.KJT"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4274,7 +4274,7 @@ Pass    Pass
 [Deal "N:7.KJ7632.QJ84.83 KQ9532.8.763.KT7 AT.AT954.K95.A42 J864.Q.AT2.QJ965"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4286,7 +4286,7 @@ Pass    Pass
 [Deal "N:A.QT984.J853.KJT J543.32.642.6432 KQT82.KJ6.AK.987 976.A75.QT97.AQ5"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3D      Pass
 4H      Pass    Pass    Pass
 
@@ -4297,10 +4297,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:96.KT42.K9.KJ965 KQ872.Q976.QJ4.2 AJ3.83.AT73.AQT3 T54.AJ5.8652.874"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4309,9 +4309,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:2.T742.J54.KJ863 AT74.A3.QT8.9542 KJ86.9865.AK.AQ7 Q953.KQJ.97632.T"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4322,7 +4322,7 @@ Pass    Pass
 [Deal "N:T9852.KQT.K76.98 63.AJ83.QT854.JT KQ.752.A93.AK743 AJ74.964.J2.Q652"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -4334,7 +4334,7 @@ Pass    Pass
 [Deal "N:QJ8743.J987.98.4 5.A6543.754.AQT2 A92.KQT.QJ63.K76 KT6.2.AKT2.J9853"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -4346,7 +4346,7 @@ Pass    Pass
 [Deal "N:.T832.T65.JT8743 QT984.A97.A3.AK9 AKJ2.J65.KQ84.Q2 7653.KQ4.J972.65"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2NT     3S
+1N     Pass    2N     3S
 Pass    Pass    Pass    
 
 
@@ -4357,8 +4357,8 @@ Pass    Pass    Pass
 [Deal "N:AK96532.KT.Q.KT2 J.J85.9832.AJ963 T84.AQ3.AK75.Q74 Q7.97642.JT64.85"]
 [Contract "5S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
-4S      Pass    4NT     Pass
+1N     Pass    4H      Pass
+4S      Pass    4N     Pass
 5H      Pass    5S      Pass
 Pass    Pass    
 
@@ -4370,7 +4370,7 @@ Pass    Pass
 [Deal "N:QJ84.KQT42.AJ6.9 KT93.J95.T87.J64 65.A76.KQ952.AK8 A72.83.43.QT7532"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4383,7 +4383,7 @@ Pass    Pass
 [Deal "N:J852.J87.J654.K5 Q764.943..A98742 AKT3.T6.AQT9.Q63 9.AKQ52.K8732.JT"]
 [Contract "2H"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -4392,10 +4392,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K43.QT74.K.QJ985 T52.K95.QJ98632. AQJ76.863.A7.A74 98.AJ2.T54.KT632"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4404,10 +4404,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQT3.987.J42.A94 8654.K654.Q.T832 972.QJT.AK53.KQ7 KJ.A32.T9876.J65"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4418,7 +4418,7 @@ Pass    Pass
 [Deal "N:JT972.32.J97.765 K83.QT754.T82.J9 654.KJ.KQ65.AQT3 AQ.A986.A43.K842"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -4430,7 +4430,7 @@ Pass    Pass
 [Deal "N:94.53.KQT965.J72 AQ85.8742.8432.K KJT3.AT9.A7.AT94 762.KQJ6.J.Q8653"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4442,7 +4442,7 @@ Pass    Pass
 [Deal "N:9.A8.T9864.KJ983 KJ8532.J9.J72.T2 AT6.K2.A53.A7654 Q74.QT76543.KQ.Q"]
 [Contract "5C"]
 [Auction "S"]
-1NT     2C      2S      Pass
+1N     2C      2S      Pass
 3C      Pass    4C      Pass
 5C      Pass    Pass    Pass
 
@@ -4455,8 +4455,8 @@ Pass    Pass
 [Deal "N:KQ753.54.987.AT8 984.Q7.KJ65.9432 AJT.JT83.AT.KQ65 62.AK962.Q432.J7"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    2N     Pass
 3S      Pass    Pass    Pass
 
 
@@ -4468,7 +4468,7 @@ Pass    Pass
 [Deal "N:6.KT962.JT8.K873 JT984.853.KQ5.Q6 KQ2.AQ4.A92.J952 A753.J7.7643.AT4"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4480,7 +4480,7 @@ Pass    Pass
 [Deal "N:AJ864.K964.T5.QT 32.JT52.AK2.K984 KQ75.AQ.9864.AJ7 T9.873.QJ73.6532"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4490,9 +4490,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q953.J8.QT86.QJ5 A4.KT96.953.K743 KJ76.AQ3.AK42.98 T82.7542.J7.AT62"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4501,11 +4501,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJ52.T64.KJ7.963 764.97532.832.QJ T8.KJ8.AQ5.AK874 KQ93.AQ.T964.T52"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4516,7 +4516,7 @@ Pass    Pass
 [Deal "N:QJT.J.AK43.T7653 632.9543.985.J94 K4.KQT7.QJT2.KQ8 A9875.A862.76.A2"]
 [Contract "5D"]
 [Auction "S"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 3D      Pass    4D      Pass
 5D      Pass    Pass    Pass
 
@@ -4529,7 +4529,7 @@ Pass    Pass
 [Deal "N:8.9764.A8.T95432 AK.KQJT32.KT2.76 QJ53.A5.Q964.AQ8 T97642.8.J753.KJ"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2NT     3H
+1N     Pass    2N     3H
 Pass    Pass    Pass    
 
 
@@ -4540,7 +4540,7 @@ Pass    Pass    Pass
 [Deal "N:KQT983.92.JT3.QJ AJ2.643.872.A853 754.AKJ.A5.KT976 6.QT875.KQ964.42"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4550,11 +4550,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:74.T76.AK95.JT94 J983.K.QJ763.653 AK2.AQ953.T2.K72 QT65.J842.84.AQ8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4565,7 +4565,7 @@ Pass    Pass    Pass
 [Deal "N:KQJT.QJ7632.9.A6 4.T4.Q872.KQ9752 A6.A98.AKJ6.JT43 987532.K5.T543.8"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    4D      Pass
 4H      Pass    Pass    Pass
 
@@ -4576,9 +4576,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q842.JT8.2.87542 K7.7432.AT9.QT93 AJ95.KQ5.KJ83.J6 T63.A96.Q7654.AK"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4587,9 +4587,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T52.Q94.AJ76.743 AJ76.AJ85.82.KQ9 KQ983.K6.K95.A82 4.T732.QT43.JT65"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4598,9 +4598,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:965.A974.A84.T64 AT43.QT52.9.AJ52 QJ7.KJ8.KQ53.KQ8 K82.63.JT762.973"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4609,11 +4609,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J952.98.AQ63.Q97 T743.KT5.T4.T842 AKQ.Q6.J872.KJ53 86.AJ7432.K95.A6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2C      Db      Pass
-2D      2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2C      Db      Pass
+2D      2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4624,7 +4624,7 @@ Pass    Pass    Pass
 [Deal "N:J.AKQ643.T973.Q7 K8762.T98.2.JT62 T954.75.AKQ8.AK8 AQ3.J2.J654.9543"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4634,11 +4634,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:92.AKT87.92.QT97 QT743.92.KJ6.A52 AKJ.QJ.Q73.KJ863 865.6543.AT854.4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2D      Pass
+2H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4647,9 +4647,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQ7.73.J932.QJ76 T8652.KJ5.87.532 J3.A64.AKQ.KT984 K94.QT982.T654.A"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4660,7 +4660,7 @@ Pass    Pass
 [Deal "N:85.AQ864.J73.Q95 AT97432.93.T.AT7 KJ.KJT5.AK982.63 Q6.72.Q654.KJ842"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      3S
+1N     Pass    2D      3S
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -4672,7 +4672,7 @@ Pass    Pass
 [Deal "N:7654.A863.AT.T85 Q.Q.KJ86542.A943 A8.KJ54.Q9.KQJ72 KJT932.T972.73.6"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    Pass    3D
+1N     Pass    Pass    3D
 Pass    Pass    Pass    
 
 
@@ -4683,7 +4683,7 @@ Pass    Pass    Pass
 [Deal "N:KQ.JT7652.AT32.5 J8.K8.Q54.T87643 A952.AQ43.K6.K92 T7643.9.J987.AQJ"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4695,7 +4695,7 @@ Pass    Pass    Pass
 [Deal "N:AT96.T43.84.JT53 874.K85.QT7.9874 J2.Q962.K65.AKQ2 KQ53.AJ7.AJ932.6"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -4704,9 +4704,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KT9.QT54.Q4.JT82 AQ74.AK.98732.74 832.J32.AKJT5.AQ J65.9876.6.K9653"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4715,10 +4715,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A85.KT9.JT53.J97 Q3.87653.K72.T85 J64.AQJ2.Q98.KQ2 KT972.4.A64.A643"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4727,10 +4727,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A62.J72.J42.KT98 87.9853.Q87.A643 KQ43.AKT.K653.52 JT95.Q64.AT9.QJ7"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4739,9 +4739,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q832.T93.Q963.65 754.A7542.842.T7 KJT.J8.KJT.AKJ43 A96.KQ6.A75.Q982"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4750,10 +4750,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QT4.AQ3.A964.876 3.T76.KT832.JT54 K862.954.QJ.AKQ3 AJ975.KJ82.75.92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2D      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2D      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4764,7 +4764,7 @@ Pass    Pass
 [Deal "N:KJT9543.9742.J.J 8.AK5.Q87632.Q98 AQ.83.AKT54.K652 762.QJT6.9.AT743"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -4775,9 +4775,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q932.8632.T86.AQ J4.974.Q43.KJ863 K75.AKQJ.A9.T942 AT86.T5.KJ752.75"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4786,10 +4786,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K964.J4.2.KT8753 JT73.K65.T8543.Q AQ5.T972.AJ6.A94 82.AQ83.KQ97.J62"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4800,8 +4800,8 @@ Pass    Pass
 [Deal "N:K.7.QJ952.AJ9852 JT.9853.T76.T643 A864.QJ42.K3.KQ7 Q97532.AKT6.A84."]
 [Contract "5C"]
 [Auction "S"]
-1NT     2D      3C      Pass
-3NT     Pass    5C      Pass
+1N     2D      3C      Pass
+3N     Pass    5C      Pass
 Pass    Pass    
 
 
@@ -4810,9 +4810,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A42.Q32.9843.973 JT95.K9.KQT75.KQ K86.A65.AJ.AJ864 Q73.JT874.62.T52"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4821,9 +4821,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:9653.J8.K983.542 72.AT43.QJ75.J93 AKT.K76.T4.AQT87 QJ84.Q952.A62.K6"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4832,10 +4832,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A83.K53.Q65.T643 J9.AJT97.4.AQ952 Q2.Q84.AKJ82.K87 KT7654.62.T973.J"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      2H
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2H
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4846,7 +4846,7 @@ Pass    Pass
 [Deal "N:Q8.KQJ6.A3.QJ762 K9754.872.T2.KT5 AJ6.AT43.Q65.A93 T32.95.KJ9874.84"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4858,7 +4858,7 @@ Pass    Pass
 [Deal "N:A4.J97642.9.T953 QT75.A.643.KQJ87 KJ96.KT3.AQ2.A62 832.Q85.KJT875.4"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4868,9 +4868,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A75.874.T84.QJ32 T98.KQ6.AKQ92.T7 K43.A52.J753.AK5 QJ62.JT93.6.9864"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4879,10 +4879,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:54.A.9642.AKJ983 T982.Q63.KQ75.72 AQJ.K74.AJT83.T5 K763.JT9852..Q64"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2S      Pass
-3D      Pass    3NT     Pass
+1N     Pass    2S      Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4891,9 +4891,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:54.Q643.A63.9875 QJ83.J985.K82.A4 AK.T2.QJ54.KQJ32 T9762.AK7.T97.T6"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4904,7 +4904,7 @@ Pass    Pass
 [Deal "N:J3.AQ865.JT65.72 T975.KT94.7.K854 Q62.J32.AKQ3.QJ9 AK84.7.9842.AT63"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4916,7 +4916,7 @@ Pass    Pass
 [Deal "N:JT97.A7543.K6.75 K85.KJ.J7542.642 432.QT62.AT9.AKQ AQ6.98.Q83.JT983"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -4926,9 +4926,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:JT9.J64.85.KQ753 AQ75.Q92.Q7.A864 632.AK8.AKJ42.92 K84.T753.T963.JT"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4939,7 +4939,7 @@ Pass    Pass
 [Deal "N:KJT9865.2.AJ3.T3 7.KJ65.T862.K984 Q4.A943.KQ4.AQ62 A32.QT87.975.J75"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4951,7 +4951,7 @@ Pass    Pass
 [Deal "N:653.952.AKQ532.J T9.Q6.T9.Q987642 AQJ7.73.J874.AKT K842.AKJT84.6.53"]
 [Contract "5D"]
 [Auction "S"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 4D      Pass    5D      Pass
 Pass    Pass    
 
@@ -4961,11 +4961,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KT432.76.A8.Q653 A976.AQ3.JT75.92 QJ.KJ9.Q942.AKJ8 85.T8542.K63.T74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2H      Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4976,7 +4976,7 @@ Pass    Pass
 [Deal "N:AKJ85.9432.4.654 4.A875.J832.KJ82 Q97.K6.AQ975.AQT T632.QJT.KT6.973"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -4987,9 +4987,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T983.T62.J73.Q32 A65.Q974.62.9854 K4.A3.KQT95.KJT6 QJ72.KJ85.A84.A7"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5000,7 +5000,7 @@ Pass    Pass
 [Deal "N:98765.T9.KT8.T86 J.K732.AJ9764.J2 KQ32.AQ84.Q3.K94 AT4.J65.52.AQ753"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    3D
 Pass    Pass    Pass    
 
@@ -5010,9 +5010,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AT5.QJ4.A5.AQJ92 KJ763.K75.96.T74 Q984.A3.KQJ8.K86 2.T9862.T7432.53"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
-1NT     Pass    6NT     Pass
+1N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5021,10 +5021,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:T6.KJ95.87.KJT87 Q872.A7.QJT92.43 KJ94.T63.AK63.A6 A53.Q842.54.Q952"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5035,7 +5035,7 @@ Pass    Pass
 [Deal "N:.Q9862.T984.Q863 AKT9.J753.Q53.97 J872.KT4.AKJ.AJ5 Q6543.A.762.KT42"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -5047,7 +5047,7 @@ Pass    Pass
 [Deal "N:T8.9.984.AJ98653 7543.Q64.AJ63.42 AJ6.T32.KQT7.KQ7 KQ92.AKJ875.52.T"]
 [Contract "3S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3H      Pass    3S
 Pass    Pass    Pass    
 
@@ -5057,9 +5057,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:96.QJ9.J875.J954 Q72.76532.AT4.T6 KT83.AT84.Q6.AQ7 AJ54.K.K932.K832"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5068,9 +5068,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q2.Q52.AQT6.QJ93 K864.K93.972.T62 A9.A876.KJ5.A754 JT753.JT4.843.K8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5081,7 +5081,7 @@ Pass    Pass
 [Deal "N:J.J92.AJ4.QJ7652 7432.AKQ84.K9.T4 AQ86.75.Q85.AK83 KT95.T63.T7632.9"]
 [Contract "4C"]
 [Auction "S"]
-1NT     Pass    2NT     3H
+1N     Pass    2N     3H
 4C      Pass    Pass    Pass
 
 
@@ -5093,7 +5093,7 @@ Pass    Pass
 [Deal "N:75.QT65.9654.Q72 J3.3.AKQJ82.KT65 KT84.AK87.T3.AJ3 AQ962.J942.7.984"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    Pass    3D
+1N     Pass    Pass    3D
 Pass    Pass    Pass    
 
 
@@ -5104,7 +5104,7 @@ Pass    Pass    Pass
 [Deal "N:T7632.Q.A8.QJ983 A54.KJT4.T543.A4 KQ9.A9652.KQJ.T7 J8.873.9762.K652"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3C      Pass
 4S      Pass    Pass    Pass
 
@@ -5115,11 +5115,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:76.KQ98.A2.KQ654 KJT9.6543.754.T7 AQ53.AJ2.KQ96.J9 842.T7.JT83.A832"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5128,10 +5128,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KT53.K32.QJ32.74 J764.A97.87.AJ32 A82.Q65.A95.KQ85 Q9.JT84.KT64.T96"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5140,9 +5140,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T432.Q87.AT5.JT5 AQ865.T652.9.Q72 J97.AK.K764.A984 K.J943.QJ832.K63"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5153,7 +5153,7 @@ Pass    Pass
 [Deal "N:KQ9.T7652.K87.93 AJ874.QJ4.T3.A84 T6.A3.AJ54.KQJT5 532.K98.Q962.762"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -5163,9 +5163,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J65.T87.KJ72.J82 AQ82.A32.AQ.Q765 K3.KQ9.T9853.AKT T974.J654.64.943"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "S"]
-1NT     Pass    Pass    Db
+1N     Pass    Pass    Db
 Pass    Pass    Pass    
 
 
@@ -5176,7 +5176,7 @@ Pass    Pass    Pass
 [Deal "N:65.85.KT73.KT765 98.A963.Q92.Q984 AJ4.KQT4.J64.AJ2 KQT732.J72.A85.3"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -5186,10 +5186,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQT52.J9.KT8.J72 A.AT72.743.QT543 98.K65.AJ6.AK986 J7643.Q843.Q952."]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5200,7 +5200,7 @@ Pass    Pass
 [Deal "N:Q54.Q9873.K9.976 KJ97.T4.T432.T83 T32.K52.AQ6.KQJ2 A86.AJ6.J875.A54"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -5212,8 +5212,8 @@ Pass    Pass
 [Deal "N:97.AJ743.AJ5.AJ2 T.T2.T8742.KT875 AQ5.KQ96.Q96.Q96 KJ86432.85.K3.43"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -5223,11 +5223,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KJ82.T2.K963.Q75 93.QJ63.JT85.J84 AT5.K94.AQ.AT932 Q764.A875.742.K6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5236,10 +5236,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J62.KQ84.KQ8.982 Q9.T762.AJ62.AT3 AK54.AJ.T93.KQ76 T873.953.754.J54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5248,10 +5248,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J94.Q864.AJ652.A 2.AJT7.Q743.J986 AQT8.K52.KT.KT73 K7653.93.98.Q542"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5262,8 +5262,8 @@ Pass    Pass
 [Deal "N:J9842.A8.A9732.8 T6.K543.Q5.KQJ75 AK75.Q62.KJ6.AT6 Q3.JT97.T84.9432"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2NT     Pass    3H      Pass
+1N     Pass    2H      Pass
+2N     Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5275,7 +5275,7 @@ Pass    Pass
 [Deal "N:J94.QT9762.65.AK Q53.A3.987.86532 AK.J85.AJT3.QJ74 T8762.K4.KQ42.T9"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5287,8 +5287,8 @@ Pass    Pass
 [Deal "N:T432.A9.K9.AQT73 96.QT642.J432.85 AQ75.J753.A6.KJ2 KJ8.K8.QT875.964"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -5298,9 +5298,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KJ6.A62.953.KJ75 3.QT974.QJ87.T84 A98.K3.KT64.AQ93 QT7542.J85.A2.62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5311,7 +5311,7 @@ Pass    Pass
 [Deal "N:J83.Q8542.Q76.J7 A2.AT7.K954.AT62 KQT54.KJ.A83.Q85 976.963.JT2.K943"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -5323,7 +5323,7 @@ Pass    Pass
 [Deal "N:QJ3.952.Q42.T752 A7542.KQ83.J976. KT8.JT6.AK3.A963 96.A74.T85.KQJ84"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    3H      Pass    Pass
 Pass    
 
@@ -5335,8 +5335,8 @@ Pass
 [Deal "N:QJT82.K84.62.KQ2 73.QJT53.K87.JT9 K64.A96.AQ43.A76 A95.72.JT95.8543"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 4C      Pass    4S      Pass
 Pass    Pass    
 
@@ -5346,9 +5346,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:642.Q63.KT6.AQ87 KQT95.AJT5.952.9 AJ7.K72.AQ73.K43 83.984.J84.JT652"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5357,9 +5357,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:63.Q865.Q94.QT54 982.943.AJT2.K96 AK75.AJ.K53.J873 QJT4.KT72.876.A2"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5368,9 +5368,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:754.K85.T985.J73 K62.Q93.43.AKQ86 AQJ8.A7.AQ62.952 T93.JT642.KJ7.T4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5381,8 +5381,8 @@ Pass    Pass
 [Deal "N:Q96.AQJT3.95.T52 832.8764.KQ63.87 AKJ.K92.J4.KQ643 T754.5.AT872.AJ9"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    2N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -5392,11 +5392,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:73.8.KJ432.KQ752 QJ52.QJ97542..J4 AK6.A63.Q85.AT96 T984.KT.AT976.83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2S      Pass
-2NT     Pass    3C      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2S      Pass
+2N     Pass    3C      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5407,7 +5407,7 @@ Pass    Pass
 [Deal "N:QJ8.3.J95.976432 AK4.QT985.K832.A 7632.AJ7.AQ4.KJ8 T95.K642.T76.QT5"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    2NT     Db
+1N     Pass    2N     Db
 3C      Pass    Pass    Pass
 
 
@@ -5419,7 +5419,7 @@ Pass    Pass
 [Deal "N:AK74.J854.Q8.653 QJ65.A.AT53.9872 T983.K7.K42.AKQ4 2.QT9632.J976.JT"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5431,7 +5431,7 @@ Pass    Pass
 [Deal "N:876.QT9832.K97.2 KT32.6.J853.T543 AJ4.K74.AT62.K97 Q95.AJ5.Q4.AQJ86"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Db      2D      Pass
+1N     Db      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -5443,8 +5443,8 @@ Pass    Pass
 [Deal "N:K983.A72.KT2.T32 752.J65.J43.A654 QJ64.KQT4.A76.QJ AT.983.Q985.K987"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -5454,10 +5454,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:82.9873.J92.AK96 J43.QT4.Q64.JT75 Q97.A65.AK8.Q843 AKT65.KJ2.T753.2"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5466,9 +5466,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QT75.6432.976.T7 984.KT875.Q43.54 62.AQ9.AKJ82.QJ8 AKJ3.J.T5.AK9632"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "S"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -5479,7 +5479,7 @@ Pass
 [Deal "N:T87432..985.KJ86 A9.KQ832.T4.Q752 KJ6.J974.AQ72.AT Q5.AT65.KJ63.943"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 2S      Pass    Pass    3H
 Pass    Pass    Pass    
 
@@ -5491,7 +5491,7 @@ Pass    Pass    Pass
 [Deal "N:J.KQT54.JT642.KQ 9852.A763.KQ5.82 AQ7.J98.A83.A974 KT643.2.97.JT653"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3D      Pass
 4H      Pass    Pass    Pass
 
@@ -5504,7 +5504,7 @@ Pass    Pass    Pass
 [Deal "N:K7542.T96.J632.7 T86.AKJ42.K54.65 AQJ3.Q73.T8.KQJ2 9.85.AQ97.AT9843"]
 [Contract "3S"]
 [Auction "S"]
-1NT     2C      2H      Db
+1N     2C      2H      Db
 2S      Pass    Pass    Db
 Pass    3C      Pass    Pass
 3S      Pass    Pass    Pass
@@ -5516,11 +5516,11 @@ Pass    3C      Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q842.K2.KJ642.52 T7.AQ963.Q3.7643 AK6.754.A5.AQT98 J953.JT8.T987.KJ"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5529,10 +5529,10 @@ Pass    3C      Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q986.K83.32.AQ84 KJ3.T764.KJ6.763 T2.AQ.AQ974.KT95 A754.J952.T85.J2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5541,9 +5541,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:93.JT4.762.KQ984 KQJT8.876.QJ9.T3 72.AK532.K84.AJ5 A654.Q9.AT53.762"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5554,7 +5554,7 @@ Pass    Pass
 [Deal "N:Q9754.97532.7.43 J3.Q84.K85.QJ752 A8.KJ6.T632.AK86 KT62.AT.AQJ94.T9"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -5566,7 +5566,7 @@ Pass    Pass
 [Deal "N:742.K9862.J865.5 965.T3.T432.8764 AJT8.75.AKQ7.K32 KQ3.AQJ4.9.AQJT9"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Db      2D      Pass
+1N     Db      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -5578,7 +5578,7 @@ Pass    Pass
 [Deal "N:KJ7654.852.Q9.53 Q9.T76.AJT72.876 AT32.K94.K6.AQT2 8.AQJ3.8543.KJ94"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5588,9 +5588,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJ32.J97.9853.T8 Q864.AK84.QJ.K32 T5.QT.AKT7.AQ954 K97.6532.642.J76"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5601,7 +5601,7 @@ Pass    Pass
 [Deal "N:QJ72.J96.Q2.QT83 AT94.KT5.J43.752 K853.A2.T65.AKJ9 6.Q8743.AK987.64"]
 [Contract "2H"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -5612,7 +5612,7 @@ Pass
 [Deal "N:J975.Q2.AKJ9.842 42.7543.T863.J93 AT83.AJ8.Q75.AT7 KQ6.KT96.42.KQ65"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5622,9 +5622,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:842.KT87.J632.J6 93.Q532.74.KT983 AQT65.AJ6.A85.52 KJ7.94.KQT9.AQ74"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5635,7 +5635,7 @@ Pass    Pass
 [Deal "N:KQT96.A.J92.Q932 J8743.JT3.T7.J65 A52.Q2.AQ83.K874 .K987654.K654.AT"]
 [Contract "4S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3C      Pass
 4S      Pass    Pass    Pass
 
@@ -5648,7 +5648,7 @@ Pass    Pass
 [Deal "N:JT863.AJ92.76.K9 975.Q83.T43.QT64 AK42.T54.AKQ2.85 Q.K76.J985.AJ732"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5660,7 +5660,7 @@ Pass    Pass
 [Deal "N:J5.Q862.T64.T542 A42.JT954.Q953.9 973.AK7.K2.AK863 KQT86.3.AJ87.QJ7"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5669,11 +5669,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AT94.KJ954.J7.82 82.A32.KT83.JT95 KJ3.76.A654.AK76 Q765.QT8.Q92.Q43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5682,9 +5682,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J943.3.JT984.K76 75.QT87.KQ65.AJ2 AQ62.A95.A73.Q95 KT8.KJ642.2.T843"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5695,7 +5695,7 @@ Pass
 [Deal "N:QT984.9532.AQ.96 J763.T8.8.AJ8752 A52.AQJ4.J962.K3 K.K76.KT7543.QT4"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -5707,7 +5707,7 @@ Pass    Pass
 [Deal "N:K98765.974.KJT.3 QJT2.A.962.AJ654 A43.Q8.AQ3.KQ972 .KJT6532.8754.T8"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -5718,9 +5718,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J4.94.T8542.KJT4 Q9873.7652.K.AQ2 62.AKJ3.AQJ93.85 AKT5.QT8.76.9763"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5729,9 +5729,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:8543.T82.KJ.AT97 Q76.Q953.872.J82 KJT2.AJ6.AQ64.Q3 A9.K74.T953.K654"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5740,9 +5740,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:542.K875.8765.86 Q8.QJ9.AKQT.9753 AKJ.A632.J42.QJT T9763.T4.93.AK42"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5753,9 +5753,9 @@ Pass    Pass
 [Deal "N:A.KJ42.K74.AK984 JT9763.6.T952.76 KQ8.AT95.QJ.QJ32 542.Q873.A863.T5"]
 [Contract "5H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    5H      Pass
 Pass    Pass    
 
@@ -5765,9 +5765,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:53.J63.532.QT974 AT87.9874.Q94.65 KQ64.K52.J76.AKJ J92.AQT.AKT8.832"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5778,8 +5778,8 @@ Pass    Pass
 [Deal "N:AJ975.A6.QT8.AK5 2.QT73.AJ762.T76 KQ63.KJ9.K53.QJ3 T84.8542.94.9842"]
 [Contract "7S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    5NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -5789,9 +5789,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:7532.863.A6.8642 K864.42.JT53.KJT J9.AJ9.KQ872.A93 AQT.KQT75.94.Q75"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5800,11 +5800,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:63.A764.A7.JT652 AT72.J95.JT542.9 K8.KT8.Q98.AKQ74 QJ954.Q32.K63.83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5813,10 +5813,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQ53.A32.KJ7.K64 T7642.7.T9843.QT KJ.Q8654.AQ6.A52 98.KJT9.52.J9873"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -5825,9 +5825,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J973.Q83.975.AQ3 4.9742.T864.7542 AQ62.A65.KJ2.J98 KT85.KJT.AQ3.KT6"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "S"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -5836,9 +5836,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QJ53.JT.K863.J65 976.53.742.QT984 AK8.Q9862.QJT.A2 T42.AK74.A95.K73"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5849,7 +5849,7 @@ Pass
 [Deal "N:AKJ86.T982..KT52 74.J76.Q98764.J9 95.AQ43.K52.AQ86 QT32.K5.AJT3.743"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5859,9 +5859,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AK7.K2.AT87.J932 QT65.J9764.4.T64 J82.AT83.KQ3.AK5 943.Q5.J9652.Q87"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5870,10 +5870,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QT875.K4.Q.AQJT8 J96432.JT75.762. AK.Q93.KJ43.K953 .A862.AT985.7642"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5884,9 +5884,9 @@ Pass    Pass
 [Deal "N:.JT6.AK97642.Q62 KT752.A875.J5.T5 A863.K9.QT3.AKJ4 QJ94.Q432.8.9873"]
 [Contract "5D"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    3S      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -5897,7 +5897,7 @@ Pass    Pass
 [Deal "N:J732.T8.AK5.A987 QT5.J62.98642.K4 K964.AKQ.JT3.QJT A8.97543.Q7.6532"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5907,9 +5907,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KJ.A65.KT863.K84 754.T98732.Q2.62 AQT.KQ4.A954.J95 98632.J.J7.AQT73"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5918,9 +5918,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:652.KT52.Q987.74 KQ87.943.AT2.Q65 AJT.A876.63.AK32 943.QJ.KJ54.JT98"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5931,7 +5931,7 @@ Pass    Pass
 [Deal "N:875432.73.KQ74.3 AJ.K5.JT82.AJ965 K96.AQ986.A9.Q87 QT.JT42.653.KT42"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5941,9 +5941,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K98.AJ.AJ84.J983 QT4.Q862.753.T52 J7652.K7.KQT.AQ6 A3.T9543.962.K74"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5952,11 +5952,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J6.Q2.KT964.QJ64 AK7.K8763.Q.9732 43.AJ9.AJ83.AKT5 QT9852.T54.752.8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5967,7 +5967,7 @@ Pass    Pass
 [Deal "N:QT63.864.K4.KJ72 K94.K75.QT63.Q53 J872.AJ.AJ98.A84 A5.QT932.752.T96"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 

--- a/GIB/GIB_1N5422.pbn
+++ b/GIB/GIB_1N5422.pbn
@@ -6,7 +6,7 @@
 [Deal "N:JT8653.3.A3.T642 KQ742.72.K872.K3 A9.K8.QT64.AQJ95 .AQJT9654.J95.87"]
 [Contract "2SX"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Db
 Pass    Pass    Pass    
 
@@ -16,9 +16,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:86.K6.KT.AJ98762 K542.QJT52.QJ6.5 AJ.A984.A9875.Q3 QT973.73.432.KT4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -29,7 +29,7 @@ Pass    Pass
 [Deal "N:6.AJ764.764.6432 JT942.T852.K2.QJ A7.K3.QT853.AKT5 KQ853.Q9.AJ9.987"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -41,7 +41,7 @@ Pass    Pass
 [Deal "N:JT7532.9543.5.QT AK98.JT6.KQ32.K4 64.KQ.AJ84.AJ986 Q.A872.T976.7532"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -51,9 +51,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:5.653.98432.A965 KT9632.T82.J.Q84 A4.Q4.AQT76.KT72 QJ87.AKJ97.K5.J3"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -62,11 +62,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J.JT54.A87643.AK QT764.A82.9.8763 A8.K7.KQJ2.QT954 K9532.Q963.T5.J2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -75,10 +75,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K84.AQJ3.T965.T8 AQ.K9852.742.Q93 J6.T6.AKQJ8.KJ64 T97532.74.3.A752"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -89,7 +89,7 @@ Pass    Pass
 [Deal "N:K962.Q3.98.T7543 QJT8543.542.Q.A2 A7.A976.AKT76.98 .KJT8.J5432.KQJ6"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      2S      Pass
 3D      3S      Pass    4S
 Pass    Pass    Pass    
@@ -102,7 +102,7 @@ Pass    Pass    Pass
 [Deal "N:AK6542.T4.KQ4.T7 83.72.J98652.542 J7.Q863.AT.AKJ98 QT9.AKJ95.73.Q63"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -114,7 +114,7 @@ Pass    Pass
 [Deal "N:862.9872.53.K532 Q43.AKQT43.4.J98 KJ.J6.KQ972.AQ64 AT975.5.AJT86.T7"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2S      Pass    4H
+1N     2S      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -123,11 +123,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQT75.K7653.A4.3 86.Q942.QJ73.AT8 AJ.AJ.K952.K7642 9432.T8.T86.QJ95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -136,9 +136,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T753.7.QJT.K8652 A98.AJT64.A85.Q3 Q6.KQ95.K2.AJ974 KJ42.832.97643.T"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -147,9 +147,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:853.9875.Q75.A63 T976.62.JT3.Q987 AJ.T3.AK96.KT542 KQ42.AKQJ4.842.J"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "S"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -160,7 +160,7 @@ Pass
 [Deal "N:AT98643.8432.62. .AKQ6.Q987.KJT86 J2.JT.AKT54.AQ53 KQ75.975.J3.9742"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2H      2S
+1N     Pass    2H      2S
 Pass    3C      3S      Pass
 Pass    Pass    
 
@@ -172,7 +172,7 @@ Pass    Pass
 [Deal "N:AKJ8643.5.T8.QJ8 T75.K73.J32.T763 Q9.AJT6.KQ765.A9 2.Q9842.A94.K542"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    4H      Pass
 4S      Pass    Pass    Pass
 
@@ -185,7 +185,7 @@ Pass    Pass
 [Deal "N:63.Q9632.6543.T8 QJ974.K87.Q7.Q63 T5.A4.AKJ92.KJ95 AK82.JT5.T8.A742"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -195,11 +195,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QJ8.AJ72.J2.6432 K7653.9853.93.85 42.Q4.AKQ84.AJT9 AT9.KT6.T765.KQ7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -210,7 +210,7 @@ Pass    Pass
 [Deal "N:T952.9.9872.Q542 A8764.AKJ872..J3 KQ.Q643.AKQT3.T9 J3.T5.J654.AK876"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Db      2H      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -223,7 +223,7 @@ Pass
 [Deal "N:96.T84.43.Q98643 KQT83.A96.AK6.52 A4.Q2.JT752.AKJ7 J752.KJ753.Q98.T"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2NT     3S
+1N     Pass    2N     3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -235,7 +235,7 @@ Pass
 [Deal "N:QT985.AQ4.JT832. 3.97632.Q96.AQ97 A6.K8.AK754.JT53 KJ742.JT5..K8642"]
 [Contract "3C"]
 [Auction "S"]
-1NT     2S      Pass    2NT
+1N     2S      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -245,9 +245,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJ54.852.J86.T96 7632.9763.KQ.AK4 A9.AKJ4.AT975.87 QT8.QT.432.QJ532"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -258,7 +258,7 @@ Pass
 [Deal "N:Q7543.T85.4.K765 AJ98.J62.QJ76.82 T2.A7.AK532.AJT9 K6.KQ943.T98.Q43"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -270,7 +270,7 @@ Pass
 [Deal "N:KJ87632.T82.J54. A.KJ76.K7.KQJ753 Q9.A3.AQT63.AT92 T54.Q954.982.864"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -283,7 +283,7 @@ Pass
 [Deal "N:T932.J7543.T975. KQ7654.Q9.Q2.AJ3 A8.KT.AK64.Q8742 J.A862.J83.KT965"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2D      2S
+1N     Pass    2D      2S
 Pass    3H      Pass    4S
 Pass    Pass    Pass    
 
@@ -293,10 +293,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q652.KJ9.QT954.A KJ87.Q76.K87.542 A4.A5.A632.KJ983 T93.T8432.J.QT76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -307,7 +307,7 @@ Pass    Pass
 [Deal "N:K8753.A82.73.632 AQ64.Q9654.65.AT T2.KJ.AKQJ8.J975 J9.T73.T942.KQ84"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -317,10 +317,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QT874.QJ4.KJ.A85 K9.96532.7653.T2 32.A7.AQT9.KQ764 AJ65.KT8.842.J93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -329,9 +329,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q976.Q9.QT863.A5 T83.T63.974.8643 42.AJ84.AKJ52.Q9 AKJ5.K752..KJT72"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "S"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -342,7 +342,7 @@ Pass
 [Deal "N:QJ432.T65.A73.32 986.J874.KT54.Q4 T7.AKQ2.Q6.KJT85 AK5.93.J982.A976"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -354,7 +354,7 @@ Pass
 [Deal "N:J83.T3.9643.J753 T7654.K.JT87.AKQ A9.Q985.AKQ52.42 KQ2.AJ7642..T986"]
 [Contract "3C"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Db      2H      Pass    2S
 Pass    3C      Pass    Pass
 Pass    
@@ -365,9 +365,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K96.63.Q8742.953 AJ754.K87.J.8642 T8.QT42.AK953.AK Q32.AJ95.T6.QJT7"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -378,7 +378,7 @@ Pass
 [Deal "N:JT8753.K.T83.Q97 AK.AQJ97.9.T6543 Q2.T5.KQ72.AKJ82 964.86432.AJ654."]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 Pass    Pass    2S      Pass
 Pass    4H      Pass    Pass
 Pass    
@@ -389,9 +389,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:93.K962.K92.T864 K654.AQJ.Q3.J932 AT.T873.AJ874.AK QJ872.54.T65.Q75"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -400,9 +400,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:653.832.A9852.K7 A972.KT7.JT64.54 QJ.AQJ6.Q7.AT983 KT84.954.K3.QJ62"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -413,7 +413,7 @@ Pass
 [Deal "N:AQJT8754.K63.94. 62.874.532.AQJ63 K3.J2.AKJ76.KT98 9.AQT95.QT8.7542"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    4C      Db
 4S      Pass    Pass    Pass
 
@@ -426,7 +426,7 @@ Pass
 [Deal "N:AJ86543.K72.86.A T.AT83.K7.T98752 Q9.Q5.AQT52.KQ63 K72.J964.J943.J4"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    4C      Pass
 4S      Pass    Pass    Pass
 
@@ -439,7 +439,7 @@ Pass
 [Deal "N:Q62.K2.K743.8542 A8543.AJ85.T9.Q7 K9.QT94.AJ865.AJ JT7.763.Q2.KT963"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -449,10 +449,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QJ92.Q982.JT2.A6 7543.JT5.976.JT8 K6.K4.KQ43.KQ952 AT8.A763.A85.743"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -463,7 +463,7 @@ Pass    Pass
 [Deal "N:Q7642.K94.92.976 KJ.JT3.AQT64.Q52 AT.A852.KJ.KJT43 9853.Q76.8753.A8"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -475,7 +475,7 @@ Pass    Pass
 [Deal "N:T654.QT9.T83.AJ3 KQJ9.KJ852.K.KQ5 A2.A743.AQJ75.96 873.6.9642.T8742"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    Pass    Db
+1N     Pass    Pass    Db
 Pass    2C      2S      3C
 Pass    Pass    Pass    
 
@@ -487,7 +487,7 @@ Pass    Pass    Pass
 [Deal "N:A7543.875.832.K8 T82.A64.AT764.76 Q9.KJT9.Q5.AQJ43 KJ6.Q32.KJ9.T952"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -499,7 +499,7 @@ Pass    Pass    Pass
 [Deal "N:J54.Q986.4.AQT63 976.K52.Q76.8742 K2.AJT4.AKJT2.95 AQT83.73.9853.KJ"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -511,7 +511,7 @@ Pass    Pass
 [Deal "N:QT.8762.QJ873.Q6 K754.J3.T654.K93 83.AT.AK92.AJ875 AJ962.KQ954..T42"]
 [Contract "3D"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    3D      Pass
 Pass    Pass    
 
@@ -521,10 +521,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ982.Q65.Q2.AJ2 T6543.873.853.65 Q7.AK94.KJ.QT873 A.JT2.AT9764.K94"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2C      2H      Pass
-2S      Pass    3NT     Pass
+1N     2C      2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -535,7 +535,7 @@ Pass    Pass
 [Deal "N:J72.9864.765.T53 AKT854.Q53.J4.KJ 96.AKJ2.AKT82.98 Q3.T7.Q93.AQ7642"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      Pass    2S
+1N     2C      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -544,9 +544,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A843.T86.9632.KT QJ5.J54.AKT87.73 T6.AKQ7.J5.AQ542 K972.932.Q4.J986"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -557,7 +557,7 @@ Pass    Pass    Pass
 [Deal "N:Q2.97.KQJ72.9873 AKT9654.8642..A6 J7.AKQJ.AT964.JT 83.T53.853.KQ542"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -568,7 +568,7 @@ Pass    Pass    Pass
 [Deal "N:K84.J9875.32.KT2 A652.K3.KJ94.764 Q7.QT.AQT85.AJ53 JT93.A642.76.Q98"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -580,7 +580,7 @@ Pass    Pass    Pass
 [Deal "N:JT954.T7643.54.5 Q862.A82.AK32.A9 AK.KJ95.J6.QJ832 73.Q.QT987.KT764"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Db
 Pass    3D      Pass    Pass
 3H      Pass    Pass    Pass
@@ -594,7 +594,7 @@ Pass    3D      Pass    Pass
 [Deal "N:Q.QT985.KQ92.KQ8 K53.AJ763.763.52 AT.K2.AT84.AJ964 J987642.4.J5.T73"]
 [Contract "5D"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3D      Pass
 3S      Pass    4C      Pass
 4H      Pass    5D      Pass
@@ -606,9 +606,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K75.T854.J96.K52 J42.KQ.QT754.T87 Q6.AJ62.A8.AJ964 AT983.973.K32.Q3"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -619,7 +619,7 @@ Pass    Pass
 [Deal "N:T97.J964.J9.T974 63.T5.AK7543.A83 AJ.K832.QT.KQJ52 KQ8542.AQ7.862.6"]
 [Contract "4S"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -632,7 +632,7 @@ Pass
 [Deal "N:K86.T8653.KJ2.98 AQ974.92.974.764 J5.AQ.T8653.AKJT T32.KJ74.AQ.Q532"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -642,9 +642,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:6.9863.876.QJ976 KQ987.T4.K95.AT2 AT.QJ52.AJ432.K3 J5432.AK7.QT.854"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -655,7 +655,7 @@ Pass
 [Deal "N:Q98.752.J743.A85 6532.AKT643.KT2. KJ.Q8.AQ65.K9742 AT74.J9.98.QJT63"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      Pass    2H
 Pass    Pass    Pass    
 
@@ -665,10 +665,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQ854.964.J84.Q4 K963.2.62.JT9752 T2.KQ53.AQT75.A6 J7.AJT87.K93.K83"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -679,7 +679,7 @@ Pass    Pass
 [Deal "N:KT875.AJ95.86.53 6.QT742.753.Q964 A9.K863.AKJ92.T8 QJ432..QT4.AKJ72"]
 [Contract "3C"]
 [Auction "S"]
-1NT     2S      Pass    2NT
+1N     2S      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -691,7 +691,7 @@ Pass
 [Deal "N:KQT932.Q64.4.754 765.A2.AKT987.T9 A4.J3.QJ65.AQJ86 J8.KT9875.32.K32"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -701,9 +701,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q8.964.K976.AQ86 T73.QJ8753.JT.92 A2.K2.AQ843.K543 KJ9654.AT.52.JT7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -714,7 +714,7 @@ Pass    Pass
 [Deal "N:J96543.5.Q8.A932 AQT.KJ732.A762.6 K8.A9.K943.KQT87 72.QT864.JT5.J54"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -726,7 +726,7 @@ Pass    Pass
 [Deal "N:J642.AQJ943.5.98 A53.7.KQJT97.652 K8.T652.A2.AKJ74 QT97.K8.8643.QT3"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -736,11 +736,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A.A7643.8632.KQ5 KQ3.J85.KJT7.J62 J5.KQ.AQ94.AT987 T987642.T92.5.43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -749,9 +749,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J73.JT5.J52.J652 62.742.K86.AK974 AK.Q983.AT943.QT QT9854.AK6.Q7.83"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -762,7 +762,7 @@ Pass    Pass
 [Deal "N:K962.K832.Q82.J5 A85.T9.954.Q9874 J7.QJ64.KJT73.AK QT43.A75.A6.T632"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -774,10 +774,10 @@ Pass    Pass
 [Deal "N:Q94.K83.AKQJT7.T J86.T74.864.K954 A3.AQJ5.53.A8762 KT752.962.92.QJ3"]
 [Contract "6D"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    4C      Pass
-4D      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4D      Pass    4N     Pass
+5C      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -787,10 +787,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ53.Q94.Q7.KT86 T8742.JT.T2.Q754 A9.K732.A9863.AJ J6.A865.KJ54.932"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -799,11 +799,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:9874.QT543.AK8.7 KT2.J7.762.KT543 QJ.AK.QJ943.QJ86 A653.9862.T5.A92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -812,10 +812,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:JT4.AKJT9.983.Q9 Q95.8432.T64.AJ7 K2.Q5.AKQJ5.8652 A8763.76.72.KT43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -824,10 +824,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QT2.KT64.T93.AJ7 K9854.A953.Q8.Q8 A7.QJ.AJ654.KT96 J63.872.K72.5432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -836,11 +836,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJ954.AK87.32.96 QT876.JT5.K94.T2 K2.64.AQ75.KQJ74 3.Q932.JT86.A853"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -851,7 +851,7 @@ Pass    Pass
 [Deal "N:QT9864.AQ7.742.9 AKJ2.K953.5.KT64 73.T2.AKQT9.AQ72 5.J864.J863.J853"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -863,7 +863,7 @@ Pass    Pass
 [Deal "N:AT.J8642.86.JT87 Q72.9753.AJ942.5 96.AT.KQT75.AK32 KJ8543.KQ.3.Q964"]
 [Contract "2H"]
 [Auction "S"]
-1NT     2C      2D      Db
+1N     2C      2D      Db
 Pass    Pass    2H      Pass
 Pass    Pass    
 
@@ -873,9 +873,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AKJT.KQJT6.A3.A5 876542.43.K9.T72 Q9.A7.QJ52.KQJ94 3.9852.T8764.863"]
-[Contract "7NT"]
+[Contract "7N"]
 [Auction "S"]
-1NT     Pass    7NT     Pass
+1N     Pass    7N     Pass
 Pass    Pass    
 
 
@@ -886,7 +886,7 @@ Pass    Pass
 [Deal "N:J97.QJ9764.K3.74 8432.K2.9864.KQT AT.53.AQJ72.A865 KQ65.AT8.T5.J932"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -898,7 +898,7 @@ Pass    Pass
 [Deal "N:AKQJ9.A.T63.A762 T8532.972.Q982.T 76.Q3.AKJ75.KQJ8 4.KJT8654.4.9543"]
 [Contract "6C"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3C      Pass
 3D      Pass    4H      Pass
 5C      Pass    6C      Pass
@@ -912,7 +912,7 @@ Pass    Pass
 [Deal "N:J9862.6.K842.T63 KQ3.Q72.QJT9.954 54.AKT5.65.AKJ72 AT7.J9843.A73.Q8"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -922,9 +922,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q97.KQ63.J87.986 JT8542.AT.94.J72 K3.87.K632.AKQ53 A6.J9542.AQT5.T4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -935,7 +935,7 @@ Pass    Pass
 [Deal "N:T94.J5.AT73.QT54 AK53.QT642.K42.9 QJ.K873.Q9.AKJ87 8762.A9.J865.632"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -945,9 +945,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K74.T5.85432.J96 Q952.AJ.QJT76.K7 63.KQ92.AK.A8532 AJT8.87643.9.QT4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -956,9 +956,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QT3.K7.QJ3.AJT43 J98754.J952.K8.7 A6.A6.AT54.K9862 K2.QT843.9762.Q5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -969,7 +969,7 @@ Pass    Pass
 [Deal "N:Q9654.Q9.K53.763 AJT8.A842.QJ4.J9 K7.T7.AT62.AKQT5 32.KJ653.987.842"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -981,7 +981,7 @@ Pass    Pass
 [Deal "N:Q983.J9.8.JT8542 KJT52.63.J542.K6 A6.T874.AKQ96.Q3 74.AKQ52.T73.A97"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -991,9 +991,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K854.J62.9863.J3 973.A54.KQ4.Q865 AJ.93.A752.AK942 QT62.KQT87.JT.T7"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1002,10 +1002,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AK764.K6.8753.98 J52.JT954.Q4.A63 Q9.A8.AK92.QJT54 T83.Q732.JT6.K72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1014,9 +1014,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q875.KJ6.JT52.98 T93.QT73.K643.T7 AJ.A954.Q8.KQ432 K642.82.A97.AJ65"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1027,7 +1027,7 @@ Pass    Pass
 [Deal "N:J85.T7.85.QJT654 AK932.953.K942.3 Q4.Q4.AQJT6.A972 T76.AKJ862.73.K8"]
 [Contract "3C"]
 [Auction "S"]
-1NT     2C      2NT     Pass
+1N     2C      2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1039,7 +1039,7 @@ Pass    Pass
 [Deal "N:K9863.95.AQ96.T9 J.AKQ2.7.J876542 A4.T763.KJT32.AK QT752.J84.854.Q3"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      3C
+1N     Pass    2H      3C
 Pass    Pass    3D      3H
 Pass    4C      4S      Pass
 Pass    Pass    
@@ -1050,11 +1050,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AQT5.AQT98.K953. 982.K53.Q82.T752 74.64.AJ74.AKQJ6 KJ63.J72.T6.9843"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1065,7 +1065,7 @@ Pass    Pass
 [Deal "N:43.QJT85.T8.AQ32 AKT9875.3.K73.54 QJ.AK97.AJ964.87 62.642.Q52.KJT96"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      3S
+1N     Pass    2D      3S
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -1077,7 +1077,7 @@ Pass    Pass
 [Deal "N:QJ7.J7432.65.752 T32.K9.T.AKQT864 96.AQ65.AKQ42.J3 AK854.T8.J9873.9"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1088,7 +1088,7 @@ Pass
 [Deal "N:J984.762.Q85.JT8 A3.Q95.AJ432.742 Q7.J3.K976.AKQ96 KT652.AKT84.T.53"]
 [Contract "3H"]
 [Auction "S"]
-1NT     2D      Pass    3H
+1N     2D      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -1099,7 +1099,7 @@ Pass    Pass    Pass
 [Deal "N:85.K982.63.QT632 QJ63.QJT.KQJ4.84 K7.A754.95.AKJ97 AT942.63.AT872.5"]
 [Contract "4S"]
 [Auction "S"]
-1NT     2S      2NT     4S
+1N     2S      2N     4S
 Pass    Pass    Pass    
 
 
@@ -1108,12 +1108,12 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AT93.J6.QJ943.T8 542.A3.A72.Q9432 Q6.QT74.K8.AKJ75 KJ87.K9852.T65.6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1122,10 +1122,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AK95.T85.K98.T83 QJ3.J3.JT7642.54 T4.K972.A5.AKJ62 8762.AQ64.Q3.Q97"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1134,9 +1134,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q74.T93.T4.T9873 AKJT6.Q75.87.652 95.A862.AKJ53.K4 832.KJ4.Q962.AQJ"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1145,9 +1145,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K62.863.KQJ75.T8 AQ875.T5.963.J72 J3.AKJ4.84.AQ654 T94.Q972.AT2.K93"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1156,11 +1156,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K7642.A.82.QJ874 AT83.KJ5.KJ976.T QJ.86.AQT43.AK63 95.QT97432.5.952"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1171,7 +1171,7 @@ Pass    Pass
 [Deal "N:J42.AQJ8765.8.J6 T93.T93.JT6.Q743 K5.K2.AQ972.A852 AQ876.4.K543.KT9"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -1183,7 +1183,7 @@ Pass    Pass
 [Deal "N:Q9732.2.642.9853 T.AKJ953.K93.JT6 AK.QT76.AQT85.74 J8654.84.J7.AKQ2"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -1193,9 +1193,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QJ5.Q654.542.T92 KT986.KT8.J87.A6 32.A7.AKQT9.Q543 A74.J932.63.KJ87"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1204,10 +1204,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AK642.43.K98.JT5 9.KQT972.743.Q98 T5.A6.AQJ2.A6432 QJ873.J85.T65.K7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1216,10 +1216,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K87.KQ53.J4.KJ83 QT.A872.KT83.Q64 A2.J4.AQ95.AT752 J96543.T96.762.9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1228,9 +1228,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QT84.QT85.Q97.Q7 J962.92.AKJ3.A65 AK.AKJ7.T8542.J4 753.643.6.KT9832"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1241,7 +1241,7 @@ Pass    Pass
 [Deal "N:QT7652.J63.83.J5 AKJ4.A54.QT6.Q74 83.KQT2.AK.AT963 9.987.J97542.K82"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1251,9 +1251,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J654.K8.J53.Q832 AQT97.QJT.K74.96 K2.A942.AQ962.K4 83.7653.T8.AJT75"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1264,9 +1264,9 @@ Pass    Pass
 [Deal "N:AKT973.AKQ64.K3. 652.875.954.QJ87 QJ.J9.AJT7.AKT32 84.T32.Q862.9654"]
 [Contract "7S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3H      Pass
-3NT     Pass    7S      Pass
+3N     Pass    7S      Pass
 Pass    Pass    
 
 
@@ -1275,10 +1275,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT87.K54.J8.AKQ6 J9654.97.A63.T92 KQ.AQT6.K9542.J5 32.J832.QT7.8743"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    6NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -1287,9 +1287,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T76.T53.A863.KJ3 K32.AK972.54.T86 AJ.64.KJT72.AQ94 Q9854.QJ8.Q9.752"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1300,7 +1300,7 @@ Pass    Pass
 [Deal "N:AT72.74.64.QJ976 K9.Q82.AT8532.T5 Q8.AJ65.J9.AK432 J6543.KT93.KQ7.8"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Db      Pass    Pass    2D
 Pass    Pass    2S      Pass
 Pass    3D      Pass    Pass
@@ -1314,7 +1314,7 @@ Pass
 [Deal "N:Q.8764.82.KQJ965 8532.KT.Q74.T872 K4.Q953.AKT93.A3 AJT976.AJ2.J65.4"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2C      Db      Pass
+1N     2C      Db      Pass
 2H      2S      4H      Pass
 Pass    Pass    
 
@@ -1326,7 +1326,7 @@ Pass    Pass
 [Deal "N:A652.J764.K92.JT 83.AQT.T4.Q98532 97.K852.AQ753.AK KQJT4.93.J86.764"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -1336,11 +1336,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ98.AT4.J865.98 765.73.T74.AT762 43.J652.AKQ32.KQ AQT2.KQ98.9.J543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1351,7 +1351,7 @@ Pass    Pass
 [Deal "N:A2.K7.A9764.QJT2 Q874.T6432.8.954 K9.95.KQJT5.AK86 JT653.AQJ8.32.73"]
 [Contract "5D"]
 [Auction "S"]
-1NT     Pass    2S      Pass
+1N     Pass    2S      Pass
 3D      Pass    5D      Pass
 Pass    Pass    
 
@@ -1363,7 +1363,7 @@ Pass    Pass
 [Deal "N:J642.T92.JT943.6 AKQT8.83.Q.JT754 53.K654.A7.AKQ32 97.AQJ7.K8652.98"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    Pass    2S
+1N     Pass    Pass    2S
 Pass    3D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -1376,7 +1376,7 @@ Pass
 [Deal "N:KQJ95.42.T84.T32 T8762.T653.J7.65 A3.KJ.Q9532.AQ84 4.AQ987.AK6.KJ97"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      3H      Pass    Pass
 Pass    
 
@@ -1386,11 +1386,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J94.K6.QJ632.Q94 T8532.92.AK94.83 K7.AQ85.75.AKT76 AQ6.JT743.T8.J52"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1399,9 +1399,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J753.AQ87.Q54.98 64.964.JT73.T742 92.KT.AK962.AJ63 AKQT8.J532.8.KQ5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -1412,7 +1412,7 @@ Pass    Pass
 [Deal "N:T.J8632.A5.J8743 AKQ543.Q.9842.Q6 96.AK97.KJT76.AT J872.T54.Q3.K952"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      2S
+1N     Pass    2D      2S
 Pass    Pass    3C      Pass
 4H      Pass    Pass    Pass
 
@@ -1425,7 +1425,7 @@ Pass    Pass    3C      Pass
 [Deal "N:AQJ64.983.65.Q54 5.KQT6.AQ973.K73 K8.A7.KJT8.AJ862 T9732.J542.42.T9"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      2S
+1N     Pass    2H      2S
 Pass    3H      4S      Pass
 Pass    Pass    
 
@@ -1437,7 +1437,7 @@ Pass    Pass
 [Deal "N:4.A972.K86.QT974 962.Q4.QT74.J632 KT.K653.AJ952.A5 AQJ8753.JT8.3.K8"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2C      Db      Pass
+1N     2C      Db      Pass
 2H      2S      4H      Pass
 Pass    Pass    
 
@@ -1449,7 +1449,7 @@ Pass    Pass
 [Deal "N:A42.J96.543.K752 QJT963.Q.J2.AQT9 K8.A542.AKQ97.63 75.KT873.T86.J84"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2S
+1N     Pass    Pass    2S
 Pass    Pass    Pass    
 
 
@@ -1458,10 +1458,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQ3.AKQ2.T3.8732 J94.864.AK52.QT4 A8.T5.QJ98.AKJ96 T7652.J973.764.5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1470,9 +1470,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:JT7.985.T752.T76 AQ4.KJT73.4.Q983 82.Q6.AKQJ3.KJ54 K9653.A42.986.A2"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1483,7 +1483,7 @@ Pass    Pass
 [Deal "N:86432.QT7.K75.92 QJT.5.Q98.KQJ863 A7.AK42.T6432.A4 K95.J9863.AJ.T75"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1495,7 +1495,7 @@ Pass    Pass
 [Deal "N:KJT84.63.T654.97 .JT52.Q9.KQT8543 72.KQ94.AJ872.AJ AQ9653.A87.K3.62"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1505,9 +1505,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A75.876.AK.AK752 JT8642.T4.Q98.QJ KQ.AKQJ.T5432.93 93.9532.J76.T864"]
-[Contract "6NT"]
+[Contract "6N"]
 [Auction "S"]
-1NT     Pass    6NT     Pass
+1N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -1518,7 +1518,7 @@ Pass    Pass
 [Deal "N:AQ942.875.765.T2 T873.T94.QT92.64 65.A2.AJ83.AK985 KJ.KQJ63.K4.QJ73"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1528,9 +1528,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q843.T54.T72.K64 K7652.KQ8.A8.QJ9 JT.A2.KQJ96.AT72 A9.J9763.543.853"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1541,7 +1541,7 @@ Pass    Pass
 [Deal "N:AT85432.3.932.98 KJ97.AK762.Q4.J7 Q6.QT.KJ65.AK653 .J9854.AT87.QT42"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 Pass    Pass    2S      Pass
 Pass    4H      Pass    Pass
 Pass    
@@ -1552,11 +1552,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:JT6.6.KT3.AJ9653 Q8732.T97.J.QT84 A5.A432.A9876.K2 K94.KQJ85.Q542.7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1565,11 +1565,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:.KJ73.QJT7543.72 QJT987.82.A.AQJ9 AK.AQ95.98.KT865 65432.T64.K62.43"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1578,10 +1578,10 @@ Pass    Pass    3D      Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:6.AKT7.QJ4.98653 KQT.8642.8765.Q2 AJ.Q5.AT932.AJ74 9875432.J93.K.KT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1590,9 +1590,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQJ5.6432.83.964 T842.AT.J52.AT32 K3.J9.AQ94.KQJ75 976.KQ875.KT76.8"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1603,7 +1603,7 @@ Pass    Pass
 [Deal "N:KQ54.JT7643.6.86 T6.2.KQT5.KQJT92 A7.AQ.J973.A7543 J9832.K985.A842."]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -1615,7 +1615,7 @@ Pass    Pass
 [Deal "N:AJT87.J54.64.T98 Q5432.Q873.Q8.Q5 96.AT.AK97.A7632 K.K962.JT532.KJ4"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1625,10 +1625,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K873.AT87.8.KT92 QJ92.43.QT42.Q54 AT.K9.AJ976.A763 654.QJ652.K53.J8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1637,10 +1637,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQJ43.Q84.42.QJ9 952.KJ532.985.75 K7.T6.AKQT7.A842 T86.A97.J63.KT63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1651,7 +1651,7 @@ Pass    Pass
 [Deal "N:AQT76.J742.8.874 K543.T95.Q94.632 J2.A3.AKT62.QJT5 98.KQ86.J753.AK9"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -1663,7 +1663,7 @@ Pass    Pass
 [Deal "N:K73.T72.T7643.A7 QT98654.Q4.Q2.52 AJ.AJ85.KJ985.Q9 2.K963.A.KJT8643"]
 [Contract "3C"]
 [Auction "S"]
-1NT     3C      Pass    Pass
+1N     3C      Pass    Pass
 Pass    
 
 
@@ -1672,9 +1672,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:2.AT5.Q762.J7632 QJ9.QJ9862.93.K9 A8.74.AKJT.AT854 KT76543.K3.854.Q"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1685,9 +1685,9 @@ Pass
 [Deal "N:J.AQT.Q74.AKJT84 AQ97532.J865..52 K6.K7.AKJ95.Q763 T84.9432.T8632.9"]
 [Contract "6C"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    3S      Db
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -1697,9 +1697,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q972.7432.J98.T8 63.A865.KQ52.Q92 K8.QT.AT64.AK754 AJT54.KJ9.73.J63"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1710,7 +1710,7 @@ Pass    Pass
 [Deal "N:98.T942.KJT73.73 Q76.J8653.54.AT8 T3.AQ.AQ982.QJ64 AKJ542.K7.6.K952"]
 [Contract "3D"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Db      2S      3D      Pass
 Pass    Pass    
 
@@ -1720,10 +1720,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KQ7.AQ5.9872.K74 JT4.T86.T643.QT5 95.KJ72.AKQJ5.J3 A8632.943..A9862"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2S      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1734,7 +1734,7 @@ Pass    Pass
 [Deal "N:8764.J8542.K3.J5 AT5.KQT6.T95.A97 KQ.73.AJ76.KQT32 J932.A9.Q842.864"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1744,9 +1744,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AKQ.98.J752.KT84 9863.KQ3.964.Q95 JT.A7.AQ83.AJ632 7542.JT6542.KT.7"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1755,11 +1755,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QJ92.Q82.Q64.QT8 864.976.AT5.KJ93 AK.KT53.J3.A7654 T753.AJ4.K9872.2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1770,7 +1770,7 @@ Pass    Pass
 [Deal "N:AQT9862.T74.T42. 3.8632.Q985.AKJ7 J7.AK95.AK763.53 K54.QJ.J.QT98642"]
 [Contract "4S"]
 [Auction "S"]
-1NT     2C      4H      Pass
+1N     2C      4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -1780,11 +1780,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K543.87.J3.AJT53 AQJ8.T9.KT875.84 76.AQ64.AQ962.K9 T92.KJ532.4.Q762"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1795,7 +1795,7 @@ Pass    Pass
 [Deal "N:J2.KJT2.A9643.32 AK854.8654.T.965 Q7.AQ97.KJ872.A8 T963.3.Q5.KQJT74"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2C      Db      Pass
+1N     2C      Db      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1807,7 +1807,7 @@ Pass    Pass
 [Deal "N:J8.AQ9.Q863.T743 QT97542.KJT875.. K6.32.AK742.AJ95 A3.64.JT95.KQ862"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2C      3S
+1N     Pass    2C      3S
 Pass    Pass    Pass    
 
 
@@ -1818,7 +1818,7 @@ Pass    Pass    Pass
 [Deal "N:J843.8753.A865.T QT5.Q4.T2.K98754 AK.T9.Q743.AQ632 9762.AKJ62.KJ9.J"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -1827,10 +1827,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AJT93.T6.A854.J6 K6.Q972.6.AT9754 Q5.AK43.KT972.K2 8742.J85.QJ3.Q83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1841,7 +1841,7 @@ Pass    Pass
 [Deal "N:KQ92.52.T73.AQ75 J75.AQJT87.K6.T9 A3.K963.AQ984.K3 T864.4.J52.J8642"]
 [Contract "5D"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
 3D      Pass    4C      Pass
 4D      Pass    5D      Pass
@@ -1855,7 +1855,7 @@ Pass    Pass
 [Deal "N:97642.9.J8.QT943 K.K83.T9652.KJ86 A5.QJ65.KQ743.A2 QJT83.AT742.A.75"]
 [Contract "3H"]
 [Auction "S"]
-1NT     2D      Pass    3H
+1N     2D      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -1864,11 +1864,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:JT853.KQ73.Q96.A Q4.T86.KJ843.T84 AK.52.AT75.KQ532 9762.AJ94.2.J976"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1877,9 +1877,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:985.J8.K86.JT986 AQT.QT6.942.Q754 J7.AK53.QJ753.A2 K6432.9742.AT.K3"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1890,7 +1890,7 @@ Pass    Pass    Pass
 [Deal "N:AJ6.AT73.AT63.Q7 T7542.9854.J5.K5 93.KQJ6.KQ.AJT42 KQ8.2.98742.9863"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1902,7 +1902,7 @@ Pass    Pass
 [Deal "N:AQT954.A8.Q5.T72 J86.QT63.T963.93 K3.KJ75.KJ.AJ864 72.942.A8742.KQ5"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -1912,10 +1912,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ.AK92.Q972.T96 AQT952.543.64.54 73.86.AKT53.AKQ2 864.QJT7.J8.J873"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1924,10 +1924,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQ854.QT.532.A84 JT72.54.AJ74.T93 A3.KJ93.Q9.KQJ65 96.A8762.KT86.72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1936,10 +1936,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T32.K9.QJT832.K2 KQ764.T4.95.AT75 85.AQJ8.AK.J9843 AJ9.76532.764.Q6"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1950,7 +1950,7 @@ Pass    Pass
 [Deal "N:K9853.82.86543.9 J762.974.AQT.JT3 Q4.63.KJ92.AKQ74 AT.AKQJT5.7.8652"]
 [Contract "3H"]
 [Auction "S"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -1961,7 +1961,7 @@ Pass
 [Deal "N:T85.AQ93.AQ9.742 Q4.T8.T64.KQJT98 KJ.KJ54.KJ872.A3 A97632.762.53.65"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1973,7 +1973,7 @@ Pass    Pass
 [Deal "N:A542.AKQJ9..T754 KQ76.4.98754.KQ9 T3.8632.AKQJ6.AJ J98.T75.T32.8632"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4D      Pass
 5C      Pass    6H      Pass
 Pass    Pass    
@@ -1984,11 +1984,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J6543.KQJ872.6.K AK2.63.KQJT73.92 Q9.AT.A852.AJ854 T87.954.94.QT763"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1997,9 +1997,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:9764.T98.A53.J93 QT32.Q64.982.K42 K8.AJ.QJ74.A8765 AJ5.K7532.KT6.QT"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2008,9 +2008,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:J965.QJ63.JT2.J6 AKQ.T2.Q83.98532 T2.54.AK96.AKQT4 8743.AK987.754.7"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2021,7 +2021,7 @@ Pass    Pass
 [Deal "N:K9843.872.A872.7 AQ7.QJ964.4.K652 65.AKT5.KJ965.A4 JT2.3.QT3.QJT983"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -2033,7 +2033,7 @@ Pass    Pass
 [Deal "N:K9753.AKQ2.64.A2 QT6.84.32.KQ8764 AJ.JT63.AKQ85.J9 842.975.JT97.T53"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3S      Pass
 4D      Pass    6H      Pass
 Pass    Pass    
@@ -2044,9 +2044,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:643.KT2.KJ2.AQ96 K92.Q863.Q65.J83 A7.AJ54.AT987.K4 QJT85.97.43.T752"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2055,9 +2055,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:3.J742.8532.T976 KJ987.A8.QJ4.A82 Q6.KT53.AK976.K3 AT542.Q96.T.QJ54"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2068,7 +2068,7 @@ Pass    Pass
 [Deal "N:32.QJ9874.AJ64.9 AQT5.T2.832.J643 98.AK65.KQ975.K5 KJ764.3.T.AQT872"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2078,11 +2078,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q9653.AQ976.A7.K A7.J8542.J.87632 K8.KT.KQ965.AJT9 JT42.3.T8432.Q54"]
-[Contract "4NT"]
+[Contract "4N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -2091,11 +2091,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KT642.Q.KQ984.42 A5.JT9762.A62.53 QJ.A853.53.AKJT7 9873.K4.JT7.Q986"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2104,9 +2104,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QT76.K6.87543.73 J93.Q942.AT9.K65 A4.AT.KQJ6.JT942 K852.J8753.2.AQ8"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2117,7 +2117,7 @@ Pass    Pass
 [Deal "N:AKJT9432.K.J96.5 8.Q87.KT842.J832 76.AJ.A753.AQT74 Q5.T965432.Q.K96"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    4C      Pass
 4S      Pass    Pass    Pass
 
@@ -2130,7 +2130,7 @@ Pass    Pass
 [Deal "N:Q6.KQ52.T.AQ9652 AJT9543.T8.J4.74 K2.J973.AKQ73.KT 87.A64.98652.J83"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2142,7 +2142,7 @@ Pass    Pass
 [Deal "N:8732.QT.JT543.Q4 AQ6.K9863.A982.K K5.AJ72.K6.AJT62 JT94.54.Q7.98753"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    Db
+1N     Pass    Pass    Db
 Pass    2C      2D      Pass
 2H      2S      Pass    Pass
 Pass    
@@ -2153,9 +2153,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T532.72.J9653.J4 A87.AQ96.K72.AT7 K4.KJT5.AT.KQ652 QJ96.843.Q84.983"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "S"]
-1NT     Pass    Pass    Db
+1N     Pass    Pass    Db
 Pass    Pass    Pass    
 
 
@@ -2164,9 +2164,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJ9.QT5.T94.AKJ2 QT8732.84.KJ3.T5 A4.AK76.A8752.64 65.J932.Q6.Q9873"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2177,7 +2177,7 @@ Pass    Pass
 [Deal "N:9742.T9.QJ6.Q985 KQJT863.Q2.T8.64 A5.86.AK742.KJT7 .AKJ7543.953.A32"]
 [Contract "4H"]
 [Auction "S"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -2188,7 +2188,7 @@ Pass    Pass    Pass
 [Deal "N:J87.J875.KQ3.J94 AKQT6.QT63.652.Q 92.A2.A9874.AKT6 543.K94.JT.87532"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 2H      Pass    3C      Pass
 Pass    Pass    
 
@@ -2200,7 +2200,7 @@ Pass    Pass
 [Deal "N:K8642.976.942.T8 T3.KQ842.A73.A63 A7.A3.QJ85.KJ542 QJ95.JT5.KT6.Q97"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 Pass    Pass    2S      Db
 Pass    3H      Pass    Pass
 Pass    
@@ -2213,7 +2213,7 @@ Pass
 [Deal "N:T542.T7532.52.J5 KJ93.K4.KT7.K872 AQ.AQ.9864.AT963 876.J986.AQJ3.Q4"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -2223,9 +2223,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T52.742.Q9852.T8 K764.QJ93.K7.QJ4 A9.K8.AT64.A7632 QJ83.AT65.J3.K95"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2234,10 +2234,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QT954.752.KJ.AQ3 632.T64.T32.T986 A8.A9.A9765.K742 KJ7.KQJ83.Q84.J5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2248,7 +2248,7 @@ Pass    Pass
 [Deal "N:J864.98764.T9.72 K732.AJ52.J72.AT 95.Q3.AKQ84.KJ63 AQT.KT.653.Q9854"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -2258,9 +2258,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:72.983.QJ92.KT97 AQT63.64.KT54.J2 J8.AJ72.A7.AQ643 K954.KQT5.863.85"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2269,10 +2269,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:KQJ87.K3.Q8.J875 963.T976.KJ54.T9 42.AJ85.A9632.AK AT5.Q42.T7.Q6432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2281,11 +2281,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AJ876.6.J654.QT9 T54.AT98.Q97.842 Q9.QJ52.AK.KJ763 K32.K743.T832.A5"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2296,7 +2296,7 @@ Pass    Pass
 [Deal "N:KJ8742.Q.987.A72 6.7.Q652.KQ98543 AQ.A985.AJT43.J6 T953.KJT6432.K.T"]
 [Contract "4S"]
 [Auction "S"]
-1NT     2C      4H      Pass
+1N     2C      4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -2308,7 +2308,7 @@ Pass    Pass
 [Deal "N:Q5.KQ87.Q76.QT92 AT92.A642.9.AJ83 KJ.JT95.AKT54.K4 87643.3.J832.765"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2318,11 +2318,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJ953.Q.T9754.Q7 T862.KJ982.AQJ8. K7.AT53.K6.AJ843 Q4.764.32.KT9652"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2333,7 +2333,7 @@ Pass    Pass
 [Deal "N:AKJ9732.A92.9.A6 Q4.Q63.6543.T542 T6.K5.AKJT8.KQ98 85.JT874.Q72.J73"]
 [Contract "6S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    6S      Pass
 Pass    Pass    
 
@@ -2345,7 +2345,7 @@ Pass    Pass
 [Deal "N:J9753.T754.J93.K A62.983.K542.T93 Q4.KQ.A876.A8654 KT8.AJ62.QT.QJ72"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -2357,7 +2357,7 @@ Pass    Pass
 [Deal "N:AT.AJ98652.T.T53 K3.QT7.Q9853.Q92 Q8.K4.AJ764.AJ86 J976542.3.K2.K74"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2367,9 +2367,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJ8.8743.Q42.JT8 T95.AQ952.K63.Q9 42.KJT6.AJ.AK742 KQ763..T9875.653"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2380,10 +2380,10 @@ Pass    Pass
 [Deal "N:K5.AKQ6.K85.KT54 97632..JT.QJ8732 A8.J742.AQ732.A9 QJT4.T9853.964.6"]
 [Contract "7H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3S      Pass
-4C      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4C      Pass    4N     Pass
+5C      Pass    5N     Pass
 6H      Pass    7H      Pass
 Pass    Pass    
 
@@ -2393,9 +2393,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q85.QJT2.765.KT5 A73.A86.JT43.932 T6.K7.AQ92.AQ876 KJ942.9543.K8.J4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2404,9 +2404,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:T94.AK2.964.QJ75 73.QT8654.KT3.K4 A2.73.AQJ75.AT98 KQJ865.J9.82.632"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2417,7 +2417,7 @@ Pass    Pass
 [Deal "N:T864.J7642.86.42 AQJ3.A985.AJ7.63 92.KQ.KT94.AKT75 K75.T3.Q532.QJ98"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Db
 Pass    3C      Pass    Pass
 Pass    
@@ -2428,10 +2428,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A3.AQ96.Q63.Q976 KQT875.8.A542.T2 J2.K542.KJ987.AK 964.JT73.T.J8543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2440,10 +2440,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q72.AQJ54.82.K72 K98.9876.T743.T4 A4.K2.QJ65.AQ963 JT653.T3.AK9.J85"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2454,9 +2454,9 @@ Pass    Pass
 [Deal "N:AQ94.K76542.A54. KT86..KJ763.J854 J5.AQJT.92.AKT62 732.983.QT8.Q973"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    4S      Pass
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 6H      Pass    Pass    Pass
 
 
@@ -2466,9 +2466,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:92.T82.K643.7654 KQT8.AJ97.QJ8.T3 53.K6.A952.AKQ98 AJ764.Q543.T7.J2"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2479,7 +2479,7 @@ Pass    Pass
 [Deal "N:KQ94.Q9742.72.T6 J83.J83.Q83.9843 72.A6.AJT64.KQJ7 AT65.KT5.K95.A52"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2H      Pass
 Pass    Pass    
 
@@ -2491,7 +2491,7 @@ Pass    Pass
 [Deal "N:J75.QJT932.94.93 AT63.5.87632.AKT 84.AK87.AK.Q7654 KQ92.64.QJT5.J82"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -2503,7 +2503,7 @@ Pass    Pass
 [Deal "N:QT86.T6.T.JT9652 AK743.J984.986.Q J9.73.AKQJ4.A843 52.AKQ52.7532.K7"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2513,9 +2513,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T53.J74.6432.QJT AJ8.QT652.AKJ8.2 K9.AK.Q975.A9654 Q7642.983.T.K873"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2526,7 +2526,7 @@ Pass    Pass
 [Deal "N:42.T7.KJT72.5432 AKT8765.AQ2.864. Q3.K864.Q3.AKQT9 J9.J953.A95.J876"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    Pass    3S
+1N     Pass    Pass    3S
 Pass    Pass    Pass    
 
 
@@ -2537,7 +2537,7 @@ Pass    Pass    Pass
 [Deal "N:62.T97654.K96.QT JT83.QJ.AT53.AJ3 A7.AK32.J8.K8742 KQ954.8.Q742.965"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -2549,7 +2549,7 @@ Pass    Pass    Pass
 [Deal "N:AT732.J6.84.9876 J84.9875.Q65.Q32 Q9.AKQ3.32.KJT54 K65.T42.AKJT97.A"]
 [Contract "3D"]
 [Auction "S"]
-1NT     3D      Pass    Pass
+1N     3D      Pass    Pass
 Pass    
 
 
@@ -2560,7 +2560,7 @@ Pass
 [Deal "N:QJ8752.J32..K976 943.K87.KJT76.AQ AT.A4.AQ953.JT53 K6.QT965.842.842"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -2572,7 +2572,7 @@ Pass
 [Deal "N:J.J953.83.Q86543 Q7642.T72.T74.JT A3.AK64.KQ952.72 KT985.Q8.AJ6.AK9"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Db      Rd      2S
+1N     Db      Rd      2S
 Pass    Pass    Pass    
 
 
@@ -2583,7 +2583,7 @@ Pass    Pass    Pass
 [Deal "N:T952.T9.T2.T8752 AQJ876.Q4.J75.AJ K4.AJ76.KQ943.Q9 3.K8532.A86.K643"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      Pass    2S
 Pass    Pass    Pass    
 
@@ -2593,10 +2593,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AT542.Q65.KT3.42 9763.K42.7.AKJT9 KQ.AT.A9865.Q863 J8.J9873.QJ42.75"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2607,7 +2607,7 @@ Pass    Pass
 [Deal "N:KQ7653.3.832.AT3 84.K976.764.K762 A9.AT.KJT9.QJ985 JT2.QJ8542.AQ5.4"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -2617,10 +2617,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AK985.KT3.QT2.KT T763.9864.J74.Q9 Q2.AQ.K963.AJ743 J4.J752.A85.8652"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2631,7 +2631,7 @@ Pass    Pass
 [Deal "N:J52.Q62.AQ9872.5 K943.3.KT54.T643 QT.AK98.J6.AJ872 A876.JT754.3.KQ9"]
 [Contract "5D"]
 [Auction "S"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 4C      Pass    4D      Pass
 5D      Pass    Pass    Pass
 
@@ -2642,10 +2642,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJT87.A96.KT6.K7 A653.T53.9753.T2 Q9.J842.AJ.AQJ93 42.KQ7.Q842.8654"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2656,7 +2656,7 @@ Pass    Pass
 [Deal "N:KQJT9.42.985.865 A732.9875.J7.JT4 84.AJ.KT43.AK972 65.KQT63.AQ62.Q3"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -2665,10 +2665,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:7643.K93.A32.A76 AK82.JT84.J86.53 QT.AQ.KQT94.QJT2 J95.7652.75.K984"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2679,7 +2679,7 @@ Pass    Pass
 [Deal "N:95.J.QT7543.AJ85 AJ63.AT653.9.963 K2.KQ98.K8.KQ742 QT874.742.AJ62.T"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2689,9 +2689,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQ98.T53.J85.632 J743.K.963.KQJ84 A6.AJ74.AKT42.T7 T52.Q9862.Q7.A95"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2700,11 +2700,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ843.A.K32.6532 JT.KQJ982.T9.QT8 K2.75.AQJ86.AJ97 9765.T643.754.K4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2715,7 +2715,7 @@ Pass    Pass
 [Deal "N:AKJT6.KQ.QT.T962 Q932.8532.K8543. 84.AJ74.J2.AKQ75 75.T96.A976.J843"]
 [Contract "5C"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3C      Pass
 3D      Pass    4H      Pass
 5C      Pass    Pass    Pass
@@ -2729,7 +2729,7 @@ Pass    Pass
 [Deal "N:K9652.754.K952.3 QJ873.QT932.7.J9 T4.A6.QT64.AKQT6 A.KJ8.AJ83.87542"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Db      Pass    3H
 Pass    Pass    Pass    
 
@@ -2741,7 +2741,7 @@ Pass    Pass    Pass
 [Deal "N:T8754.J9862.A2.A AJ932.3.J753.JT4 KQ.AQ74.KQ964.73 6.KT5.T8.KQ98652"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -2752,9 +2752,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T53.A98.Q6532.JT J982.KJ7643..952 AK.QT.KT98.K8763 Q764.52.AJ74.AQ4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2763,10 +2763,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:42.K92.QT8.KT532 QJ53.JT53.A5.AJ9 AT.AQ64.K7643.Q8 K9876.87.J92.764"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2775,9 +2775,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A5.K53.KQT3.T632 T8.A9642.8642.Q9 92.QJT8.AJ.AKJ54 KQJ7643.7.975.87"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2786,11 +2786,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:JT762.QJ875.K7.Q K843.K942.93.983 A9.A6.AT42.AT654 Q5.T3.QJ865.KJ72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2799,9 +2799,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:A82.KT6.543.K973 KJ763.AJ875..654 95.Q2.AKQJ6.QJT2 QT4.943.T9872.A8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2812,7 +2812,7 @@ Pass    Pass
 [Deal "N:QT6.T9872.73.T75 A97432.5.J8.AJ94 K5.KQ.KT92.KQ862 J8.AJ643.AQ654.3"]
 [Contract "4S"]
 [Auction "S"]
-1NT     2H      Pass    2S
+1N     2H      Pass    2S
 Pass    3D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -2825,7 +2825,7 @@ Pass
 [Deal "N:K2.KT8643..QJ984 QT76.97.T854.A65 95.QJ52.AKQ73.K3 AJ843.A.J962.T72"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2835,9 +2835,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:T976.KQ76.953.K6 A832.JT984.T7.J8 J5.A2.KQ842.AQ94 KQ4.53.AJ6.T7532"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2846,9 +2846,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q.964.JT72.JT932 J98643.AT2.AQ3.7 AK.Q8.98654.AQ85 T752.KJ753.K.K64"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2857,10 +2857,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QT983.982.65.T86 A765.T54.KJ8.432 K2.AJ.QT974.AQ97 J4.KQ763.A32.KJ5"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Db      Pass    2NT
+1N     Pass    2H      Pass
+2S      Db      Pass    2N
 Pass    Pass    Pass    
 
 
@@ -2871,9 +2871,9 @@ Pass    Pass    Pass
 [Deal "N:KT98753.Q5.AK63. 4.7643.T84.KT963 A6.AKJ2.Q2.Q7542 QJ2.T98.J975.AJ8"]
 [Contract "6S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3D      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -2885,7 +2885,7 @@ Pass    Pass
 [Deal "N:KT3.QJ74.875.KQ7 Q8654.T3.T4.JT83 A9.AK82.KQ632.54 J72.965.AJ9.A962"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2897,7 +2897,7 @@ Pass    Pass
 [Deal "N:AQT9872.A43.4.J6 J43.T862.KT6.K32 K6.QJ.AQ985.A985 5.K975.J732.QT74"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -2909,7 +2909,7 @@ Pass    Pass
 [Deal "N:Q52.QT4.Q763.K82 T83.J9832.5.JT96 A9.A7.KJT9.A7543 KJ764.K65.A842.Q"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -2920,7 +2920,7 @@ Pass
 [Deal "N:A42.KT87542.Q5.5 QJ95.Q3.K3.QJT82 K6.J9.AT842.AK74 T873.A6.J976.963"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2932,7 +2932,7 @@ Pass
 [Deal "N:A8753.872.A62.T2 KJ642.KT3.8.Q854 QT.AJ64.KJ953.AJ 9.Q95.QT74.K9763"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -2942,10 +2942,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AT96.K943.A2.T64 4.T87652.QT98.K3 J2.AJ.K654.AQ875 KQ8753.Q.J73.J92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2C      Db      2H
-Pass    Pass    3NT     Pass
+1N     2C      Db      2H
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2954,10 +2954,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQ92.J6.K9.97654 876.98754.632.K2 K5.QT32.AQT87.A8 JT43.AK.J54.QJT3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2968,7 +2968,7 @@ Pass    Pass
 [Deal "N:K9762.Q8643.J85. J.J75.T632.AQT76 Q3.KT.AK94.KJ853 AT854.A92.Q7.942"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    2S      Pass
 Pass    Pass    
 
@@ -2978,9 +2978,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K86.9.9863.QJ843 J973.AQT62.5.AT2 AT.KJ87.AJT74.K5 Q542.543.KQ2.976"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2989,10 +2989,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:8765.K654.K64.KQ KJ9.JT873.7.J762 AQ.Q2.QJ82.AT983 T432.A9.AT953.54"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3003,7 +3003,7 @@ Pass    Pass
 [Deal "N:AT2.QT98.AT82.T3 9843.42.Q75.J764 Q7.A765.96.AKQ82 KJ65.KJ3.KJ43.95"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3013,9 +3013,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q95.9652.Q65.K65 K873.JT4.KJT2.Q7 J4.AKQ3.A3.JT842 AT62.87.9874.A93"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3026,7 +3026,7 @@ Pass    Pass
 [Deal "N:KJT86.763.T6.T76 Q974.AQ92.Q85.85 A2.85.AKJ32.QJ43 53.KJT4.974.AK92"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -3036,9 +3036,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:9764.943.J762.AK T532.T6.A984.942 KQ.AQ85.Q3.QJ753 AJ8.KJ72.KT5.T86"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3049,7 +3049,7 @@ Pass    Pass
 [Deal "N:QJ7632.T3.J2.A92 A84.J854.8763.K6 T9.AK96.AKT54.QT K5.Q72.Q9.J87543"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -3062,7 +3062,7 @@ Pass    Pass
 [Deal "N:42.T7.JT8.AKT975 AKT53.63.76.8643 96.AJ95.AKQ32.J2 QJ87.KQ842.954.Q"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3072,10 +3072,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AK97.JT.KT8743.7 J8.Q98742.2.KJ32 42.A3.AQJ5.A9654 QT653.K65.96.QT8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3084,11 +3084,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T6532.AKT7.K6.62 J97.J9843.Q72.AT AQ.Q2.AT83.KJ754 K84.65.J954.Q983"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3097,9 +3097,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T94.52.AT873.AK2 K852.QJ986.K5.98 QJ.AKT7.Q4.QJ543 A763.43.J962.T76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3108,9 +3108,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K75.QT8.JT8.Q982 QJT92.A43.Q53.J4 A6.62.A742.AKT73 843.KJ975.K96.65"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3121,7 +3121,7 @@ Pass    Pass
 [Deal "N:962.J752.A83.J42 QJT5.64.KT5.KT85 K3.KQ.J9642.AQ63 A874.AT983.Q7.97"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -3132,7 +3132,7 @@ Pass    Pass    Pass
 [Deal "N:K9642.KJ7542.5.4 8.T86.832.KQT876 J5.AQ.QJT4.AJ932 AQT73.93.AK976.5"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 4C      Pass    4H      Pass
 Pass    Pass    
 
@@ -3144,7 +3144,7 @@ Pass    Pass
 [Deal "N:9763.642.K96.KQT .KQJ5.QJT42.J654 AT.A873.A5.A9872 KQJ8542.T9.873.3"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    Pass    2H
+1N     Pass    Pass    2H
 Db      2S      Pass    3D
 Pass    Pass    Pass    
 
@@ -3154,10 +3154,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AJT87.KJ.862.873 9532.Q863.5.9654 K4.A975.KJT94.A2 Q6.T42.AQ73.KQJT"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Db      2NT     Pass
+1N     Pass    2H      Pass
+2S      Db      2N     Pass
 Pass    Pass    
 
 
@@ -3168,7 +3168,7 @@ Pass    Pass
 [Deal "N:J54.AQJT54..K763 873.732.KJ32.JT2 KT.K9.AQ85.A9854 AQ962.86.T9764.Q"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    4D      Pass
 4H      Pass    Pass    Pass
 
@@ -3181,7 +3181,7 @@ Pass    Pass
 [Deal "N:A6532.QT9.Q63.52 K9.A843.742.T973 74.KJ75.KJT95.AK QJT8.62.A8.QJ864"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -3193,9 +3193,9 @@ Pass    Pass
 [Deal "N:AKT83.K76532.A.2 9752.JT.7.JT8643 Q4.A8.QT42.AK975 J6.Q94.KJ98653.Q"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3H      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -3206,7 +3206,7 @@ Pass    Pass
 [Deal "N:85.KQ83.K9852.J2 AQ632.J2.Q764.95 J9.A954.A3.AK843 KT74.T76.JT.QT76"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3218,7 +3218,7 @@ Pass    Pass
 [Deal "N:QJ85.KT92.T74.86 T9643.J3.A53.954 A2.54.KQJ96.AQT3 K7.AQ876.82.KJ72"]
 [Contract "2H"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -3227,11 +3227,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J43..AQJ952.J842 QT97.KQT54.K87.7 A6.A963.64.AK953 K852.J872.T3.QT6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2S      3H
+1N     Pass    2S      3H
 Pass    Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3242,7 +3242,7 @@ Pass    Pass    3S      Pass
 [Deal "N:T973.AT9852.62.9 AQJ84.K4.KT7.643 K5.QJ73.54.AKQJ7 62.6.AQJ983.T852"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -3254,7 +3254,7 @@ Pass    Pass    Pass
 [Deal "N:A8652.J842.976.7 743.QT76.Q842.KT K9.A9.AJT5.QJ642 QJT.K53.K3.A9853"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -3266,7 +3266,7 @@ Pass    Pass    Pass
 [Deal "N:983.QT9876.Q7.42 QJ2.32.KJ85.KQT3 65.AK.AT92.AJ976 AKT74.J54.643.85"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -3278,7 +3278,7 @@ Pass    Pass    Pass
 [Deal "N:AJ963.7543.53.JT 75.J2.KJT87.Q963 K8.A9.AQ62.K7542 QT42.KQT86.94.A8"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -3288,10 +3288,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:KQJ97.T7.KT97.92 T652.A83.Q4.Q753 A4.Q964.AJ852.KJ 83.KJ52.63.AT864"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -3302,7 +3302,7 @@ Pass    Pass
 [Deal "N:QJ973.52.J9.KJ95 865.A98.KQ653.82 AK.KJT6.AT742.64 T42.Q743.8.AQT73"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -3314,7 +3314,7 @@ Pass    Pass
 [Deal "N:J7.JT93.Q7652.T2 KQ32.4.T93.QJ975 A9.K865.A8.A8643 T8654.AQ72.KJ4.K"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -3325,7 +3325,7 @@ Pass    Pass    Pass
 [Deal "N:J.QT653.QT73.854 8764.A98.852.K76 A9.J742.KJ.AQ932 KQT532.K.A964.JT"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3334,9 +3334,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:9642.T42.96.9742 KQ83.85.KT74.KQ6 75.AK.QJ85.AJT85 AJT.QJ9763.A32.3"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3347,7 +3347,7 @@ Pass
 [Deal "N:J864.AQ94.6.AKT3 Q73.52.753.Q9862 K9.KJT6.AKJ84.75 AT52.873.QT92.J4"]
 [Contract "5H"]
 [Auction "S"]
-1NT     Pass    3D      Pass
+1N     Pass    3D      Pass
 4H      Pass    5C      Pass
 5D      Pass    5H      Pass
 Pass    Pass    
@@ -3360,7 +3360,7 @@ Pass    Pass
 [Deal "N:J942.QJ86..AK732 T853.A3.KT95.J54 K7.KT95.AQJ42.Q6 AQ6.742.8763.T98"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    3D      Pass
+1N     Pass    3D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3370,9 +3370,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:53.T742.JT75.A86 9762.Q8.A9.T7543 A4.KJ96.KQ642.K2 KQJT8.A53.83.QJ9"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3383,7 +3383,7 @@ Pass    Pass
 [Deal "N:Q97652.7.J93.Q86 K3.AJ865.Q85.A72 A8.T9.AKT64.KJ93 JT4.KQ432.72.T54"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Db
 Pass    3H      Pass    Pass
 Pass    
@@ -3394,11 +3394,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q.A83.T963.AQ643 KJ93.QJT5.4.K952 AT.K962.AK852.J7 876542.74.QJ7.T8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2S      Pass
+1N     Pass    2S      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3409,7 +3409,7 @@ Pass
 [Deal "N:.AJT8.A962.KJT54 KT9742.7.73.A832 AQ.Q964.KQT84.Q6 J8653.K532.J5.97"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    3S      Pass
+1N     Pass    3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3421,7 +3421,7 @@ Pass
 [Deal "N:T63.96543.K76.T3 KQJ85.KJ7.542.72 42.A2.AJ83.AQ864 A97.QT8.QT9.KJ95"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    2S
 Pass    3S      Pass    Pass
 Pass    
@@ -3432,9 +3432,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A92.K84.K3.T8765 T8764.AT97.9.J93 KQ.J3.J762.AKQ42 J53.Q652.AQT854."]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -3445,7 +3445,7 @@ Pass    Pass
 [Deal "N:87642.72.T9.T543 K9.QJ653.KQ72.62 AJ.A984.65.KQJ97 QT53.KT.AJ843.A8"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -3457,7 +3457,7 @@ Pass    Pass
 [Deal "N:QJ63.A9875.8765. T92.QT63..KQJ932 A8.J4.AKT43.A765 K754.K2.QJ92.T84"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 Pass    Pass    2H      Pass
 Pass    Pass    
 
@@ -3467,11 +3467,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ76.Q84.T43.862 J852.AKT952.8.43 T4.J3.AKQ96.KQJ9 K93.76.J752.AT75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3480,10 +3480,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:542.AK542.742.K7 QT96.QT.Q85.8542 A7.63.AKJT6.QJ63 KJ83.J987.93.AT9"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3494,7 +3494,7 @@ Pass    Pass
 [Deal "N:KT965.962.T32.42 A8732.JT84.96.AK J4.AK53.KJ.QJ865 Q.Q7.AQ8754.T973"]
 [Contract "2SX"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Db
 Pass    Pass    Pass    
 
@@ -3506,7 +3506,7 @@ Pass    Pass    Pass
 [Deal "N:QJ976.J853.T63.9 4.97.AQ85.KQ8753 K5.AT.KJ974.A642 AT832.KQ642.2.JT"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2D      Pass    3D
+1N     2D      Pass    3D
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
 
@@ -3518,7 +3518,7 @@ Pass    Pass    Pass
 [Deal "N:82.AKJT942.63.98 KJT764.65.Q7.Q54 Q9.73.AJ82.AKJT6 A53.Q8.KT954.732"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3530,7 +3530,7 @@ Pass    Pass    Pass
 [Deal "N:J9842.Q752.J65.5 QT653.T.83.AT973 K7.KJ98.AKQ94.86 A.A643.T72.KQJ42"]
 [Contract "3C"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Db      Pass    3C
 Pass    Pass    Pass    
 
@@ -3540,12 +3540,12 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KT8.T9432.8.AQ74 AQ5.J876.J4.K962 J4.AK.AKT53.T853 97632.Q5.Q9762.J"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3C      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3556,7 +3556,7 @@ Pass    Pass    Pass
 [Deal "N:K98643.Q953.K2.K T5.AT874.974.A95 A7.K6.AQT8.QT876 QJ2.J2.J653.J432"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3568,7 +3568,7 @@ Pass    Pass    Pass
 [Deal "N:J2.AJT95.7.T9876 K8.8764.K943.J43 63.K2.AQJT2.AQ52 AQT9754.Q3.865.K"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      2S      Pass    Pass
 Pass    
 
@@ -3578,9 +3578,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:9852.T873.Q54.T9 A76.942.KT3.AK53 KT.AQJ5.AJ876.J7 QJ43.K6.92.Q8642"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3589,11 +3589,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q9.AT82.K872.985 83.J7653.AT6.643 A5.KQ.QJ95.KJT72 KJT7642.94.43.AQ"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2C      Db      Pass
-2D      2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2C      Db      Pass
+2D      2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3602,10 +3602,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJ3.J54.AJ3.T765 654.KQT976.T94.4 82.A832.K6.AKQ32 AQT97..Q8752.J98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3C      Pass    3NT     Pass
+1N     2S      2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3614,11 +3614,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QJ732.Q2.AJT543. A94.T63.982.Q984 KT.KJ74.Q7.AKT32 865.A985.K6.J765"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3627,10 +3627,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q982.Q7.KJ65.A75 T764.J43.4.QT962 AK.A5.AT973.J843 J53.KT9862.Q82.K"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3641,7 +3641,7 @@ Pass    Pass
 [Deal "N:K8.9643.973.KQ54 A765432.JT52..A6 T9.AQ87.AKQ42.72 QJ.K.JT865.JT983"]
 [Contract "4SX"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      2H      2S
 Pass    3D      Pass    3S
 Pass    4C      Db      4S
@@ -3654,11 +3654,11 @@ Db      Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AJ974.8642..AKJT Q86.T93.QT865.96 K3.AJ.AJ42.Q5432 T52.KQ75.K973.87"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3667,11 +3667,11 @@ Db      Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T972.K852.4.KQ75 865.QJ63.Q52.J86 J4.A4.AKT87.A943 AKQ3.T97.J963.T2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3682,7 +3682,7 @@ Db      Pass    Pass    Pass
 [Deal "N:5432.Q8643.K842. AT6.T52.Q.Q87543 J7.AJ.AJ963.AJT2 KQ98.K97.T75.K96"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -3692,11 +3692,11 @@ Db      Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AK932.K532.K5.K8 T874.JT6.962.532 QJ.A7.QJ874.AJT7 65.Q984.AT3.Q964"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3707,7 +3707,7 @@ Db      Pass    Pass    Pass
 [Deal "N:874.T85432.83.Q4 96532.AQ.2.KJ873 KQ.KJ.Q9754.AT65 AJT.976.AKJT6.92"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -3719,7 +3719,7 @@ Db      Pass    Pass    Pass
 [Deal "N:J3.AQT974.T32.86 A95.KJ65.9.AT542 K6.82.AKQ75.KJ73 QT8742.3.J864.Q9"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -3731,8 +3731,8 @@ Db      Pass    Pass    Pass
 [Deal "N:AJ84.983.T853.72 Q9.KJT65.AQ74.65 72.AQ74.96.AKQT3 KT653.2.KJ2.J984"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    Pass    2H
-Pass    2NT     Pass    3D
+1N     Pass    Pass    2H
+Pass    2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -3743,7 +3743,7 @@ Pass    Pass    Pass
 [Deal "N:98432.Q84.9872.K QJ.A97.K643.8543 AK.T653.Q5.AQJT7 T765.KJ2.AJT.962"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -3753,9 +3753,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:62.QT65.T9853.84 AQ54.J943.Q6.J92 JT.A2.AKJ2.K7653 K9873.K87.74.AQT"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3764,9 +3764,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:9532.K32.QJ5.Q43 T87.AT96.632.AT7 AK.J874.AK987.62 QJ64.Q5.T4.KJ985"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3777,7 +3777,7 @@ Pass    Pass    Pass
 [Deal "N:5.974.QJT42.6543 K9732.A86.A9753. Q4.KQJT.K8.AJT92 AJT86.532.6.KQ87"]
 [Contract "4S"]
 [Auction "S"]
-1NT     2S      Pass    4S
+1N     2S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -3786,9 +3786,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QT6.84.KJ764.J84 95432.K72.T3.975 K7.QJT6.A5.KQT62 AJ8.A953.Q982.A3"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3797,9 +3797,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:943.K764.A83.J92 K82.A32.KT72.T54 AT.QJT5.Q4.AK863 QJ765.98.J965.Q7"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3810,7 +3810,7 @@ Pass    Pass    Pass
 [Deal "N:T95.KQ9753.K94.4 62.A.Q7532.KT765 A4.62.AJT86.AQJ9 KQJ873.JT84..832"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2C      4D      Pass
+1N     2C      4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3822,7 +3822,7 @@ Pass    Pass    Pass
 [Deal "N:Q763.Q8.Q4.T8432 KT842.JT653.987. J9.A742.A6.AQJ97 A5.K9.KJT532.K65"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -3834,7 +3834,7 @@ Pass    Pass
 [Deal "N:74.JT875.7.AK962 AK863.3.K8654.Q8 J9.AK62.AQJT2.54 QT52.Q94.93.JT73"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3C      Pass
 4H      Pass    Pass    Pass
 
@@ -3847,7 +3847,7 @@ Pass    Pass
 [Deal "N:AJT7643.Q532.3.K Q92.AT.976.JT742 K5.84.AK54.AQ986 8.KJ976.QJT82.53"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3857,10 +3857,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:862.KQ532.AK7.94 QJT3.JT7.T532.85 AK.84.Q864.KQJ63 9754.A96.J9.AT72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3869,10 +3869,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T72.A8754.K52.K7 KQ643.9.873.QT54 A5.Q2.AQT6.A9862 J98.KJT63.J94.J3"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3881,9 +3881,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T62.J93.9764.T65 KQ974.864.32.A84 J8.KQ.AKT8.Q9732 A53.AT752.QJ5.KJ"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3892,9 +3892,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:K4.A875.987.8752 9862.KT.T6532.96 Q5.Q943.QJ.AKQT4 AJT73.J62.AK4.J3"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3903,9 +3903,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T8.9832.43.AQJ53 Q963.AJT7.Q7.874 K5.KQ.AJ862.KT92 AJ742.654.KT95.6"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3914,9 +3914,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q974.65.QJ2.T753 AK86.QT72.97.KQ2 T2.AJ.AK643.A964 J53.K9843.T85.J8"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3927,7 +3927,7 @@ Pass    Pass
 [Deal "N:Q8762.K8.J98.765 T4.Q76532.AQ63.K K3.AJT9.T4.AQJ93 AJ95.4.K752.T842"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -3937,9 +3937,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QJT3.A.T763.8732 AK97.QJ95.Q9.K96 84.K7.AJ854.AQJ5 652.T86432.K2.T4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3950,7 +3950,7 @@ Pass    Pass
 [Deal "N:7.96.Q6432.KT543 AKQT864.7.KJ.J72 J3.AT52.A5.AQ986 952.KQJ843.T987."]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    Pass    3S
+1N     Pass    Pass    3S
 Pass    Pass    Pass    
 
 
@@ -3959,10 +3959,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q875.A983.96.A53 AKT3.Q64.QJ43.94 J9.K7.AKT87.KJ87 642.JT52.52.QT62"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3973,7 +3973,7 @@ Pass    Pass
 [Deal "N:AJ65.JT9864.4.A3 K7.732.JT9876.Q4 Q2.AK.KQ532.JT96 T9843.Q5.A.K8752"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3983,10 +3983,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AQT87.86.873.A85 J9.QJ2.KT92.QJ93 K5.KT.AQ654.KT64 6432.A97543.J.72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3997,7 +3997,7 @@ Pass    Pass
 [Deal "N:JT9652.962.KJ86. Q43.AQ5.T.KJ8642 A7.KJ74.Q2.AQ975 K8.T83.A97543.T3"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -4007,9 +4007,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K53.84.AJT985.Q4 J86.AJT3.4.A8765 AQ.Q972.KQ632.K3 T9742.K65.7.JT92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4020,7 +4020,7 @@ Pass    Pass
 [Deal "N:AQ7432.5.KT.A974 T6.QJT6.J92.J632 J9.K8.AQ874.KQ85 K85.A97432.653.T"]
 [Contract "5C"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3C      Pass
 3D      Pass    4H      Pass
 5C      Pass    Pass    Pass
@@ -4032,10 +4032,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AK74.K98.95.Q754 JT852.Q63.J64.KT Q6.A5.AKQ32.J986 93.JT742.T87.A32"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4044,10 +4044,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K963.AK.875.K932 A8.QJT854.963.J8 JT.92.AKQT2.AQT5 Q7542.763.J4.764"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4058,7 +4058,7 @@ Pass    Pass
 [Deal "N:K9.864.KJ63.JT52 Q8653.AJ32.QT85. AJ.KQ97.A4.Q7643 T742.T5.972.AK98"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -4070,7 +4070,7 @@ Pass
 [Deal "N:Q62.J75.J9753.64 AJT5.K63.KQ8.AK9 K7.AQ94.A6.QJT87 9843.T82.T42.532"]
 [Contract "2D"]
 [Auction "S"]
-1NT     Pass    Pass    Db
+1N     Pass    Pass    Db
 Pass    Pass    2D      Pass
 Pass    Pass    
 
@@ -4080,11 +4080,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QT876.KJ6.9.K542 AKJ4.Q.QJ753.Q76 32.AT75.AKT84.A9 95.98432.62.JT83"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4095,7 +4095,7 @@ Pass    Pass
 [Deal "N:975.J6.832.KT843 J642.Q8752.J96.2 T3.A3.KQ54.AQJ76 AKQ8.KT94.AT7.95"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Db      Rd      2H
+1N     Db      Rd      2H
 Pass    Pass    Pass    
 
 
@@ -4106,7 +4106,7 @@ Pass    Pass    Pass
 [Deal "N:AQ543.72.T65.Q63 K2.Q6.AQ9732.J74 J9.AKT8.J4.AKT95 T876.J9543.K8.82"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    3D
 Pass    Pass    Pass    
 
@@ -4118,7 +4118,7 @@ Pass    Pass    Pass
 [Deal "N:KQJ764.Q3.K9.643 T32.765.T8765.AK A9.KJT8.AJ.Q9752 85.A942.Q432.JT8"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4130,7 +4130,7 @@ Pass    Pass    Pass
 [Deal "N:AQ8643.95.75.Q76 J95.JT84.J8.K984 T7.AQ62.AKQ94.53 K2.K73.T632.AJT2"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4142,7 +4142,7 @@ Pass    Pass    Pass
 [Deal "N:9754.AT732.873.T J82.K965.642.J65 A6.J8.KQT5.KQ982 KQT3.Q4.AJ9.A743"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Db      2D      Pass
+1N     Db      2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4152,10 +4152,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AK753.762.K6.864 J94.8.9743.AT752 T6.AKQ5.J8.KQJ93 Q82.JT943.AQT52."]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4166,7 +4166,7 @@ Pass    Pass    Pass
 [Deal "N:KT85.T7.87632.32 972.Q84.Q94.J987 A4.K932.AJ.KT654 QJ63.AJ65.KT5.AQ"]
 [Contract "2D"]
 [Auction "S"]
-1NT     Db      Rd      Pass
+1N     Db      Rd      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -4178,7 +4178,7 @@ Pass    Pass
 [Deal "N:A64.JT92.J97.852 QJ873.A853.5.K73 K9.74.AQ42.AQT96 T52.KQ6.KT863.J4"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 2H      2S      Pass    Pass
 Pass    
 
@@ -4188,10 +4188,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K72.A.T875.KQ543 J965.K95.KQ643.T A4.Q742.AJ.AJ986 QT83.JT863.92.72"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2S      Pass
-3C      Pass    3NT     Pass
+1N     Pass    2S      Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4202,7 +4202,7 @@ Pass    Pass
 [Deal "N:QT954.86.J93.K95 82.J732.65.QJ842 J3.AQ95.A4.AT763 AK76.KT4.KQT872."]
 [Contract "2S"]
 [Auction "S"]
-1NT     Db      2H      Pass
+1N     Db      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -4214,7 +4214,7 @@ Pass    Pass
 [Deal "N:QJ94.4.QJ862.983 A53.KQ75.7.KQT42 K7.AJ62.AT953.A6 T862.T983.K4.J75"]
 [Contract "2HX"]
 [Auction "S"]
-1NT     Pass    Pass    2H
+1N     Pass    Pass    2H
 Db      Pass    Pass    Pass
 
 
@@ -4226,7 +4226,7 @@ Db      Pass    Pass    Pass
 [Deal "N:943.985.T7.T7652 KQJ6.KQT73.J92.4 87.AJ.K863.AQJ98 AT52.642.AQ54.K3"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 2H      3D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -4239,7 +4239,7 @@ Pass
 [Deal "N:82.J6542.92.JT73 A7653.T8.AK54.A5 KQ.AQ93.J7.K8642 JT94.K7.QT863.Q9"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -4249,11 +4249,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AT972.AT5.QT82.4 KJ4.J9864.J97.T6 Q6.Q3.AK53.KJ753 853.K72.64.AQ982"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4264,7 +4264,7 @@ Pass    Pass
 [Deal "N:AJ7532.862.Q52.Q QT864.5.94.A9632 K9.J7.AKT8.KJ874 .AKQT943.J763.T5"]
 [Contract "4S"]
 [Auction "S"]
-1NT     3H      4S      Pass
+1N     3H      4S      Pass
 Pass    Pass    
 
 
@@ -4275,7 +4275,7 @@ Pass    Pass
 [Deal "N:A54.A753.KT83.J5 JT92.62.94.AK743 Q7.KQJ8.AQ765.Q8 K863.T94.J2.T962"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4285,10 +4285,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K942.Q93.K5.KT87 T765.J52.T8763.9 AQ.AT84.J2.AJ654 J83.K76.AQ94.Q32"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4297,10 +4297,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A853.JT7.K42.Q92 9.85.9753.A87643 Q2.AK43.AQJ86.T5 KJT764.Q962.T.KJ"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     2C      Db      Pass
-2H      Pass    3NT     Pass
+1N     2C      Db      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4311,7 +4311,7 @@ Pass    Pass
 [Deal "N:65.KJ53.4.J98742 A9873.Q8642.Q.AQ K4.A9.AJT73.KT53 QJT2.T7.K98652.6"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    2NT     3S
+1N     Pass    2N     3S
 4C      4S      Pass    Pass
 Pass    
 
@@ -4323,7 +4323,7 @@ Pass
 [Deal "N:53.AJ8765.J97.42 AK9842.94.T6.KJ8 J6.QT.AQ82.AQ653 QT7.K32.K543.T97"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -4335,10 +4335,10 @@ Pass    Pass    Pass
 [Deal "N:A7.Q7654..AKQJT7 KJT865.93.J532.9 93.AKJ8.AK986.52 Q42.T2.QT74.8643"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3C      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -4350,7 +4350,7 @@ Pass    Pass    Pass
 [Deal "N:AK642.T4.754.J72 Q85.K872.KQ83.K5 J7.AJ.AJT92.A986 T93.Q9653.6.QT43"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -4362,7 +4362,7 @@ Pass    Pass    Pass
 [Deal "N:AKJ862.T4.T5.QT9 QT7.J32.763.8654 43.K765.AKQJ9.K7 95.AQ98.842.AJ32"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4372,10 +4372,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AK854.K92.874.J8 J92.A7.T962.A762 76.Q6.AKJ5.KQT43 QT3.JT8543.Q3.95"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4386,7 +4386,7 @@ Pass    Pass
 [Deal "N:63.AQT543.T.8632 K854.K82.A742.75 A2.J7.Q853.AKQ94 QJT97.96.KJ96.JT"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -4399,7 +4399,7 @@ Pass    Pass
 [Deal "N:A63.J9853.Q8.953 QJ985.K6.975.642 K2.AT74.AKT62.Q7 T74.Q2.J43.AKJT8"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4411,7 +4411,7 @@ Pass    Pass
 [Deal "N:64.Q84.K42.JT983 AKQ2.A753.A986.6 73.KJT6.QJ.AKQ42 JT985.92.T753.75"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    Db
+1N     Pass    Pass    Db
 Pass    2S      Pass    Pass
 Pass    
 
@@ -4421,9 +4421,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J32.KQJ7.852.JT5 AT98.52.K4.Q8762 K5.A863.AJ763.K3 Q764.T94.QT9.A94"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4432,9 +4432,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:T987.986.KJ73.Q6 A5.KJT72.965.A32 Q2.A3.AQ82.K9875 KJ643.Q54.T4.JT4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4445,7 +4445,7 @@ Pass
 [Deal "N:82.T8762.QT5.AQT JT54.543.A43.J85 A7.A9.KJ972.K764 KQ963.KQJ.86.932"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4457,7 +4457,7 @@ Pass
 [Deal "N:AKQ732.T6.AJ8.87 84.72.KQ6432.932 T6.KQJ9.95.AKQT6 J95.A8543.T7.J54"]
 [Contract "6S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    5D      Db
 Pass    Pass    Rd      Pass
 6S      Pass    Pass    Pass
@@ -4471,7 +4471,7 @@ Pass    Pass    Rd      Pass
 [Deal "N:AQ.74.T8732.7652 764.AQJ932.A4.T3 J3.K6.KQ65.AQ984 KT9852.T85.J9.KJ"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Db      2S      Pass    Pass
 Pass    
 
@@ -4481,10 +4481,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:QT72.K3.AQJ2.986 J6543.982.43.JT4 A8.QT74.75.AKQ32 K9.AJ65.KT986.75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4495,7 +4495,7 @@ Pass    Pass
 [Deal "N:84.T987632.KQ73. KQ975.KJ.A64.A75 A2.A4.JT852.KQJ4 JT63.Q5.9.T98632"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4505,9 +4505,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:A84.K32.QJ86.AT9 QT972.Q96.73.Q43 K3.AJT5.AK954.72 J65.874.T2.KJ865"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4518,7 +4518,7 @@ Pass    Pass
 [Deal "N:3.AKQT8765.97.J9 AKQ654..JT52.876 J9.J9.AK83.AQ532 T872.432.Q64.KT4"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4530,7 +4530,7 @@ Pass    Pass
 [Deal "N:AT832.JT74.T.QJ4 J76.K62.A852.732 94.Q3.KQJ6.AK985 KQ5.A985.9743.T6"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2S      Pass
 Pass    Pass    
 
@@ -4540,10 +4540,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:A762.AQJ6.AT2.86 KT85.T95.K765.T2 Q3.43.QJ98.AKQJ3 J94.K872.43.9754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4552,10 +4552,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T9864.KJT.92.542 K732.754.654.K87 AQ.Q962.AKJ73.T3 J5.A83.QT8.AQJ96"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Db      Pass    2NT
+1N     Pass    2H      Pass
+2S      Db      Pass    2N
 Pass    Pass    Pass    
 
 
@@ -4566,7 +4566,7 @@ Pass    Pass    Pass
 [Deal "N:972.J875432.Q8.9 QJ6.KQT.T5.AKT75 K3.A6.AKJ32.J643 AT854.9.9764.Q82"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4576,10 +4576,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AQ872.K62.963.94 643.QJ7.K7542.A3 KJ.9854.AJ.KQJT6 T95.AT3.QT8.8752"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4590,7 +4590,7 @@ Pass    Pass
 [Deal "N:QJT62.KQT9.6.842 8743.7.AQJ952.J9 AK.6543.KT.KQT53 95.AJ82.8743.A76"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4600,9 +4600,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AT65.T65.93.JT42 743.A73.A754.Q97 J9.KQ92.KQJT8.K8 KQ82.J84.62.A653"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4613,7 +4613,7 @@ Pass    Pass
 [Deal "N:65.A984.9852.Q97 AK84.73..AJT6532 J3.KJT2.AK763.K4 QT972.Q65.QJT4.8"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2S
+1N     Pass    Pass    2S
 Pass    Pass    Pass    
 
 
@@ -4622,9 +4622,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J864.A862.865.73 3.QJ54.KQT3.KQ95 K9.K9.A974.AJT86 AQT752.T73.J2.42"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4635,7 +4635,7 @@ Pass    Pass    Pass
 [Deal "N:KT543.T93.QJ2.87 J9.J87.AK865.AK6 A6.AKQ4.43.QJ942 Q872.652.T97.T53"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      2S
+1N     Pass    2H      2S
 Pass    Pass    Pass    
 
 
@@ -4644,10 +4644,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K864.AKJ.KJ74.94 AQ5.8754.98.QT53 J3.93.AQ53.AKJ72 T972.QT62.T62.86"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4656,9 +4656,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J63.AT75.T642.95 T87.J32.AKJ7.JT8 AQ.K8.9853.AQ763 K9542.Q964.Q.K42"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4669,7 +4669,7 @@ Pass    Pass
 [Deal "N:983.AK875.9.T543 KJT74.QJ3.T54.KQ A5.92.KQJ62.AJ62 Q62.T64.A873.987"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -4681,7 +4681,7 @@ Pass    Pass    Pass
 [Deal "N:K764.943.T95.KT7 QJ85.8.K742.9654 T3.A5.AJ86.AQJ83 A92.KQJT762.Q3.2"]
 [Contract "3H"]
 [Auction "S"]
-1NT     3H      Pass    Pass
+1N     3H      Pass    Pass
 Pass    
 
 
@@ -4692,7 +4692,7 @@ Pass
 [Deal "N:T9.Q832.QT4.T932 AQJ542.T754.A2.5 K6.AJ.J9876.AK86 873.K96.K53.QJ74"]
 [Contract "3D"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      2H      Pass
 3D      Pass    Pass    Pass
 
@@ -4705,7 +4705,7 @@ Pass    2D      2H      Pass
 [Deal "N:AT6.T75.T7.K9742 J974.Q82.A65.T85 Q5.J9.KQ42.AQJ63 K832.AK643.J983."]
 [Contract "4C"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      Pass    Pass    3S
 4C      Pass    Pass    Pass
 
@@ -4718,7 +4718,7 @@ Pass    2D      2H      Pass
 [Deal "N:AJ.T8654.T94.965 KT9832.AK9.A.732 Q4.Q2.Q752.AKQ84 765.J73.KJ863.JT"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -4728,9 +4728,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:732.KT63.6542.A5 KQJ98.J84.KT.QJ9 A6.A7.AJ987.KT43 T54.Q952.Q3.8762"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4739,10 +4739,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AKQ8.84.AQT9.873 9542.T53.KJ654.5 63.AKQ2.82.KQJ64 JT7.J976.73.AT92"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4753,7 +4753,7 @@ Pass    Pass
 [Deal "N:T54.AJ864.KJ87.3 Q63..Q543.AJT854 K7.KT75.A2.KQ976 AJ982.Q932.T96.2"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3D      Pass
 4H      Pass    Pass    Pass
 
@@ -4766,7 +4766,7 @@ Pass    Pass
 [Deal "N:KT86.9632.AK9.K7 QJ9.AJ85.J6.J932 A5.KQ74.Q8752.A5 7432.T.T43.QT864"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4776,9 +4776,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:9542.QJT7.762.T9 AQT86.953.KT.J86 KJ.K4.QJ43.AQ542 73.A862.A985.K73"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4787,9 +4787,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ7.K4.KJT95.875 QT86.965.A72.KJ4 A5.AJ32.Q8.AT963 9432.QT87.643.Q2"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4800,7 +4800,7 @@ Pass    Pass
 [Deal "N:T973.J7542.65.AK A.Q9.AT872.J9542 QJ.A3.KQJ43.QT86 K86542.KT86.9.73"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2H      Pass
 Pass    Pass    
 
@@ -4812,7 +4812,7 @@ Pass    Pass
 [Deal "N:53.76.942.Q98752 KJT862.J8.Q65.KT 94.AT42.AKT73.A6 AQ7.KQ953.J8.J43"]
 [Contract "3C"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4822,9 +4822,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QJ.T52.QJ72.T972 K85.K874.K98.A54 A4.AQJ9.43.KJ863 T97632.63.AT65.Q"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4833,9 +4833,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q94.AT4.763.T762 J732.KQ63.84.Q85 86.J9.AKQJ.KJ943 AKT5.8752.T952.A"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4844,10 +4844,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KQ975.A84.JT8.A6 JT863.J52.A94.T2 A2.96.KQ65.KQJ43 4.KQT73.732.9875"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4858,7 +4858,7 @@ Pass    Pass
 [Deal "N:KJT87.932.3.JT62 Q65.AK654.KJT.A8 A9.QT.A754.KQ743 432.J87.Q9862.95"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -4870,7 +4870,7 @@ Pass    Pass
 [Deal "N:9732.KJ53.JT986. AKQJT.2.2.KJT865 65.A8.AK54.A9732 84.QT9764.Q73.Q4"]
 [Contract "2D"]
 [Auction "S"]
-1NT     Pass    2C      Db
+1N     Pass    2C      Db
 Pass    Pass    2D      Pass
 Pass    Pass    
 
@@ -4882,7 +4882,7 @@ Pass    Pass
 [Deal "N:Q532.A9742.J7.85 AJ84.K85.542.J43 KT.Q6.AQT63.KQT7 976.JT3.K98.A962"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4892,9 +4892,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:75.J982.T92.AJT7 Q963.AT75.84.632 KJ.K6.KQJ63.Q984 AT842.Q43.A75.K5"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4903,9 +4903,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:62.Q754.K876.643 KJ875.A82.A93.J8 AQ.J3.T542.AKQT5 T943.KT96.QJ.972"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4914,10 +4914,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQ42.A97.Q9.K876 JT8.QT5.8742.J92 K9.KJ64.AKT65.Q4 7653.832.J3.AT53"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4928,7 +4928,7 @@ Pass    Pass
 [Deal "N:942.2.AKJ9.QT932 J83.J983.843.765 AT.KQT7.QT762.KJ KQ765.A654.5.A84"]
 [Contract "5D"]
 [Auction "S"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 3D      Pass    4D      Pass
 5D      Pass    Pass    Pass
 
@@ -4941,8 +4941,8 @@ Pass    Pass
 [Deal "N:A83.AQJ542.K64.Q Q974.T96.7.AJT82 KJ.K7.AJ832.K974 T652.83.QT95.653"]
 [Contract "6H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
-4H      Pass    4NT     Pass
+1N     Pass    4D      Pass
+4H      Pass    4N     Pass
 5H      Pass    6H      Pass
 Pass    Pass    
 
@@ -4954,7 +4954,7 @@ Pass    Pass
 [Deal "N:76543.83.76.JT97 J.AQ752.AJT52.A2 K2.K4.KQ93.KQ865 AQT98.JT96.84.43"]
 [Contract "3H"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 Pass    Pass    2S      Pass
 Pass    3H      Pass    Pass
 Pass    
@@ -4967,7 +4967,7 @@ Pass
 [Deal "N:63.QT875.A4.8542 AJT54.AK62.K52.J KQ.J3.Q983.AKT97 9872.94.JT76.Q63"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Db
 Pass    2S      Pass    Pass
 Pass    
@@ -4980,9 +4980,9 @@ Pass
 [Deal "N:K.93.K97.KJ75432 AT876.QJ654.J5.8 92.K2.AQ32.AQT96 QJ543.AT87.T864."]
 [Contract "6C"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
-3C      Pass    3NT     Pass
-4NT     Pass    5D      Pass
+1N     Pass    2N     Pass
+3C      Pass    3N     Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -4994,9 +4994,9 @@ Pass
 [Deal "N:Q3.AJ92.AQJ763.8 AJ9652.85.T42.96 K8.KT74.98.AKQJ5 T74.Q63.K5.T7432"]
 [Contract "5H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 Pass    Pass    
 
 
@@ -5007,7 +5007,7 @@ Pass    Pass
 [Deal "N:8432.64.Q432.854 6.AKJT9732.K7.97 97.Q8.AJT96.AKQ3 AKQJT5.5.85.JT62"]
 [Contract "4S"]
 [Auction "S"]
-1NT     3S      Pass    4H
+1N     3S      Pass    4H
 Pass    4S      Pass    Pass
 Pass    
 
@@ -5019,9 +5019,9 @@ Pass
 [Deal "N:AJT863.8.K7.AJ86 9542.K3.Q862.KQ4 KQ.AQ97.AJ543.T9 7.JT6542.T9.7532"]
 [Contract "6S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3C      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -5031,11 +5031,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:8.A7532.QT2.Q874 AT9753.J84.54.32 KJ.T9.KJ98.AKJT5 Q642.KQ6.A763.96"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5044,9 +5044,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:J7.T83.QJ53.T632 QT963.65.A982.A9 A2.KQJ2.T4.KQJ87 K854.A974.K76.54"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5055,9 +5055,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J9.K72.K84.AK976 654.T965.QJ7.JT8 K2.AQJ8.AT653.Q5 AQT873.43.92.432"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5066,9 +5066,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:T2.T943.KJ5.J652 K973.KQ62.T872.8 A8.85.AQ943.KQT4 QJ654.AJ7.6.A973"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5077,10 +5077,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KT42.A853.J5.Q96 AJ93.94.87632.J2 85.Q7.AKT94.AK83 Q76.KJT62.Q.T754"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5089,9 +5089,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:542.JT83.A3.T752 QJT9.Q5.T865.Q43 AK.74.QJ742.AJ86 8763.AK962.K9.K9"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5100,11 +5100,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AKQT8.6.QT873.86 7654.JT974.9.QT9 J2.AQ53.J2.AKJ72 93.K82.AK654.543"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5113,9 +5113,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AKQJ9.AQ7543.K.K T72.9.JT8643.T76 53.KT82.AQ.AQJ43 864.J6.9752.9852"]
-[Contract "7NT"]
+[Contract "7N"]
 [Auction "S"]
-1NT     Pass    7NT     Pass
+1N     Pass    7N     Pass
 Pass    Pass    
 
 
@@ -5124,9 +5124,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q865.J8.K63.9832 AJT2.T764.QT2.A4 93.AKQ3.J9.KQ765 K74.952.A8754.JT"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5135,9 +5135,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KJ.T9873.J7.K987 972.6542.854.432 Q3.AQ.AQT92.QT65 AT8654.KJ.K63.AJ"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "S"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -5146,10 +5146,10 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:Q6.A9742.652.AQ2 A952.Q5.JT83.953 J4.KJ.AQ97.KJ764 KT873.T863.K4.T8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2D      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5160,7 +5160,7 @@ Pass    Pass
 [Deal "N:Q.AQ96543.T8.JT7 KT95.8.K532.Q943 43.K2.AQ976.AK52 AJ8762.JT7.J4.86"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5170,9 +5170,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:3.832.AT874.KT32 A642.Q65.KQ95.QJ Q8.AKJ4.J6.A9765 KJT975.T97.32.84"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5183,7 +5183,7 @@ Pass    Pass
 [Deal "N:KQ92.KJ97.A.9742 T4.65.T9652.QJT5 J8.AQT8.KQJ43.K6 A7653.432.87.A83"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    3D      Pass
+1N     Pass    3D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5195,8 +5195,8 @@ Pass    Pass
 [Deal "N:AQJT864.7.Q9.KQ7 .A954.8543.T8432 K5.KQ32.AKJ72.65 9732.JT86.T6.AJ9"]
 [Contract "5S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
-4S      Pass    4NT     Pass
+1N     Pass    4H      Pass
+4S      Pass    4N     Pass
 5H      Pass    5S      Pass
 Pass    Pass    
 
@@ -5206,10 +5206,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:K873.7.KQ73.Q752 A965.9842.62.JT9 T2.KQJT.AJT95.A6 QJ4.A653.84.K843"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3H      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5218,9 +5218,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K8.874.AT2.T9542 J9753.J96.Q54.KJ AQ.KQ52.J9763.A3 T642.AT3.K8.Q876"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5231,7 +5231,7 @@ Pass    Pass
 [Deal "N:AT7.AJT654.Q5.J2 KQ642.92.K7.8764 J3.Q3.AT962.AKQT 985.K87.J843.953"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    4D      Pass
+1N     Pass    4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5243,7 +5243,7 @@ Pass    Pass
 [Deal "N:43.JT3.QJ843.T97 KJ75.A9742.T6.Q2 A9.Q865.AK.K6543 QT862.K.9752.AJ8"]
 [Contract "3S"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    3S      Pass    Pass
 Pass    
 
@@ -5253,9 +5253,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:983.K3.AKT972.32 AJ65.T874.QJ8.T8 KQ.AQ92.43.KJ964 T742.J65.65.AQ75"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5266,7 +5266,7 @@ Pass    Pass
 [Deal "N:J986542.Q9.J72.6 .AJ63.Q95.JT8732 A7.K742.AT864.A9 KQT3.T85.K3.KQ54"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5276,9 +5276,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:KT54.6.A72.T9864 AQ7.KT8543.JT.J7 63.AJ.K9543.AK53 J982.Q972.Q86.Q2"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5287,9 +5287,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:K832.987.J82.QT2 QT974.632.74.A64 J6.QJT5.AKQ53.K9 A5.AK4.T96.J8753"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5298,9 +5298,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q92.Q743.963.732 8754.KT62.AKT4.T J6.AJ85.Q7.AKJ64 AKT3.9.J852.Q985"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5309,9 +5309,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:T875.KT63.73.T64 J32.AJ82.65.AK72 AQ.74.AK94.QJ953 K964.Q95.QJT82.8"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5320,9 +5320,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AT52.KT93.74.732 J86.Q62.Q86.K965 K4.A854.AJT32.A4 Q973.J7.K95.QJT8"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5333,7 +5333,7 @@ Pass    Pass
 [Deal "N:T97432.T87.5.QT9 KJ8.432.Q94.AJ72 A6.AQJ6.A8762.63 Q5.K95.KJT3.K854"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5345,7 +5345,7 @@ Pass    Pass
 [Deal "N:T9764.87.432.QT3 QJ83.QT4.J96.A95 A2.K965.AKQ87.87 K5.AJ32.T5.KJ642"]
 [Contract "3C"]
 [Auction "S"]
-1NT     2H      Pass    2S
+1N     2H      Pass    2S
 Pass    3C      Pass    Pass
 Pass    
 
@@ -5355,9 +5355,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K7.Q82.K7432.T63 A86432.974.9.K42 QJ.AT63.JT.AQJ75 T95.KJ5.AQ865.98"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5366,9 +5366,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:QT42.K.KT76.9732 9763.9753.8432.J K5.A6.AQJ95.QT85 AJ8.QJT842..AK64"]
-[Contract "1NTX"]
+[Contract "1NX"]
 [Auction "S"]
-1NT     Db      Pass    Pass
+1N     Db      Pass    Pass
 Pass    
 
 
@@ -5379,7 +5379,7 @@ Pass
 [Deal "N:AT75.T854.T4.943 K86..KJ987632.Q5 Q9.K973.AQ.AT762 J432.AQJ62.5.KJ8"]
 [Contract "4S"]
 [Auction "S"]
-1NT     2D      Pass    3S
+1N     2D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -5389,9 +5389,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:8532.87.QT5.QT73 K764.KJT3.9874.4 J9.AQ42.K6.AJ852 AQT.965.AJ32.K96"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5400,11 +5400,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KJ874.K7432.8.A3 T9532.Q5.QJ97.42 AQ.86.AK643.QJT6 6.AJT9.T52.K9875"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5413,9 +5413,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:752.AK2.T942.432 J864.QT753.J73.Q QT.94.KQ86.AKJT5 AK93.J86.A5.9876"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5424,9 +5424,9 @@ Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJ32.82.JT8.9872 97.A64.A92.KJT53 T8.KQ93.KQ654.AQ KQ654.JT75.73.64"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5437,7 +5437,7 @@ Pass
 [Deal "N:654.Q.Q64.JT9873 K9732.T32.K93.64 Q8.74.AJT82.AKQ2 AJT.AKJ9865.75.5"]
 [Contract "4H"]
 [Auction "S"]
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -5446,11 +5446,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AKQ76.K653.T.K72 42.T97.AJ95.8653 T5.AQ.KQ832.AJ94 J983.J842.764.QT"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5461,7 +5461,7 @@ Pass    Pass    Pass
 [Deal "N:K87.QT874.82.J83 J5432.A95.94.T72 A6.J6.AJT3.KQ954 QT9.K32.KQ765.A6"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -5473,7 +5473,7 @@ Pass    Pass    Pass
 [Deal "N:98.QT973.854.QJ5 AJT65.A8.73.K732 K7.KJ.AT92.AT986 Q432.6542.KQJ6.4"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -5485,7 +5485,7 @@ Pass    Pass    Pass
 [Deal "N:K9753.9.976.KJT8 AJ86.KJT.T2.Q742 QT.A862.KQJ84.A9 42.Q7543.A53.653"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5495,10 +5495,10 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:KT964.JT.T65.KQ7 A85.Q94.9743.985 32.A763.AK.AJ642 QJ7.K852.QJ82.T3"]
-[Contract "2NT"]
+[Contract "2N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -5507,11 +5507,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:AT73.54.4.AJ8632 Q8652.Q7.762.T95 K4.JT92.AKQT9.Q7 J9.AK863.J853.K4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5520,11 +5520,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:AJ964.QT85.T6.AT Q.KJ76.J85.J9832 75.A2.AQ974.KQ54 KT832.943.K32.76"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5533,10 +5533,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:QJT5.J52.K62.K43 7642.84.T.QT9852 K8.AT76.AQJ93.J7 A93.KQ93.8754.A6"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5545,11 +5545,11 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:JT832.AKQ7.Q95.4 54.J84.84.T76532 Q7.63.KJT32.AKQJ AK96.T952.A76.98"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5560,7 +5560,7 @@ Pass    Pass
 [Deal "N:KQ6.T9643.Q7.T94 AJ52.75.K9632.53 T3.AQ.AT854.KQ62 9874.KJ82.J.AJ87"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -5572,7 +5572,7 @@ Pass    Pass
 [Deal "N:A8543.943.Q2.T75 JT9762.QJ872.A3. KQ.K6.KJT97.QJ84 .AT5.8654.AK9632"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5584,7 +5584,7 @@ Pass    Pass
 [Deal "N:KQT52.KT32.JT7.3 876.J7.K83.T8642 94.AQ64.A5.AJ975 AJ3.985.Q9642.KQ"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5596,7 +5596,7 @@ Pass    Pass
 [Deal "N:9853.KJT742.Q.73 J7.985.AJT62.QT2 QT.AQ.K8543.KJ96 AK642.63.97.A854"]
 [Contract "3H"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 3C      Pass    3H      Pass
 Pass    Pass    
 
@@ -5608,7 +5608,7 @@ Pass    Pass
 [Deal "N:A75.KQJ742.87.J4 J842.9865.T965.T 63.AT.AK432.A853 KQT9.3.QJ.KQ9762"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 4D      Pass    4H      Pass
 Pass    Pass    
 
@@ -5620,7 +5620,7 @@ Pass    Pass
 [Deal "N:JT98652.QJ9.842. Q74.T543.Q.Q9863 K3.AK62.AJ753.52 A.87.KT96.AKJT74"]
 [Contract "4C"]
 [Auction "S"]
-1NT     3C      Pass    4C
+1N     3C      Pass    4C
 Pass    Pass    Pass    
 
 
@@ -5631,7 +5631,7 @@ Pass    Pass    Pass
 [Deal "N:Q932.K54.T4.Q853 AKJT8.JT96.K92.4 65.A8.A753.AK976 74.Q732.QJ86.JT2"]
 [Contract "4C"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 2H      Db      Pass    Pass
 3C      3H      3S      Pass
 4C      Pass    Pass    Pass
@@ -5643,9 +5643,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:QT74.J.T962.J987 8532.AK986.AQ.Q5 AJ.32.K853.AKT64 K96.QT754.J74.32"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5656,7 +5656,7 @@ Pass    Pass    Pass
 [Deal "N:532.A632.3.T9862 T7.K98.T9762.AJ7 AJ.Q5.AQJ85.Q543 KQ9864.JT74.K4.K"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Db      2S      Pass    Pass
 Pass    
 
@@ -5668,7 +5668,7 @@ Pass
 [Deal "N:QT42.43.K42.9654 A6.T952.873.QJT7 85.Q7.AQJT.AK832 KJ973.AKJ86.965."]
 [Contract "2H"]
 [Auction "S"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -5677,11 +5677,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:AQ5.9.T9864.KQJ5 T963.QT72.K5.732 K8.K6.AQ73.AT964 J742.AJ8543.J2.8"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2S      Pass
+1N     Pass    2S      Pass
 3C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5692,7 +5692,7 @@ Pass    Pass    Pass
 [Deal "N:AT54.J9874.Q3.Q8 Q9732.Q53.A7.J73 J8.A2.K9865.AK94 K6.KT6.JT42.T652"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    2H      Pass
 Pass    Pass    
 
@@ -5704,7 +5704,7 @@ Pass    Pass
 [Deal "N:AT96543.KJ.84.KJ 87.QT76.J75.8743 KJ.A2.A632.AT652 Q2.98543.KQT9.Q9"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -5714,9 +5714,9 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "none"]
 [Deal "N:J96.865.J8.KQT83 AT73.KT93.752.96 54.AQ.KQT64.A542 KQ82.J742.A93.J7"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5727,7 +5727,7 @@ Pass    Pass
 [Deal "N:T.KT7652.J53.A97 AK8.943.T984.J43 Q2.A8.AKQ72.T862 J976543.QJ.6.KQ5"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2C      4D      Pass
+1N     2C      4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5739,7 +5739,7 @@ Pass    Pass
 [Deal "N:QJ653.JT.753.942 AT42.A952.A92.86 K7.84.KJ864.AKJ5 98.KQ763.QT.QT73"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5751,7 +5751,7 @@ Pass    Pass
 [Deal "N:T765432.K6.J6.53 .AT85.AQT42.J976 KQ.QJ.K9875.KQ82 AJ98.97432.3.AT4"]
 [Contract "4H"]
 [Auction "S"]
-1NT     2D      Pass    4H
+1N     2D      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -5762,7 +5762,7 @@ Pass    Pass    Pass
 [Deal "N:AKT3.KQ9765..T86 85.J2.976432.J73 96.AT.AKJT8.K952 QJ742.843.Q5.AQ4"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    4D      Pass
 4H      Pass    Pass    Pass
 
@@ -5773,9 +5773,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:9.JT95.KQ942.J96 QT742.432.T83.Q8 J5.K876.A5.AK742 AK863.AQ.J76.T53"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5784,11 +5784,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:AT93.J4.5.KJ9753 8654.AK.AT9.QT62 KQ.T862.KQJ62.A8 J72.Q9753.8743.4"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5799,7 +5799,7 @@ Pass    Pass
 [Deal "N:Q976.J93.9.QJT92 AT832.T4.AKT64.8 K5.AKQ8.52.K7543 J4.7652.QJ873.A6"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    Pass    2S
+1N     Pass    Pass    2S
 Pass    Pass    Pass    
 
 
@@ -5810,7 +5810,7 @@ Pass    Pass    Pass
 [Deal "N:9654.964.Q2.9643 AT73.A3.9764.QT8 Q8.87.AKT53.AK72 KJ2.KQJT52.J8.J5"]
 [Contract "2H"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Db      2H      Pass    Pass
 Pass    
 
@@ -5822,7 +5822,7 @@ Pass
 [Deal "N:KJ7.T62.QJ97.T54 Q84.AKJ974.KT.32 65.Q5.A854.AKQJ9 AT932.83.632.876"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Db      Pass    Pass    2H
 Pass    Pass    Pass    
 
@@ -5832,9 +5832,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:K74.Q965.J53.J53 A865.T3.K762.Q74 T3.AKJ4.A8.AT982 QJ92.872.QT94.K6"]
-[Contract "1NT"]
+[Contract "1N"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5845,7 +5845,7 @@ Pass    Pass    Pass
 [Deal "N:K8653.J92.85.Q92 74.Q54.73.A76543 A9.KT83.AJT62.K8 QJT2.A76.KQ94.JT"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5857,7 +5857,7 @@ Pass    Pass    Pass
 [Deal "N:54.QJ842.Q7.K432 AQ7.K965.JT865.5 J8.A7.A943.AQJ76 KT9632.T3.K2.T98"]
 [Contract "2H"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -5869,7 +5869,7 @@ Pass    Pass    Pass
 [Deal "N:AT74.QJ983.T7.KJ QJ85.7.J9.Q96542 K6.KT65.AKQ85.83 932.A42.6432.AT7"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5881,7 +5881,7 @@ Pass    Pass
 [Deal "N:KJT65.8542.J5.T8 Q973.T9.KQ98.943 A4.AJ.AT742.K762 82.KQ763.63.AQJ5"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -5890,10 +5890,10 @@ Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:A8532.KQ9.QT6.83 T976.32.53.KJ542 Q4.AT86.AK974.QT KJ.J754.J82.A976"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5904,7 +5904,7 @@ Pass    Pass
 [Deal "N:AQ743.KT74.53.72 85.65.AJ8642.K93 92.AJ82.KQ.AQ864 KJT6.Q93.T97.JT5"]
 [Contract "4H"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5916,7 +5916,7 @@ Pass    Pass
 [Deal "N:K98652.T8.T964.K Q3.KQJ765.8.Q843 74.A4.AKJ53.A975 AJT.932.Q72.JT62"]
 [Contract "2S"]
 [Auction "S"]
-1NT     Pass    2H      Db
+1N     Pass    2H      Db
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -5928,7 +5928,7 @@ Pass    Pass
 [Deal "N:KQT875.AT8.Q65.J 4.J73.9873.AT874 J6.K5.AKT2.KQ953 A932.Q9642.J4.62"]
 [Contract "4S"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -5940,7 +5940,7 @@ Pass    Pass
 [Deal "N:T732.AQJ2.972.52 4.843.KJ654.J843 K5.65.AQT8.AQT97 AQJ986.KT97.3.K6"]
 [Contract "2H"]
 [Auction "S"]
-1NT     2D      Pass    2H
+1N     2D      Pass    2H
 Pass    Pass    Pass    
 
 
@@ -5951,7 +5951,7 @@ Pass    Pass    Pass
 [Deal "N:AQ643.5.J64.AQJT KT975.9743.A932. J2.AKJT.KT.K9842 8.Q862.Q875.7653"]
 [Contract "5C"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3C      Pass
 3D      Pass    4H      Pass
 5C      Pass    Pass    Pass
@@ -5965,7 +5965,7 @@ Pass    Pass    Pass
 [Deal "N:J654.K7653.874.2 Q98732.AJ4..QT73 AK.Q8.K652.A9854 T.T92.AQJT93.KJ6"]
 [Contract "2S"]
 [Auction "S"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -5975,9 +5975,9 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:Q7.A9.QJ985.KJ98 KJ9632.8642..Q62 A5.KJT5.AKT32.54 T84.Q73.764.AT73"]
-[Contract "3NT"]
+[Contract "3N"]
 [Auction "S"]
-1NT     Pass    2S      Pass
-3D      Pass    3NT     Pass
+1N     Pass    2S      Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 

--- a/GIB/GIB_1m-1DorH-Collante
+++ b/GIB/GIB_1m-1DorH-Collante
@@ -12,11 +12,11 @@
 {HCP 14 6 12 8}
 {TP 14 9 14 11}
 {Losers 7 7 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2D      X       Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -33,11 +33,11 @@ Pass    Pass
 {HCP 17 5 11 7}
 {TP 18 5 13 9}
 {Losers 6 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2H      2S      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -145,7 +145,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       3H
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -247,11 +247,11 @@ Pass    Pass    Pass
 {HCP 9 7 13 11}
 {TP 9 8 13 11}
 {Losers 10 9 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -338,7 +338,7 @@ Pass    Pass    1C      Pass
 [Declarer "N"]
 [Auction "S"]
 1C      2D      2H      Pass
-2NT     Pass    3H      Pass
+2N     Pass    3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -361,8 +361,8 @@ Pass    Pass    1C      Pass
 [Auction "S"]
 1D      2H      X       3H
 3S      Pass    4C      Pass
-4S      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5H      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -422,13 +422,13 @@ Pass    Pass
 {HCP 17 4 12 7}
 {TP 17 4 12 9}
 {Losers 6 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
 1S      Pass    2D      Pass
-2NT     Pass    3H      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -445,12 +445,12 @@ Pass    Pass
 {HCP 16 4 11 9}
 {TP 19 5 13 11}
 {Losers 4 10 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1H      1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -471,7 +471,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      1H      1S      Pass
-1NT     Pass    4S      Pass
+1N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -509,11 +509,11 @@ Pass    Pass
 {HCP 14 5 12 9}
 {TP 14 6 12 10}
 {Losers 6 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1D      1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -534,8 +534,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2S      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2S      Pass    2N     Pass
+3C      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -642,7 +642,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      2H      2S      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -664,8 +664,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      1H      1S      Pass
-1NT     Pass    2C      Pass
-3NT     Pass    4S      Pass
+1N     Pass    2C      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -838,7 +838,7 @@ Pass    Pass    3H      Pass
 [Declarer "N"]
 [Auction "S"]
 1D      1H      1S      Pass
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3C      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -860,7 +860,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1C      1H      X       1NT
+1C      1H      X       1N
 2C      2D      3C      Pass
 Pass    Pass    
 
@@ -921,10 +921,10 @@ Pass    Pass
 {HCP 10 10 12 8}
 {TP 10 10 12 10}
 {Losers 8 9 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1H      1S      1NT
+1D      1H      1S      1N
 Pass    Pass    Pass    
 
 
@@ -1026,10 +1026,10 @@ Pass    Pass
 {HCP 9 9 12 10}
 {TP 10 9 14 11}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1H      X       1NT
+1D      1H      X       1N
 Pass    Pass    Pass    
 
 
@@ -1089,12 +1089,12 @@ Pass    Pass
 {HCP 10 9 13 8}
 {TP 12 10 14 10}
 {Losers 7 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       2C
 Pass    2H      3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1111,11 +1111,11 @@ Pass    2H      3H      Pass
 {HCP 10 8 14 8}
 {TP 10 9 15 10}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2H      X       Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1158,7 +1158,7 @@ Pass    Pass    3H      Pass
 [Declarer "N"]
 [Auction "S"]
 1C      2H      2S      4H
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5S      Pass
 Pass    Pass    
 
@@ -1261,11 +1261,11 @@ Pass    Pass
 {HCP 12 8 12 8}
 {TP 14 9 13 10}
 {Losers 6 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      1D      1H      1NT
-Pass    Pass    3NT     Pass
+1C      1D      1H      1N
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1307,7 +1307,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-2S      Pass    4NT     Pass
+2S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -1328,7 +1328,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1D      1H      1S      1NT
+1D      1H      1S      1N
 X       Pass    2S      Pass
 Pass    Pass    
 
@@ -1346,12 +1346,12 @@ Pass    Pass
 {HCP 9 8 14 9}
 {TP 10 9 14 10}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1476,11 +1476,11 @@ Pass    Pass
 {HCP 10 6 14 10}
 {TP 10 6 14 11}
 {Losers 9 10 6 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1497,12 +1497,12 @@ Pass    Pass
 {HCP 13 5 14 8}
 {TP 15 5 15 9}
 {Losers 6 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    3C      Pass
-3S      Pass    3NT     Pass
+1N     Pass    3C      Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1519,11 +1519,11 @@ Pass    Pass
 {HCP 15 4 14 7}
 {TP 16 5 14 9}
 {Losers 6 9 9 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1565,7 +1565,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1C      1D      1H      Pass
-1NT     Pass    2H      2S
+1N     Pass    2H      2S
 Pass    Pass    Pass    
 
 
@@ -1603,12 +1603,12 @@ Pass    Pass
 {HCP 17 1 14 8}
 {TP 18 2 14 10}
 {Losers 5 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      Pass
 2C      Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1668,11 +1668,11 @@ Pass    Pass
 {HCP 13 7 13 7}
 {TP 15 8 14 9}
 {Losers 5 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2D      2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1756,8 +1756,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      Pass
-1NT     Pass    2S      Pass
-3H      Pass    3NT     Pass
+1N     Pass    2S      Pass
+3H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -1840,12 +1840,12 @@ Pass    Pass
 {HCP 10 7 14 9}
 {TP 12 8 14 11}
 {Losers 7 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    2C      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2C      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1883,11 +1883,11 @@ Pass    Pass
 {HCP 9 9 14 8}
 {TP 11 10 15 9}
 {Losers 7 8 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2D      2H      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -1904,13 +1904,13 @@ Pass    Pass
 {HCP 12 4 13 11}
 {TP 14 5 13 11}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    2H      Pass
-2NT     Pass    3H      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2H      Pass
+2N     Pass    3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1927,11 +1927,11 @@ Pass    Pass
 {HCP 12 7 13 8}
 {TP 12 7 13 10}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      1H      X       2H
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1969,11 +1969,11 @@ Pass    Pass
 {HCP 16 4 12 8}
 {TP 18 4 13 10}
 {Losers 4 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1D      1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1993,7 +1993,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1D      1H      1S      1NT
+1D      1H      1S      1N
 X       Pass    2S      Pass
 Pass    Pass    
 
@@ -2080,7 +2080,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2102,8 +2102,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      2D      2H      Pass
-2NT     Pass    3S      Pass
-3NT     Pass    4H      Pass
+2N     Pass    3S      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -2120,11 +2120,11 @@ Pass    Pass
 {HCP 11 9 12 8}
 {TP 13 10 14 9}
 {Losers 6 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2D      2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2184,12 +2184,12 @@ Pass    Pass
 {HCP 17 4 12 7}
 {TP 18 4 14 9}
 {Losers 5 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    Pass    1S      Pass
-1NT     Pass    2D      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2227,12 +2227,12 @@ Pass    Pass    1S      Pass
 {HCP 15 4 13 8}
 {TP 15 5 13 9}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      1S      Pass
-1NT     Pass    2D      Pass
-2NT     Pass    3NT     Pass
+1N     Pass    2D      Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2273,7 +2273,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1C      1D      X       1NT
+1C      1D      X       1N
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2312,11 +2312,11 @@ Pass    Pass
 {HCP 13 6 12 9}
 {TP 13 8 13 10}
 {Losers 8 8 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2333,12 +2333,12 @@ Pass    Pass
 {HCP 16 4 11 9}
 {TP 19 6 13 10}
 {Losers 5 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      2S      Pass
 3D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2401,7 +2401,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2H      3H      X
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    X       5D      Pass
 Pass    Pass    
 
@@ -2442,11 +2442,11 @@ Pass    Pass
 {HCP 11 7 12 10}
 {TP 12 10 12 10}
 {Losers 7 7 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1H      X       Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2510,7 +2510,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1C      1D      1H      1NT
+1C      1D      1H      1N
 2H      Pass    3C      Pass
 3H      Pass    Pass    Pass
 
@@ -2551,11 +2551,11 @@ Pass    Pass    4H      Pass
 {HCP 14 4 13 9}
 {TP 15 6 14 11}
 {Losers 6 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2H      2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2593,11 +2593,11 @@ Pass    Pass
 {HCP 14 6 11 9}
 {TP 14 6 13 10}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2D      X       Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2914,11 +2914,11 @@ Pass    Pass
 {HCP 12 8 14 6}
 {TP 16 8 14 10}
 {Losers 4 10 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2960,7 +2960,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3021,11 +3021,11 @@ Pass    Pass
 {HCP 14 4 13 9}
 {TP 15 5 13 10}
 {Losers 6 10 9 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3084,12 +3084,12 @@ Pass    Pass    Pass
 {HCP 12 5 12 11}
 {TP 13 5 13 11}
 {Losers 8 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    2NT     Pass
-3S      Pass    3NT     Pass
+1N     Pass    2N     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3131,7 +3131,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      2H      2S      Pass
-2NT     Pass    4S      Pass
+2N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -3151,7 +3151,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1D      1H      1S      1NT
+1D      1H      1S      1N
 X       Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -3170,11 +3170,11 @@ X       Pass    3S      Pass
 {HCP 11 6 13 10}
 {TP 11 6 13 11}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3195,7 +3195,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      2D      2H      3D
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -3339,10 +3339,10 @@ Pass    Pass
 {HCP 10 10 12 8}
 {TP 10 10 12 9}
 {Losers 8 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1H      X       1NT
+1C      1H      X       1N
 Pass    Pass    Pass    
 
 
@@ -3428,7 +3428,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1H      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3H      Pass
+2N     Pass    3H      Pass
 4H      Pass    6H      Pass
 Pass    Pass    
 
@@ -3446,10 +3446,10 @@ Pass    Pass
 {HCP 10 10 12 8}
 {TP 10 10 13 9}
 {Losers 8 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1D      X       1NT
+1C      1D      X       1N
 Pass    Pass    Pass    
 
 
@@ -3556,7 +3556,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      1D      X       3D
-Pass    Pass    3NT     4D
+Pass    Pass    3N     4D
 4S      Pass    Pass    Pass
 
 
@@ -3659,11 +3659,11 @@ Pass    Pass
 {HCP 14 4 12 10}
 {TP 14 6 12 11}
 {Losers 7 9 9 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1D      1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3892,12 +3892,12 @@ Pass    Pass
 {HCP 11 7 13 9}
 {TP 12 9 13 10}
 {Losers 8 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2NT     Pass    3C      Pass
-3H      Pass    3NT     Pass
+2N     Pass    3C      Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3914,11 +3914,11 @@ Pass    Pass
 {HCP 14 4 13 9}
 {TP 14 4 13 10}
 {Losers 7 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2D      X       Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3982,7 +3982,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      2H      2S      4H
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -4067,11 +4067,11 @@ Pass    Pass
 {HCP 14 7 11 8}
 {TP 14 8 13 11}
 {Losers 8 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2H      X       Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4109,11 +4109,11 @@ Pass    Pass
 {HCP 13 6 13 8}
 {TP 13 6 14 10}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      2D
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4176,7 +4176,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      2H      2S      3H
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -4257,12 +4257,12 @@ Pass    Pass
 {HCP 14 4 13 9}
 {TP 14 5 14 10}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2D      X       Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4368,7 +4368,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      1H      1S      2H
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 4H      Pass    4S      Pass
 Pass    Pass    
 
@@ -4452,10 +4452,10 @@ Pass    Pass
 {HCP 9 9 14 8}
 {TP 11 9 14 10}
 {Losers 7 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1H      X       1NT
+1C      1H      X       1N
 Pass    Pass    Pass    
 
 
@@ -4494,12 +4494,12 @@ Pass    Pass
 {HCP 13 7 11 9}
 {TP 16 8 13 10}
 {Losers 5 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1H      X       2H
 Pass    Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4539,11 +4539,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 9 13 10}
 {Losers 7 8 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4625,11 +4625,11 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 12 7 13 11}
 {Losers 8 10 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4690,12 +4690,12 @@ Pass    Pass
 {HCP 12 6 13 9}
 {TP 12 8 13 11}
 {Losers 9 7 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4712,12 +4712,12 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 7 15 10}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4778,11 +4778,11 @@ Pass    Pass    3S      Pass
 {HCP 15 5 12 8}
 {TP 15 5 13 9}
 {Losers 6 11 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2H      X       3H
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4843,11 +4843,11 @@ Pass    Pass
 {HCP 14 5 12 9}
 {TP 15 6 12 10}
 {Losers 7 9 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2D      2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4885,12 +4885,12 @@ Pass
 {HCP 12 7 13 8}
 {TP 13 9 13 9}
 {Losers 7 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      1H      1S      2H
 Pass    Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4933,7 +4933,7 @@ Pass    Pass    4S      Pass
 [Declarer "S"]
 [Auction "S"]
 1C      2D      X       4D
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    5S      Pass
 Pass    Pass    
 
@@ -4976,8 +4976,8 @@ Pass    Pass    Pass
 [Auction "S"]
 1D      1H      X       Pass
 2C      Pass    3D      Pass
-3H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+3H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -5015,11 +5015,11 @@ Pass    Pass    Pass
 {HCP 15 5 13 7}
 {TP 16 6 14 10}
 {Losers 7 9 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5057,11 +5057,11 @@ Pass    Pass
 {HCP 13 5 13 9}
 {TP 14 6 14 11}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5148,9 +5148,9 @@ Pass    Pass    X       Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1C      1H      1S      1NT
+1C      1H      1S      1N
 X       Pass    3S      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -5213,7 +5213,7 @@ Pass    3D      3H      4D
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      1H      X       1NT
+1D      1H      X       1N
 Pass    Pass    3D      Pass
 Pass    Pass    
 
@@ -5258,7 +5258,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 2D      Pass    4D      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -5280,7 +5280,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      2D      2H      3D
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -5298,11 +5298,11 @@ Pass    Pass    3NT     Pass
 {HCP 15 5 12 8}
 {TP 15 5 13 10}
 {Losers 7 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5386,11 +5386,11 @@ Pass    Pass    X       Pass
 {HCP 14 7 11 8}
 {TP 14 7 13 10}
 {Losers 7 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      3C
-Pass    3D      3NT     Pass
+Pass    3D      3N     Pass
 Pass    Pass    
 
 
@@ -5429,11 +5429,11 @@ Pass    Pass
 {HCP 15 2 14 9}
 {TP 17 3 14 10}
 {Losers 6 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2H      3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5475,7 +5475,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1D      Pass
 2D      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -5599,11 +5599,11 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 16 5 13 11}
 {Losers 5 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5663,12 +5663,12 @@ Pass    Pass    3S      Pass
 {HCP 14 3 13 10}
 {TP 14 4 13 11}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2H      2S      Pass
 3D      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5710,7 +5710,7 @@ Pass    Pass    3C      Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-Pass    Pass    1NT     Pass
+Pass    Pass    1N     Pass
 3D      Pass    4H      Pass
 Pass    Pass    
 
@@ -5749,12 +5749,12 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 15 7 13 10}
 {Losers 6 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      1S      2H
 Pass    Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5814,11 +5814,11 @@ Pass    Pass    4S      Pass
 {HCP 15 3 13 9}
 {TP 15 5 13 11}
 {Losers 8 9 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2H      X       Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5840,7 +5840,7 @@ Pass    Pass
 [Auction "S"]
 1C      1D      1H      Pass
 2C      Pass    2D      Pass
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 3D      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -5859,11 +5859,11 @@ Pass    Pass
 {HCP 14 6 12 8}
 {TP 14 7 12 11}
 {Losers 6 8 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2D      2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5945,11 +5945,11 @@ Pass    Pass
 {HCP 11 7 13 9}
 {TP 11 8 13 11}
 {Losers 8 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6031,11 +6031,11 @@ Pass    Pass
 {HCP 14 6 11 9}
 {TP 15 6 13 11}
 {Losers 7 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      X       2D
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6078,7 +6078,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 Pass    Pass    
 
 
@@ -6143,7 +6143,7 @@ Pass    Pass    Pass
 [Auction "S"]
 1C      1D      X       3D
 3S      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -6225,11 +6225,11 @@ Pass    Pass    X       Pass
 {HCP 12 8 12 8}
 {TP 14 8 12 10}
 {Losers 6 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2D      3D      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6250,7 +6250,7 @@ Pass    Pass    X       Pass
 [Declarer "S"]
 [Auction "S"]
 1C      2H      X       Pass
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 Pass    Pass    
 
 
@@ -6312,7 +6312,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      1H      1S      3H
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -6334,7 +6334,7 @@ Pass    Pass    3NT     Pass
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       2H
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -6417,12 +6417,12 @@ Pass    Pass
 {HCP 9 10 14 7}
 {TP 11 11 14 9}
 {Losers 7 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2H      X       3H
 Pass    Pass    X       Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6481,11 +6481,11 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 12 8 13 11}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6502,11 +6502,11 @@ Pass    Pass
 {HCP 13 6 13 8}
 {TP 13 7 13 10}
 {Losers 8 8 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6566,11 +6566,11 @@ Pass    Pass    X       Pass
 {HCP 10 6 14 10}
 {TP 10 7 14 11}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1D      1H      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6696,10 +6696,10 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    2H      Pass
-2NT     Pass    4H      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6C      Pass
+1N     Pass    2H      Pass
+2N     Pass    4H      Pass
+4N     Pass    5S      Pass
+5N     Pass    6C      Pass
 6D      Pass    Pass    Pass
 
 
@@ -6763,7 +6763,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      3D
-3H      4D      4NT     Pass
+3H      4D      4N     Pass
 5H      Pass    6H      Pass
 Pass    Pass    
 
@@ -6804,11 +6804,11 @@ X       Pass    4C      Pass
 {HCP 16 0 14 10}
 {TP 18 1 15 10}
 {Losers 5 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6825,11 +6825,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 14 9 12 10}
 {Losers 7 8 9 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2D      X       Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6850,7 +6850,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      3D
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -6868,11 +6868,11 @@ Pass    Pass    3NT     Pass
 {HCP 7 10 13 10}
 {TP 9 11 14 11}
 {Losers 8 8 6 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -6911,12 +6911,12 @@ X       Pass    3S      Pass
 {HCP 11 8 13 8}
 {TP 13 8 14 10}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1D      1H      1S      1NT
+1D      1H      1S      1N
 2C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6977,12 +6977,12 @@ Pass    Pass    3S      Pass
 {HCP 12 6 13 9}
 {TP 14 7 15 11}
 {Losers 7 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
 2C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6999,13 +6999,13 @@ Pass    Pass    3S      Pass
 {HCP 14 3 14 9}
 {TP 14 4 15 11}
 {Losers 7 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      Pass
 1S      Pass    2D      Pass
-2H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7155,7 +7155,7 @@ Pass    Pass    4D      Pass
 [Auction "S"]
 Pass    Pass    1D      Pass
 1H      Pass    1S      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -7263,7 +7263,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -7303,11 +7303,11 @@ Pass    Pass    X       Pass
 {HCP 15 5 12 8}
 {TP 15 5 15 11}
 {Losers 5 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1H      X       Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7330,7 +7330,7 @@ Pass    Pass
 1C      Pass    1H      Pass
 2H      Pass    2S      Pass
 3S      Pass    4H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 Pass    Pass    
 
 
@@ -7351,8 +7351,8 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      2H      2S      4H
-4S      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5S      Pass    5N     Pass
 6D      Pass    6S      Pass
 Pass    Pass    
 
@@ -7434,12 +7434,12 @@ Pass    Pass
 {HCP 16 4 12 8}
 {TP 16 5 12 10}
 {Losers 6 10 9 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2D      X       Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7544,7 +7544,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      1H      1S      3D
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5H      Pass    5S      Pass
 Pass    Pass    
 
@@ -7667,11 +7667,11 @@ Pass    Pass
 {HCP 12 7 12 9}
 {TP 13 8 12 10}
 {Losers 8 9 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -7711,12 +7711,12 @@ Pass    Pass    X       Pass
 {HCP 11 7 13 9}
 {TP 13 7 15 11}
 {Losers 7 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1H      1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7737,7 +7737,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      2H      2S      4H
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -7799,12 +7799,12 @@ Pass    Pass
 {HCP 16 6 11 7}
 {TP 17 8 13 9}
 {Losers 6 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2D      X       Pass
 3C      Pass    3D      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7821,11 +7821,11 @@ Pass    Pass
 {HCP 11 7 13 9}
 {TP 11 9 13 11}
 {Losers 9 8 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2H      X       Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7925,11 +7925,11 @@ Pass    Pass
 {HCP 10 9 14 7}
 {TP 11 9 15 9}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2H      2S      3H
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7967,12 +7967,12 @@ Pass    Pass
 {HCP 16 2 14 8}
 {TP 17 2 14 10}
 {Losers 6 11 8 8}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2D      X       Pass
 3C      Pass    3D      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -7989,10 +7989,10 @@ Pass    Pass
 {HCP 10 9 12 9}
 {TP 11 10 12 10}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1H      X       1NT
+1D      1H      X       1N
 Pass    Pass    Pass    
 
 
@@ -8035,7 +8035,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8053,11 +8053,11 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 13 9 12 10}
 {Losers 8 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8074,10 +8074,10 @@ Pass    Pass
 {HCP 9 10 12 9}
 {TP 10 11 12 11}
 {Losers 9 8 6 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1H      1S      1NT
+1C      1H      1S      1N
 Pass    Pass    Pass    
 
 
@@ -8162,9 +8162,9 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 3H      Pass    3S      Pass
-3NT     Pass    6S      Pass
+3N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -8250,7 +8250,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2H      3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -8273,7 +8273,7 @@ Pass    Pass
 [Auction "S"]
 1C      1D      1H      2D
 2H      Pass    2S      Pass
-2NT     Pass    3H      Pass
+2N     Pass    3H      Pass
 Pass    Pass    
 
 
@@ -8419,11 +8419,11 @@ Pass
 {HCP 12 6 12 10}
 {TP 12 8 13 11}
 {Losers 8 8 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8444,7 +8444,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1C      1H      1S      Pass
-1NT     Pass    3S      Pass
+1N     Pass    3S      Pass
 Pass    Pass    
 
 
@@ -8461,11 +8461,11 @@ Pass    Pass
 {HCP 18 1 12 9}
 {TP 18 3 12 11}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8482,11 +8482,11 @@ Pass    Pass
 {HCP 15 6 11 8}
 {TP 16 7 13 11}
 {Losers 5 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2D      2H      Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8507,7 +8507,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      1H      1S      3H
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 4C      Pass    4D      Pass
 5D      Pass    Pass    Pass
 
@@ -8551,7 +8551,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      1D      1H      3D
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -8573,7 +8573,7 @@ Pass    Pass    3NT     Pass
 [Declarer "N"]
 [Auction "S"]
 1D      2H      2S      4H
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -8613,12 +8613,12 @@ X       Pass    Pass    Pass
 {HCP 13 5 14 8}
 {TP 15 5 14 9}
 {Losers 6 11 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       3H
 Pass    Pass    X       Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8656,12 +8656,12 @@ Pass    Pass
 {HCP 13 6 14 7}
 {TP 13 8 15 9}
 {Losers 7 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2D      2H      Pass
 2S      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8742,11 +8742,11 @@ Pass    Pass
 {HCP 13 5 13 9}
 {TP 13 7 13 11}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8785,11 +8785,11 @@ Pass    Pass    X       Pass
 {HCP 16 3 12 9}
 {TP 17 5 12 11}
 {Losers 6 9 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8828,11 +8828,11 @@ Pass    Pass
 {HCP 11 10 12 7}
 {TP 12 10 12 9}
 {Losers 8 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8892,11 +8892,11 @@ Pass    Pass
 {HCP 14 7 11 8}
 {TP 14 7 13 10}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      1H      X       2H
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8913,11 +8913,11 @@ Pass    Pass
 {HCP 12 9 12 7}
 {TP 12 10 13 9}
 {Losers 8 8 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8977,12 +8977,12 @@ Pass    Pass    3S      Pass
 {HCP 13 5 13 9}
 {TP 15 5 15 10}
 {Losers 6 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9091,8 +9091,8 @@ Pass    Pass
 2S      Pass    3C      3H
 3S      Pass    4C      Pass
 4D      Pass    4H      Pass
-4NT     Pass    5C      Pass
-5D      Pass    5NT     Pass
+4N     Pass    5C      Pass
+5D      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -9110,12 +9110,12 @@ Pass    Pass
 {HCP 11 10 12 7}
 {TP 12 11 13 10}
 {Losers 8 8 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2NT     Pass    3H      X
-3NT     Pass    Pass    Pass
+2N     Pass    3H      X
+3N     Pass    Pass    Pass
 
 
 
@@ -9132,10 +9132,10 @@ Pass    Pass
 {HCP 9 9 13 9}
 {TP 11 10 14 10}
 {Losers 7 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1D      1H      1NT
+1C      1D      1H      1N
 Pass    Pass    Pass    
 
 
@@ -9173,11 +9173,11 @@ Pass    Pass
 {HCP 11 7 14 8}
 {TP 11 9 15 9}
 {Losers 9 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2H      X       Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9199,7 +9199,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    1S      Pass
 2S      Pass    3H      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -9238,11 +9238,11 @@ Pass    Pass    X       Pass
 {HCP 17 2 12 9}
 {TP 17 3 13 11}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9431,12 +9431,12 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 15 8 14 9}
 {Losers 6 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1S      Pass
 2C      Pass    2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9497,12 +9497,12 @@ Pass    Pass
 {HCP 13 6 13 8}
 {TP 14 6 13 10}
 {Losers 6 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2H      3D      3H
 Pass    Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9523,7 +9523,7 @@ Pass    Pass    3S      Pass
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1S      3C
-3S      4D      4NT     Pass
+3S      4D      4N     Pass
 5D      Pass    5S      Pass
 Pass    Pass    
 
@@ -9650,12 +9650,12 @@ Pass    Pass
 {HCP 16 4 13 7}
 {TP 19 6 14 9}
 {Losers 4 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2H      2S      Pass
 3C      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9780,11 +9780,11 @@ Pass    Pass
 {HCP 9 10 13 8}
 {TP 10 10 13 10}
 {Losers 9 8 7 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -9807,8 +9807,8 @@ Pass    Pass
 1D      2H      2S      3H
 3S      Pass    4C      Pass
 4D      Pass    4S      Pass
-4NT     Pass    5C      Pass
-5D      Pass    5NT     Pass
+4N     Pass    5C      Pass
+5D      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -9830,7 +9830,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      2D      X       4D
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    5S      Pass
 Pass    Pass    
 
@@ -9891,12 +9891,12 @@ Pass
 {HCP 16 3 13 8}
 {TP 17 5 13 10}
 {Losers 5 9 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9979,12 +9979,12 @@ Pass    Pass
 {HCP 15 5 12 8}
 {TP 16 5 15 10}
 {Losers 6 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1H      Pass
 1S      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10127,11 +10127,11 @@ Pass    Pass
 {HCP 15 4 13 8}
 {TP 15 5 14 10}
 {Losers 6 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10148,11 +10148,11 @@ Pass    Pass
 {HCP 13 9 12 6}
 {TP 13 10 12 9}
 {Losers 8 8 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10192,7 +10192,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1C      1H      X       1NT
+1C      1H      X       1N
 2S      Pass    Pass    Pass
 
 
@@ -10235,7 +10235,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1C      1H      X       1NT
+1C      1H      X       1N
 2S      Pass    Pass    Pass
 
 
@@ -10257,7 +10257,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      2H      X       Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -10275,11 +10275,11 @@ Pass    Pass    Pass
 {HCP 13 5 12 10}
 {TP 13 5 12 11}
 {Losers 8 10 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10386,7 +10386,7 @@ Pass    Pass    3D      Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1D      1H      X       1NT
+1D      1H      X       1N
 2S      Pass    Pass    Pass
 
 
@@ -10471,11 +10471,11 @@ Pass    Pass
 {HCP 8 9 14 9}
 {TP 9 10 14 9}
 {Losers 9 8 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2H      X       Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -10534,12 +10534,12 @@ Pass    Pass
 {HCP 12 7 14 7}
 {TP 12 8 14 9}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1S      Pass
-1NT     Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10621,11 +10621,11 @@ Pass    Pass
 {HCP 16 3 14 7}
 {TP 16 3 14 9}
 {Losers 6 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    1H      Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10642,11 +10642,11 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 15 6 15 9}
 {Losers 5 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2H      2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10689,7 +10689,7 @@ Pass    Pass
 [Auction "S"]
 1C      2D      2H      3D
 3H      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -10728,11 +10728,11 @@ Pass    Pass
 {HCP 14 2 14 10}
 {TP 14 3 14 11}
 {Losers 8 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 

--- a/GIB/GIB_Exit_Transfers.pbn
+++ b/GIB/GIB_Exit_Transfers.pbn
@@ -15,7 +15,7 @@
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -35,7 +35,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -56,7 +56,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -77,7 +77,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      X       Pass    3C
 Pass    Pass    Pass    
 
@@ -98,7 +98,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       Pass    2H
+1N     X       Pass    2H
 Pass    Pass    Pass    
 
 
@@ -118,7 +118,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       Pass    2C
+1N     X       Pass    2C
 Pass    Pass    2H      Pass
 Pass    2S      Pass    Pass
 Pass    
@@ -140,7 +140,7 @@ Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2C
+1N     X       XX      2C
 Pass    Pass    Pass    
 
 
@@ -157,10 +157,10 @@ Pass    Pass    Pass
 {HCP 3 5 16 16}
 {TP 4 5 16 16}
 {Losers 10 10 7 7}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -177,10 +177,10 @@ Pass
 {HCP 7 0 15 18}
 {TP 10 0 15 21}
 {Losers 7 12 8 3}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -200,7 +200,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -217,10 +217,10 @@ Pass    Pass    Pass
 {HCP 1 8 15 16}
 {TP 2 8 15 16}
 {Losers 11 8 8 7}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -240,9 +240,9 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    3D
-Pass    3S      Pass    3NT
+Pass    3S      Pass    3N
 Pass    4S      Pass    Pass
 Pass    
 
@@ -263,7 +263,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -284,7 +284,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       Pass    2S
+1N     X       Pass    2S
 Pass    Pass    Pass    
 
 
@@ -304,7 +304,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -325,7 +325,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -346,7 +346,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
 Pass    3D      Pass    3S
 Pass    4S      Pass    Pass
@@ -369,7 +369,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -390,7 +390,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       Pass    2S
+1N     X       Pass    2S
 Pass    Pass    Pass    
 
 
@@ -410,7 +410,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -431,7 +431,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       Pass    2S
+1N     X       Pass    2S
 Pass    Pass    Pass    
 
 
@@ -451,7 +451,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -472,7 +472,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       2H      2S
+1N     X       2H      2S
 X       3H      Pass    4H
 Pass    Pass    Pass    
 
@@ -490,10 +490,10 @@ Pass    Pass    Pass
 {HCP 2 5 16 17}
 {TP 3 5 16 17}
 {Losers 10 10 7 8}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -513,7 +513,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -533,7 +533,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       Pass    2D
+1N     X       Pass    2D
 Pass    3S      Pass    Pass
 Pass    
 
@@ -551,10 +551,10 @@ Pass
 {HCP 2 7 15 16}
 {TP 3 9 16 16}
 {Losers 11 7 7 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -571,10 +571,10 @@ Pass
 {HCP 6 2 15 17}
 {TP 7 2 15 17}
 {Losers 9 11 7 6}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -594,7 +594,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -614,7 +614,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -632,12 +632,12 @@ Pass    Pass    Pass
 {HCP 5 2 15 18}
 {TP 6 3 15 18}
 {Losers 9 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    2C
+1N     X       Pass    2C
 Pass    Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -657,7 +657,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    Pass    Pass    
 
 
@@ -677,8 +677,8 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       2D      2H
-Pass    2NT     Pass    3S
+1N     X       2D      2H
+Pass    2N     Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -699,7 +699,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2D
 Pass    2H      Pass    Pass
 Pass    
@@ -721,7 +721,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       Pass    2S
+1N     X       Pass    2S
 Pass    Pass    Pass    
 
 
@@ -741,7 +741,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -762,7 +762,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -780,10 +780,10 @@ Pass    Pass    Pass
 {HCP 4 5 15 16}
 {TP 5 5 15 16}
 {Losers 10 10 7 7}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -803,7 +803,7 @@ Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       Pass    2H
+1N     X       Pass    2H
 Pass    Pass    2S      Pass
 Pass    3H      Pass    Pass
 Pass    
@@ -825,7 +825,7 @@ Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       Pass    2C
+1N     X       Pass    2C
 Pass    2D      Pass    Pass
 Pass    
 
@@ -843,10 +843,10 @@ Pass
 {HCP 5 3 15 17}
 {TP 6 4 15 17}
 {Losers 10 10 7 6}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -866,7 +866,7 @@ Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -887,7 +887,7 @@ Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       Pass    2C
+1N     X       Pass    2C
 Pass    Pass    Pass    
 
 
@@ -907,7 +907,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -928,7 +928,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2S
 Pass    3C      Pass    4S
 Pass    Pass    Pass    
@@ -947,10 +947,10 @@ Pass    Pass    Pass
 {HCP 5 3 16 16}
 {TP 5 4 16 16}
 {Losers 9 10 6 7}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -970,7 +970,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2H
 Pass    4H      Pass    Pass
 Pass    
@@ -989,10 +989,10 @@ Pass
 {HCP 0 8 16 16}
 {TP 1 8 17 17}
 {Losers 11 9 6 5}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1012,7 +1012,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      3H      Pass    Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -1034,7 +1034,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -1052,10 +1052,10 @@ Pass    Pass
 {HCP 2 7 15 16}
 {TP 4 8 16 16}
 {Losers 10 8 6 7}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1075,7 +1075,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -1096,7 +1096,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
 Pass    4S      Pass    Pass
 Pass    
@@ -1115,12 +1115,12 @@ Pass
 {HCP 8 1 15 16}
 {TP 9 3 15 16}
 {Losers 7 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    2S
+1N     X       Pass    2S
 Pass    Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1137,10 +1137,10 @@ Pass    Pass    3D      Pass
 {HCP 6 3 15 16}
 {TP 7 3 15 16}
 {Losers 9 11 7 7}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1160,7 +1160,7 @@ Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       Pass    2D
+1N     X       Pass    2D
 Pass    Pass    Pass    
 
 
@@ -1180,7 +1180,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1198,10 +1198,10 @@ Pass    Pass    Pass
 {HCP 7 0 17 16}
 {TP 7 1 17 16}
 {Losers 9 11 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1221,7 +1221,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2H
 Pass    Pass    Pass    
 
@@ -1239,10 +1239,10 @@ Pass    Pass    Pass
 {HCP 7 1 15 17}
 {TP 7 2 15 17}
 {Losers 9 11 6 7}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1262,7 +1262,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    2S
 Pass    4S      Pass    Pass
 Pass    
@@ -1284,7 +1284,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -1304,7 +1304,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       Pass    2D
+1N     X       Pass    2D
 Pass    Pass    2H      Pass
 Pass    Pass    
 
@@ -1325,7 +1325,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       Pass    2D
+1N     X       Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -1343,10 +1343,10 @@ Pass
 {HCP 3 5 15 17}
 {TP 4 5 15 17}
 {Losers 10 11 6 6}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1363,10 +1363,10 @@ Pass
 {HCP 4 4 16 16}
 {TP 6 6 17 16}
 {Losers 9 9 6 6}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1386,7 +1386,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1404,12 +1404,12 @@ Pass
 {HCP 0 7 15 18}
 {TP 2 8 16 19}
 {Losers 10 8 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    3C
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1426,10 +1426,10 @@ Pass
 {HCP 3 6 15 16}
 {TP 5 9 15 16}
 {Losers 9 7 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1449,7 +1449,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1470,7 +1470,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1491,7 +1491,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1512,7 +1512,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1530,10 +1530,10 @@ Pass
 {HCP 3 6 15 16}
 {TP 4 6 15 16}
 {Losers 10 9 7 7}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1553,7 +1553,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1571,10 +1571,10 @@ Pass
 {HCP 3 5 15 17}
 {TP 3 6 16 17}
 {Losers 11 9 6 6}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1591,10 +1591,10 @@ Pass
 {HCP 4 1 15 20}
 {TP 5 2 15 20}
 {Losers 10 11 7 5}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1614,7 +1614,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1635,7 +1635,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1656,7 +1656,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1677,7 +1677,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       Pass    2S
+1N     X       Pass    2S
 Pass    Pass    Pass    
 
 
@@ -1694,10 +1694,10 @@ Pass    Pass    Pass
 {HCP 4 5 15 16}
 {TP 6 7 15 16}
 {Losers 9 9 7 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1717,7 +1717,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       2H      2S
+1N     X       2H      2S
 X       3H      Pass    4H
 Pass    Pass    Pass    
 
@@ -1738,7 +1738,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       Pass    2D
+1N     X       Pass    2D
 Pass    Pass    Pass    
 
 
@@ -1755,10 +1755,10 @@ Pass    Pass    Pass
 {HCP 0 5 16 19}
 {TP 1 7 17 19}
 {Losers 11 9 6 6}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1778,7 +1778,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -1798,7 +1798,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2D
 Pass    2H      Pass    Pass
 Pass    
@@ -1820,7 +1820,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1841,7 +1841,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1862,7 +1862,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -1883,7 +1883,7 @@ Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -1904,7 +1904,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2D
 Pass    2S      Pass    Pass
 Pass    
@@ -1926,7 +1926,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1947,7 +1947,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -1964,10 +1964,10 @@ Pass    Pass    Pass
 {HCP 3 6 15 16}
 {TP 4 8 16 16}
 {Losers 10 8 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1987,7 +1987,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       Pass    2H
+1N     X       Pass    2H
 Pass    Pass    2S      Pass
 Pass    Pass    
 
@@ -2005,10 +2005,10 @@ Pass    Pass
 {HCP 5 4 15 16}
 {TP 5 5 15 16}
 {Losers 10 10 6 6}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -2025,10 +2025,10 @@ Pass
 {HCP 3 5 15 17}
 {TP 3 6 15 17}
 {Losers 11 9 7 8}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -2045,10 +2045,10 @@ Pass
 {HCP 3 6 15 16}
 {TP 5 6 16 16}
 {Losers 9 10 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2065,11 +2065,11 @@ Pass
 {HCP 0 6 16 18}
 {TP 2 7 16 18}
 {Losers 10 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
-Pass    3C      Pass    3NT
+Pass    3C      Pass    3N
 Pass    Pass    Pass    
 

--- a/GIB/GIB_GSF_after_Preempt
+++ b/GIB/GIB_GSF_after_Preempt
@@ -15,7 +15,7 @@
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -36,7 +36,7 @@
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-3H      Pass    4NT     Pass
+3H      Pass    4N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -54,12 +54,12 @@
 {HCP 29 0 8 3}
 {TP 29 2 8 3}
 {Losers 5 10 8 11}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -79,7 +79,7 @@ Pass    Pass    2C      Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -97,12 +97,12 @@ Pass    Pass    2C      Pass
 {HCP 31 2 7 0}
 {TP 31 3 8 3}
 {Losers 4 10 8 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -122,7 +122,7 @@ Pass    Pass    2C      Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -161,11 +161,11 @@ Pass    Pass
 {HCP 31 2 7 0}
 {TP 31 4 10 0}
 {Losers 4 9 6 12}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2H      Pass    7NT     Pass
+2H      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -185,7 +185,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -206,7 +206,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -227,7 +227,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -248,7 +248,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-3S      Pass    5NT     Pass
+3S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -269,7 +269,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -287,11 +287,11 @@ Pass    Pass
 {HCP 30 0 7 3}
 {TP 30 0 10 5}
 {Losers 4 12 6 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-3D      Pass    7NT     Pass
+3D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -311,7 +311,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-3H      Pass    5NT     Pass
+3H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -332,7 +332,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -353,7 +353,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -374,7 +374,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -392,11 +392,11 @@ Pass    Pass
 {HCP 30 2 8 0}
 {TP 30 4 10 2}
 {Losers 4 9 7 10}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2H      Pass    7NT     Pass
+2H      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -416,7 +416,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -434,11 +434,11 @@ Pass    Pass
 {HCP 29 3 8 0}
 {TP 29 5 13 2}
 {Losers 4 9 4 10}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2H      Pass    7NT     Pass
+2H      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -458,7 +458,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-4H      Pass    5NT     Pass
+4H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -479,7 +479,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -497,11 +497,11 @@ Pass    Pass
 {HCP 29 0 7 4}
 {TP 29 1 10 5}
 {Losers 5 11 6 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2H      Pass    7NT     Pass
+2H      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -521,7 +521,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -542,7 +542,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-3D      Pass    5NT     Pass
+3D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -560,12 +560,12 @@ Pass    Pass
 {HCP 29 0 7 4}
 {TP 29 1 9 5}
 {Losers 5 11 7 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -585,7 +585,7 @@ Pass    Pass    2C      Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -603,12 +603,12 @@ Pass    Pass    2C      Pass
 {HCP 29 2 7 2}
 {TP 29 2 9 4}
 {Losers 5 11 7 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -625,11 +625,11 @@ Pass    Pass    2C      Pass
 {HCP 29 2 9 0}
 {TP 29 5 12 0}
 {Losers 5 8 5 12}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-3D      Pass    7NT     Pass
+3D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -649,7 +649,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -667,11 +667,11 @@ Pass    Pass
 {HCP 29 4 7 0}
 {TP 29 6 10 1}
 {Losers 5 8 6 11}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-3D      Pass    7NT     Pass
+3D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -688,11 +688,11 @@ Pass    Pass
 {HCP 29 0 9 2}
 {TP 29 2 11 5}
 {Losers 5 10 6 8}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2H      Pass    7NT     Pass
+2H      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -709,12 +709,12 @@ Pass    Pass
 {HCP 31 2 7 0}
 {TP 31 2 9 3}
 {Losers 4 11 7 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    5NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    5N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -734,7 +734,7 @@ Pass    Pass    2C      Pass
 [Contract "7C"]
 [Declarer "S"]
 [Auction "S"]
-3C      Pass    5NT     Pass
+3C      Pass    5N     Pass
 7C      Pass    Pass    Pass
 
 
@@ -755,7 +755,7 @@ Pass    Pass    2C      Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -797,7 +797,7 @@ Pass    Pass
 [Contract "7C"]
 [Declarer "S"]
 [Auction "S"]
-3C      Pass    5NT     Pass
+3C      Pass    5N     Pass
 7C      Pass    Pass    Pass
 
 
@@ -839,7 +839,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -877,11 +877,11 @@ Pass    Pass
 {HCP 29 0 9 2}
 {TP 29 2 11 5}
 {Losers 5 10 6 8}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-3D      Pass    7NT     Pass
+3D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -901,7 +901,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -922,7 +922,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -943,8 +943,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-3S      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+3S      Pass    4N     Pass
+5D      Pass    5N     Pass
 6H      Pass    7S      Pass
 Pass    Pass    
 
@@ -965,7 +965,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1007,7 +1007,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -1025,11 +1025,11 @@ Pass    Pass
 {HCP 29 2 7 2}
 {TP 29 4 11 7}
 {Losers 5 9 5 6}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-3D      Pass    7NT     Pass
+3D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1049,7 +1049,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -1070,7 +1070,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -1091,7 +1091,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-3D      Pass    5NT     Pass
+3D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -1112,7 +1112,7 @@ Pass    Pass
 [Contract "7C"]
 [Declarer "S"]
 [Auction "S"]
-3C      Pass    5NT     Pass
+3C      Pass    5N     Pass
 7C      Pass    Pass    Pass
 
 
@@ -1133,7 +1133,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -1151,11 +1151,11 @@ Pass    Pass
 {HCP 29 0 7 4}
 {TP 29 3 9 7}
 {Losers 5 9 7 7}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-3D      Pass    7NT     Pass
+3D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1172,12 +1172,12 @@ Pass    Pass
 {HCP 29 0 7 4}
 {TP 29 1 8 6}
 {Losers 5 11 8 8}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -1218,7 +1218,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-3D      Pass    5NT     Pass
+3D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -1236,11 +1236,11 @@ Pass    Pass
 {HCP 29 2 7 2}
 {TP 29 4 11 3}
 {Losers 5 9 5 10}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-3D      Pass    7NT     Pass
+3D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1257,12 +1257,12 @@ Pass    Pass
 {HCP 29 3 8 0}
 {TP 29 4 8 2}
 {Losers 5 10 8 10}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -1279,12 +1279,12 @@ Pass    Pass    2C      Pass
 {HCP 29 2 7 2}
 {TP 29 5 8 3}
 {Losers 5 8 8 10}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -1301,12 +1301,12 @@ Pass    Pass    2C      Pass
 {HCP 29 2 7 2}
 {TP 29 3 9 5}
 {Losers 5 10 7 8}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -1323,11 +1323,11 @@ Pass    Pass    2C      Pass
 {HCP 30 3 7 0}
 {TP 30 5 8 3}
 {Losers 4 9 8 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2H      Pass    7NT     Pass
+2H      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1347,7 +1347,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1365,11 +1365,11 @@ Pass    Pass
 {HCP 29 2 7 2}
 {TP 29 3 10 3}
 {Losers 5 10 6 10}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-3D      Pass    7NT     Pass
+3D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1386,12 +1386,12 @@ Pass    Pass
 {HCP 30 2 8 0}
 {TP 30 4 11 3}
 {Losers 4 9 6 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -1411,7 +1411,7 @@ Pass    Pass    2C      Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1432,8 +1432,8 @@ Pass    Pass    2C      Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-3S      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+3S      Pass    4N     Pass
+5D      Pass    5N     Pass
 6S      Pass    7S      Pass
 Pass    Pass    
 
@@ -1451,11 +1451,11 @@ Pass    Pass
 {HCP 30 2 8 0}
 {TP 30 3 10 2}
 {Losers 4 10 7 10}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2H      Pass    7NT     Pass
+2H      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1475,7 +1475,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 6C      Pass    7S      Pass
 Pass    Pass    
 
@@ -1493,11 +1493,11 @@ Pass    Pass
 {HCP 29 0 7 4}
 {TP 29 1 9 6}
 {Losers 5 11 7 8}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2H      Pass    7NT     Pass
+2H      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1514,11 +1514,11 @@ Pass    Pass
 {HCP 29 0 8 3}
 {TP 29 2 12 6}
 {Losers 4 10 5 8}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-3D      Pass    7NT     Pass
+3D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1538,7 +1538,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-3H      Pass    5NT     Pass
+3H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1559,7 +1559,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1580,7 +1580,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-4H      Pass    5NT     Pass
+4H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1622,7 +1622,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1643,7 +1643,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-4S      Pass    5NT     Pass
+4S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1664,7 +1664,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-3H      Pass    5NT     Pass
+3H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1685,7 +1685,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -1703,12 +1703,12 @@ Pass    Pass
 {HCP 29 2 7 2}
 {TP 29 3 9 4}
 {Losers 5 10 7 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -1728,7 +1728,7 @@ Pass    Pass    2C      Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-3S      Pass    5NT     Pass
+3S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1749,7 +1749,7 @@ Pass    Pass    2C      Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1767,11 +1767,11 @@ Pass    Pass    2C      Pass
 {HCP 29 4 7 0}
 {TP 29 6 12 2}
 {Losers 5 8 4 10}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2H      Pass    7NT     Pass
+2H      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1791,7 +1791,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-3H      Pass    5NT     Pass
+3H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1809,11 +1809,11 @@ Pass    Pass
 {HCP 29 0 9 2}
 {TP 29 3 12 4}
 {Losers 5 9 5 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-3C      Pass    7NT     Pass
+3C      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1833,7 +1833,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1854,7 +1854,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1893,12 +1893,12 @@ Pass    Pass
 {HCP 30 0 7 3}
 {TP 30 2 10 4}
 {Losers 4 10 6 10}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -1915,11 +1915,11 @@ Pass    Pass    2C      Pass
 {HCP 30 0 7 3}
 {TP 30 2 9 6}
 {Losers 4 10 7 8}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2S      Pass    7NT     Pass
+2S      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1939,7 +1939,7 @@ Pass    Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-2D      Pass    5NT     Pass
+2D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 
@@ -1960,7 +1960,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-4H      Pass    5NT     Pass
+4H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1981,7 +1981,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -2002,7 +2002,7 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -2023,7 +2023,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    5NT     Pass
+2H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -2041,12 +2041,12 @@ Pass    Pass
 {HCP 29 2 7 2}
 {TP 29 4 8 5}
 {Losers 5 9 8 8}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -2066,7 +2066,7 @@ Pass    Pass    2C      Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    5NT     Pass
+2S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -2084,12 +2084,12 @@ Pass    Pass    2C      Pass
 {HCP 29 0 7 4}
 {TP 29 2 9 5}
 {Losers 5 10 7 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 Pass    Pass    2C      Pass
-2D      Pass    4NT     Pass
-7NT     Pass    Pass    Pass
+2D      Pass    4N     Pass
+7N     Pass    Pass    Pass
 
 
 
@@ -2109,7 +2109,7 @@ Pass    Pass    2C      Pass
 [Contract "7D"]
 [Declarer "S"]
 [Auction "S"]
-3D      Pass    5NT     Pass
+3D      Pass    5N     Pass
 7D      Pass    Pass    Pass
 
 

--- a/GIB/GIB_GSF_by_Opener.pbn
+++ b/GIB/GIB_GSF_by_Opener.pbn
@@ -15,8 +15,8 @@
 [Contract "6S"]
 [Declarer "N"]
 [Auction "N"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -37,8 +37,8 @@
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4H      Pass    4NT     Pass
+1S      Pass    2N     Pass
+4H      Pass    4N     Pass
 5D      Pass    5H      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -60,9 +60,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "N"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3H      Pass    4H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -82,9 +82,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
-4NT     Pass    5H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -106,7 +106,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 5C      Pass    5H      Pass
 7C      Pass    Pass    Pass
 
@@ -129,7 +129,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 5C      Pass    5H      Pass
 6C      Pass    Pass    Pass
 
@@ -152,7 +152,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -173,8 +173,8 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "N"]
 [Auction "N"]
-1H      Pass    2NT     Pass
-3NT     Pass    4NT     Pass
+1H      Pass    2N     Pass
+3N     Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    Pass    Pass
 
@@ -196,8 +196,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -218,8 +218,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -241,8 +241,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -263,9 +263,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    3H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -285,9 +285,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "N"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3H      Pass    4H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -307,8 +307,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "N"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -350,9 +350,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    3S      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -394,8 +394,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -416,8 +416,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "N"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -459,8 +459,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -481,9 +481,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3H      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+1H      Pass    2N     Pass
+3H      Pass    4N     Pass
+5D      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -526,8 +526,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -548,8 +548,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -571,7 +571,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -591,8 +591,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4C      Pass    4NT     Pass
+1S      Pass    2N     Pass
+4C      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -613,8 +613,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -635,7 +635,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3D      Pass    3S      Pass
 4C      Pass    5C      Pass
 5D      Pass    6S      Pass
@@ -659,7 +659,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -679,8 +679,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -702,8 +702,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -725,8 +725,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5D      Pass    5H      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -748,9 +748,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
-4NT     Pass    5H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -771,9 +771,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 3C      Pass    4H      Pass
-5NT     Pass    6H      Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -793,8 +793,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -815,9 +815,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
-4NT     Pass    5H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -838,10 +838,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+1S      Pass    2N     Pass
+3D      Pass    3N     Pass
 4C      Pass    4S      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -861,10 +861,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3D      Pass    3H      Pass
 4C      Pass    4H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -885,8 +885,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6S      Pass
 Pass    Pass    
@@ -909,7 +909,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -930,8 +930,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3NT     Pass    4NT     Pass
+1H      Pass    2N     Pass
+3N     Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -953,8 +953,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -977,8 +977,8 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    2C      Pass
 2D      Pass    2H      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5C      Pass
+5N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -998,8 +998,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3NT     Pass    4NT     Pass
+1H      Pass    2N     Pass
+3N     Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -1021,9 +1021,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3D      Pass    3S      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -1043,8 +1043,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -1066,9 +1066,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4H      Pass    4S      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -1088,9 +1088,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3D      Pass    3S      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -1110,8 +1110,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3H      Pass    4NT     Pass
+1H      Pass    2N     Pass
+3H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -1133,8 +1133,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -1156,9 +1156,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 3D      Pass    4H      Pass
-5NT     Pass    6H      Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -1178,8 +1178,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -1200,8 +1200,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3H      Pass    4NT     Pass
+1H      Pass    2N     Pass
+3H      Pass    4N     Pass
 5D      Pass    5S      Pass
 6H      Pass    Pass    Pass
 
@@ -1223,9 +1223,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 3C      Pass    3H      Pass
-5NT     Pass    6H      Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -1245,8 +1245,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -1268,9 +1268,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-4D      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+1H      Pass    2N     Pass
+4D      Pass    4N     Pass
+5D      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -1291,10 +1291,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3H      Pass    4NT     Pass
+1H      Pass    2N     Pass
+3H      Pass    4N     Pass
 5D      Pass    5S      Pass
-5NT     Pass    6H      Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -1315,7 +1315,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4C      Pass    4NT     Pass
+4C      Pass    4N     Pass
 5C      Pass    5H      Pass
 6D      Pass    Pass    Pass
 
@@ -1337,8 +1337,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -1359,10 +1359,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6C      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
+4N     Pass    5H      Pass
+5N     Pass    6C      Pass
 6S      Pass    Pass    Pass
 
 
@@ -1383,8 +1383,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -1406,9 +1406,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3D      Pass    3H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -1428,8 +1428,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -1451,8 +1451,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3H      Pass    4NT     Pass
+1H      Pass    2N     Pass
+3H      Pass    4N     Pass
 5D      Pass    5S      Pass
 6H      Pass    Pass    Pass
 
@@ -1474,8 +1474,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -1496,8 +1496,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -1515,11 +1515,11 @@ Pass    Pass
 {HCP 14 3 19 4}
 {TP 14 4 19 5}
 {Losers 7 10 6 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2D      3D      Pass
-6NT     Pass    Pass    Pass
+6N     Pass    Pass    Pass
 
 
 
@@ -1539,10 +1539,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 3D      Pass    3S      Pass
-4S      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5C      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -1563,7 +1563,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3D      Pass    3H      Pass
 6S      Pass    Pass    Pass
 
@@ -1585,9 +1585,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    3H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -1607,9 +1607,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
-4NT     Pass    5H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -1630,8 +1630,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3NT     Pass    4NT     Pass
+1H      Pass    2N     Pass
+3N     Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -1653,8 +1653,8 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3H      Pass    4NT     Pass
+1H      Pass    2N     Pass
+3H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    Pass    Pass
 
@@ -1676,8 +1676,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3NT     Pass    4NT     Pass
+1H      Pass    2N     Pass
+3N     Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -1699,8 +1699,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3H      Pass    4NT     Pass
+1H      Pass    2N     Pass
+3H      Pass    4N     Pass
 5D      Pass    5S      Pass
 6H      Pass    Pass    Pass
 
@@ -1722,7 +1722,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4C      Pass    4H      Pass
 5C      Pass    5D      Pass
 5H      Pass    6C      Pass
@@ -1746,9 +1746,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3H      Pass    4H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -1789,8 +1789,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3H      Pass    4NT     Pass
+1H      Pass    2N     Pass
+3H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -1812,9 +1812,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3H      Pass    4H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -1834,8 +1834,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3NT     Pass    4NT     Pass
+1H      Pass    2N     Pass
+3N     Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -1856,9 +1856,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3H      Pass    4H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -1878,8 +1878,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -1900,8 +1900,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -1922,7 +1922,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3H      Pass    4H      Pass
 6S      Pass    Pass    Pass
 
@@ -1944,9 +1944,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
-4NT     Pass    5H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -1968,7 +1968,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3NT     Pass    6C      Pass
+3N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -1988,8 +1988,8 @@ Pass    Pass
 [Contract "5S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4D      Pass    4NT     Pass
+1S      Pass    2N     Pass
+4D      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    Pass    Pass
 
@@ -2011,8 +2011,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -2033,8 +2033,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5D      Pass    5H      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -2056,8 +2056,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+3S      Pass    4N     Pass
 5D      Pass    5H      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -2079,9 +2079,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3H      Pass    4H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -2101,8 +2101,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-4H      Pass    4NT     Pass
+1H      Pass    2N     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -2124,10 +2124,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6C      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
+4N     Pass    5H      Pass
+5N     Pass    6C      Pass
 6S      Pass    Pass    Pass
 
 
@@ -2148,9 +2148,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    3H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -2170,8 +2170,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -2192,7 +2192,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4C      Pass    4H      Pass
 6S      Pass    Pass    Pass
 
@@ -2214,9 +2214,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    3H      Pass
-5NT     Pass    6S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -2236,8 +2236,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3H      Pass    4NT     Pass
+1H      Pass    2N     Pass
+3H      Pass    4N     Pass
 5D      Pass    5S      Pass
 6H      Pass    Pass    Pass
 

--- a/GIB/GIB_Grand_Slam_Force.pbn
+++ b/GIB/GIB_Grand_Slam_Force.pbn
@@ -12,12 +12,12 @@
 {HCP 21 2 14 3}
 {TP 21 6 15 4}
 {Losers 5 8 6 10}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    4NT     Pass
-5D      Pass    7NT     Pass
+2H      Pass    4N     Pass
+5D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -37,8 +37,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4S      Pass    5NT     Pass
+1S      Pass    2N     Pass
+4S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -59,8 +59,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4S      Pass    5NT     Pass
+1S      Pass    2N     Pass
+4S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -82,7 +82,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    6D      Pass
+3N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -102,8 +102,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3H      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3H      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -124,8 +124,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3H      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3H      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -143,12 +143,12 @@ Pass    Pass
 {HCP 21 2 14 3}
 {TP 21 2 14 5}
 {Losers 5 11 7 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    4NT     Pass
-5D      Pass    7NT     Pass
+2D      Pass    4N     Pass
+5D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -165,11 +165,11 @@ Pass    Pass
 {HCP 20 3 14 3}
 {TP 20 6 15 3}
 {Losers 5 8 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      3S
-Pass    Pass    6NT     Pass
+Pass    Pass    6N     Pass
 Pass    Pass    
 
 
@@ -189,8 +189,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3C      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3C      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -211,7 +211,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      3D      5NT     Pass
+1H      3D      5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -232,8 +232,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4S      Pass    5NT     Pass
+1S      Pass    2N     Pass
+4S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -254,7 +254,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4S      Pass    6S      Pass
 Pass    Pass    
 
@@ -272,11 +272,11 @@ Pass    Pass
 {HCP 19 6 14 1}
 {TP 19 6 14 3}
 {Losers 6 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -318,8 +318,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3D      Pass    5NT     Pass
+1H      Pass    2N     Pass
+3D      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -340,9 +340,9 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4C      Pass
-4S      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3N     Pass    4C      Pass
+4S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -363,8 +363,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    6S      Pass
+1S      Pass    2N     Pass
+3N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -381,11 +381,11 @@ Pass    Pass
 {HCP 20 5 13 2}
 {TP 20 6 13 4}
 {Losers 6 9 7 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    6NT     Pass
+2N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -402,11 +402,11 @@ Pass    Pass
 {HCP 19 4 14 3}
 {TP 19 7 14 3}
 {Losers 6 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -426,7 +426,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    6S      Pass
 Pass    Pass    
 
@@ -447,7 +447,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    6S      Pass
 Pass    Pass    
 
@@ -468,8 +468,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3S      Pass    5NT     Pass
+1H      Pass    2N     Pass
+3S      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -490,8 +490,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-4H      Pass    5NT     Pass
+1H      Pass    2N     Pass
+4H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -512,8 +512,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3NT     Pass    7H      Pass
+1H      Pass    2N     Pass
+3N     Pass    7H      Pass
 Pass    Pass    
 
 
@@ -530,12 +530,12 @@ Pass    Pass
 {HCP 23 2 14 1}
 {TP 23 5 16 2}
 {Losers 5 8 5 11}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2H      Pass    4NT     Pass
-5D      Pass    7NT     Pass
+2H      Pass    4N     Pass
+5D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -555,7 +555,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4S      Pass    6S      Pass
 Pass    Pass    
 
@@ -576,8 +576,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3H      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3H      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -598,8 +598,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3D      Pass    5NT     Pass
+1H      Pass    2N     Pass
+3D      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -620,8 +620,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3H      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3H      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -642,10 +642,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 3D      Pass    3S      Pass
-4NT     Pass    5D      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5D      Pass
+5N     Pass    6C      Pass
 6H      Pass    Pass    Pass
 
 
@@ -688,7 +688,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4S      Pass    6S      Pass
 Pass    Pass    
 
@@ -730,8 +730,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-4H      Pass    5NT     Pass
+1H      Pass    2N     Pass
+4H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -752,7 +752,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4S      Pass    6S      Pass
 Pass    Pass    
 
@@ -770,11 +770,11 @@ Pass    Pass
 {HCP 20 1 13 6}
 {TP 20 3 13 7}
 {Losers 6 10 7 8}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    6NT     Pass
+2N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -794,7 +794,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    6S      Pass
 Pass    Pass    
 
@@ -816,7 +816,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-3H      Pass    5NT     Pass
+3H      Pass    5N     Pass
 7C      Pass    Pass    Pass
 
 
@@ -837,8 +837,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3C      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3C      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -860,7 +860,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    4NT     Pass
+2D      Pass    4N     Pass
 5D      Pass    5H      Pass
 6C      Pass    Pass    Pass
 
@@ -882,8 +882,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3C      Pass    5NT     Pass
+1H      Pass    2N     Pass
+3C      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -904,8 +904,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3H      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3H      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -926,8 +926,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    6S      Pass
+1S      Pass    2N     Pass
+3N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -947,8 +947,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -970,8 +970,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3D      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3D      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -992,7 +992,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 3D      Pass    6H      Pass
 Pass    Pass    
 
@@ -1013,8 +1013,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4S      Pass    5NT     Pass
+1S      Pass    2N     Pass
+4S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1035,8 +1035,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3C      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3C      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1057,8 +1057,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4S      Pass    5NT     Pass
+1S      Pass    2N     Pass
+4S      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1079,8 +1079,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3C      Pass    5NT     Pass
+1H      Pass    2N     Pass
+3C      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1122,8 +1122,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3C      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3C      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1144,8 +1144,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4S      Pass    5NT     Pass
+1S      Pass    2N     Pass
+4S      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -1188,10 +1188,10 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3NT     Pass    4C      Pass
-4NT     Pass    5D      Pass
-5NT     Pass    6D      Pass
+1H      Pass    2N     Pass
+3N     Pass    4C      Pass
+4N     Pass    5D      Pass
+5N     Pass    6D      Pass
 7H      Pass    Pass    Pass
 
 
@@ -1212,8 +1212,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3D      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3D      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -1234,7 +1234,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4S      Pass    6S      Pass
 Pass    Pass    
 
@@ -1255,10 +1255,10 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3H      Pass    4C      Pass
-4NT     Pass    5D      Pass
-5NT     Pass    6H      Pass
+4N     Pass    5D      Pass
+5N     Pass    6H      Pass
 7S      Pass    Pass    Pass
 
 
@@ -1279,7 +1279,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 4H      Pass    6H      Pass
 Pass    Pass    
 
@@ -1297,11 +1297,11 @@ Pass    Pass
 {HCP 20 6 14 0}
 {TP 20 7 14 3}
 {Losers 6 8 7 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      3H
-3NT     Pass    7NT     Pass
+3N     Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1321,8 +1321,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-4H      Pass    5NT     Pass
+1H      Pass    2N     Pass
+4H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1363,8 +1363,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3C      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3C      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1382,11 +1382,11 @@ Pass    Pass
 {HCP 19 3 14 4}
 {TP 19 4 14 4}
 {Losers 6 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1406,8 +1406,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3S      Pass    5NT     Pass
+1H      Pass    2N     Pass
+3S      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1428,10 +1428,10 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 3C      Pass    3D      Pass
-4NT     Pass    5D      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5D      Pass
+5N     Pass    6D      Pass
 7H      Pass    Pass    Pass
 
 
@@ -1452,8 +1452,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4S      Pass    5NT     Pass
+1S      Pass    2N     Pass
+4S      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -1474,8 +1474,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3D      Pass    5NT     Pass
+1H      Pass    2N     Pass
+3D      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1497,7 +1497,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    6D      Pass
+2N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -1517,10 +1517,10 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    3D      Pass
-4NT     Pass    5D      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5D      Pass
+5N     Pass    6D      Pass
 7S      Pass    Pass    Pass
 
 
@@ -1541,7 +1541,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3H      Pass    6S      Pass
 Pass    Pass    
 
@@ -1562,10 +1562,10 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 3C      Pass    3D      Pass
-4NT     Pass    5D      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5D      Pass
+5N     Pass    6D      Pass
 7S      Pass    Pass    Pass
 
 
@@ -1583,11 +1583,11 @@ Pass    Pass
 {HCP 21 3 13 3}
 {TP 21 5 13 5}
 {Losers 5 9 7 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    6NT     Pass
+2N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -1607,10 +1607,10 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    4C      Pass
-4NT     Pass    5D      Pass
-5NT     Pass    6H      Pass
+1S      Pass    2N     Pass
+3N     Pass    4C      Pass
+4N     Pass    5D      Pass
+5N     Pass    6H      Pass
 7S      Pass    Pass    Pass
 
 
@@ -1631,8 +1631,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3D      Pass    5NT     Pass
+1H      Pass    2N     Pass
+3D      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1653,8 +1653,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3D      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3D      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1675,8 +1675,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    6S      Pass
+1S      Pass    2N     Pass
+3N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -1696,8 +1696,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3D      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3D      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1715,12 +1715,12 @@ Pass    Pass
 {HCP 24 3 13 0}
 {TP 24 5 13 2}
 {Losers 5 9 8 10}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2D      Pass    4NT     Pass
-5D      Pass    7NT     Pass
+2D      Pass    4N     Pass
+5D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1741,7 +1741,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    6D      Pass
+3N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -1761,8 +1761,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3C      Pass    5NT     Pass
+1H      Pass    2N     Pass
+3C      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1783,7 +1783,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 4H      Pass    6H      Pass
 Pass    Pass    
 
@@ -1804,8 +1804,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-3D      Pass    5NT     Pass
+1H      Pass    2N     Pass
+3D      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -1823,11 +1823,11 @@ Pass    Pass
 {HCP 19 3 14 4}
 {TP 19 4 14 4}
 {Losers 6 10 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1847,8 +1847,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-4H      Pass    4NT     Pass
+1H      Pass    2N     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6H      Pass
 Pass    Pass    
@@ -1867,11 +1867,11 @@ Pass    Pass
 {HCP 20 0 13 7}
 {TP 20 2 13 7}
 {Losers 5 10 7 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    6NT     Pass
+2N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -1891,8 +1891,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4S      Pass    5NT     Pass
+1S      Pass    2N     Pass
+4S      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -1910,11 +1910,11 @@ Pass    Pass
 {HCP 22 2 13 3}
 {TP 22 3 15 5}
 {Losers 5 11 5 9}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    2D      Pass
-3C      Pass    7NT     Pass
+3C      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1931,12 +1931,12 @@ Pass    Pass
 {HCP 22 2 13 3}
 {TP 22 3 14 6}
 {Losers 4 10 7 8}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2H      Pass    4NT     Pass
-5D      Pass    7NT     Pass
+2H      Pass    4N     Pass
+5D      Pass    7N     Pass
 Pass    Pass    
 
 
@@ -1956,8 +1956,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3H      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3H      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -1978,8 +1978,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3C      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3C      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -2000,7 +2000,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 3D      Pass    6H      Pass
 Pass    Pass    
 
@@ -2021,8 +2021,8 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
-4H      Pass    5NT     Pass
+1H      Pass    2N     Pass
+4H      Pass    5N     Pass
 7H      Pass    Pass    Pass
 
 
@@ -2043,8 +2043,8 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3D      Pass    5NT     Pass
+1S      Pass    2N     Pass
+3D      Pass    5N     Pass
 7S      Pass    Pass    Pass
 
 
@@ -2065,8 +2065,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-4S      Pass    4NT     Pass
+1S      Pass    2N     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
 6C      Pass    6S      Pass
 Pass    Pass    
@@ -2088,7 +2088,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4S      Pass    6S      Pass
 Pass    Pass    
 
@@ -2106,11 +2106,11 @@ Pass    Pass
 {HCP 23 1 13 3}
 {TP 23 3 13 3}
 {Losers 5 10 7 11}
-[Contract "7NT"]
+[Contract "7N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    7NT     Pass
+2N     Pass    7N     Pass
 Pass    Pass    
 
 
@@ -2130,7 +2130,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
+1S      Pass    2N     Pass
 4S      Pass    6S      Pass
 Pass    Pass    
 
@@ -2151,8 +2151,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1S      Pass    2NT     Pass
-3NT     Pass    6S      Pass
+1S      Pass    2N     Pass
+3N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -2172,7 +2172,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1H      Pass    2NT     Pass
+1H      Pass    2N     Pass
 4H      Pass    6H      Pass
 Pass    Pass    
 

--- a/GIB/GIB_Open_In_Fourth_Seat.pbn
+++ b/GIB/GIB_Open_In_Fourth_Seat.pbn
@@ -52,11 +52,11 @@ Pass    Pass    Pass    Pass
 {HCP 11 10 13 6}
 {TP 12 11 13 6}
 {Losers 8 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    2NT     Pass    Pass
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -114,12 +114,12 @@ Pass    Pass    Pass    Pass
 {HCP 9 8 15 8}
 {TP 9 9 17 8}
 {Losers 9 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
 Pass    1S      Pass    2H
-Pass    3D      Pass    3NT
+Pass    3D      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -176,12 +176,12 @@ Pass    Pass    Pass    Pass
 {HCP 11 5 14 10}
 {TP 12 5 14 10}
 {Losers 8 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1S      Pass    1NT
-Pass    2NT     Pass    3NT
+Pass    1S      Pass    1N
+Pass    2N     Pass    3N
 Pass    Pass    Pass    
 
 
@@ -222,7 +222,7 @@ Pass    Pass    Pass    Pass
 [Declarer "W"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-1S      1NT     2D      X
+1S      1N     2D      X
 Pass    Pass    3C      Pass
 3S      Pass    Pass    Pass
 
@@ -281,11 +281,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 10 12 8}
 {TP 10 10 13 8}
 {Losers 8 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1D      Pass    1NT
+Pass    1D      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -323,11 +323,11 @@ Pass    Pass    Pass
 {HCP 10 9 12 9}
 {TP 10 10 12 9}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -344,12 +344,12 @@ Pass    Pass    Pass
 {HCP 8 10 12 10}
 {TP 8 10 13 10}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
 Pass    1H      Pass    1S
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -409,11 +409,11 @@ Pass
 {HCP 10 10 13 7}
 {TP 10 10 13 8}
 {Losers 10 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -434,7 +434,7 @@ Pass
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1NT     Pass    2H
+Pass    1N     Pass    2H
 Pass    3H      Pass    Pass
 Pass    
 
@@ -452,11 +452,11 @@ Pass
 {HCP 10 6 13 11}
 {TP 10 6 13 11}
 {Losers 9 10 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -621,13 +621,13 @@ Pass
 {HCP 10 7 12 11}
 {TP 10 9 13 11}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
 Pass    1H      Pass    2D
 Pass    3C      Pass    3H
-Pass    3S      Pass    3NT
+Pass    3S      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -664,12 +664,12 @@ Pass    Pass    Pass    Pass
 {HCP 8 8 13 11}
 {TP 9 9 13 11}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
 Pass    1D      Pass    1H
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -836,7 +836,7 @@ Pass
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1NT     Pass    2H
+Pass    1N     Pass    2H
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
 
@@ -896,11 +896,11 @@ Pass    Pass    Pass    Pass
 {HCP 11 11 12 6}
 {TP 11 11 12 7}
 {Losers 8 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    2NT     Pass    Pass
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -1000,11 +1000,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 7 12 11}
 {TP 10 8 12 11}
 {Losers 8 9 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -1123,11 +1123,11 @@ Pass    Pass    Pass    Pass
 {HCP 11 11 12 6}
 {TP 11 11 12 6}
 {Losers 8 8 7 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    2NT     Pass    Pass
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -1210,7 +1210,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-1H      X       1NT     2S
+1H      X       1N     2S
 Pass    Pass    Pass    
 
 
@@ -1247,11 +1247,11 @@ Pass    Pass    Pass    Pass
 {HCP 6 10 13 11}
 {TP 7 11 13 12}
 {Losers 8 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -1268,11 +1268,11 @@ Pass    Pass    Pass
 {HCP 8 11 12 9}
 {TP 9 11 13 9}
 {Losers 8 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -1293,7 +1293,7 @@ Pass
 [Declarer "E"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    2C      Pass
 Pass    Pass    
 
@@ -1331,11 +1331,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 9 12 9}
 {TP 10 9 13 9}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -1352,11 +1352,11 @@ Pass
 {HCP 10 7 12 11}
 {TP 11 7 12 11}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -1373,12 +1373,12 @@ Pass    Pass    Pass
 {HCP 11 6 15 8}
 {TP 11 6 17 8}
 {Losers 7 10 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
 Pass    1H      Pass    3C
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1395,11 +1395,11 @@ Pass
 {HCP 10 7 14 9}
 {TP 11 7 14 9}
 {Losers 8 10 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -1537,11 +1537,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 7 13 10}
 {TP 10 8 13 10}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -1618,11 +1618,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 11 12 8}
 {TP 10 11 12 8}
 {Losers 9 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -1704,7 +1704,7 @@ Pass    Pass    Pass    Pass
 [Auction "W"]
 Pass    Pass    Pass    1C
 Pass    1D      Pass    1S
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 2H      Pass    Pass    Pass
 
 
@@ -1722,11 +1722,11 @@ Pass    1NT     Pass    Pass
 {HCP 10 9 13 8}
 {TP 10 10 13 8}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -1765,12 +1765,12 @@ Pass    Pass    Pass
 {HCP 11 9 12 8}
 {TP 12 9 12 8}
 {Losers 8 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
-Pass    2NT     Pass    Pass
+Pass    1H      Pass    1N
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -1787,11 +1787,11 @@ Pass
 {HCP 6 11 13 10}
 {TP 6 12 13 10}
 {Losers 10 7 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-1H      X       1NT     Pass
+1H      X       1N     Pass
 Pass    Pass    
 
 
@@ -1848,12 +1848,12 @@ Pass    Pass    Pass    Pass
 {HCP 10 8 12 10}
 {TP 11 8 12 10}
 {Losers 8 9 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1NT     Pass    2C
-Pass    2NT     Pass    Pass
+Pass    1N     Pass    2C
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -1956,7 +1956,7 @@ Pass
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -1974,11 +1974,11 @@ Pass
 {HCP 10 9 12 9}
 {TP 11 9 13 10}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -1999,7 +1999,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1NT     Pass    2C
+Pass    1N     Pass    2C
 2D      Pass    Pass    Pass
 
 
@@ -2123,12 +2123,12 @@ Pass    Pass    Pass    Pass
 {HCP 10 10 12 8}
 {TP 11 11 12 8}
 {Losers 7 8 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
 Pass    1H      Pass    2H
-Pass    2S      Pass    2NT
+Pass    2S      Pass    2N
 Pass    Pass    Pass    
 
 
@@ -2253,7 +2253,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1S
-Pass    1NT     Pass    2H
+Pass    1N     Pass    2H
 Pass    2S      Pass    Pass
 Pass    
 
@@ -2317,7 +2317,7 @@ Pass    Pass    Pass    Pass
 Pass    Pass    Pass    1C
 Pass    1H      Pass    2H
 Pass    3C      Pass    3H
-Pass    3NT     Pass    4H
+Pass    3N     Pass    4H
 Pass    Pass    Pass    
 
 
@@ -2356,11 +2356,11 @@ Pass
 {HCP 9 8 12 11}
 {TP 9 8 13 11}
 {Losers 8 10 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -2377,11 +2377,11 @@ Pass    Pass    Pass
 {HCP 8 11 14 7}
 {TP 9 11 15 8}
 {Losers 9 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -2458,11 +2458,11 @@ Pass    Pass    Pass    Pass
 {HCP 11 8 12 9}
 {TP 11 8 12 9}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-1S      X       1NT     Pass
+1S      X       1N     Pass
 Pass    Pass    
 
 
@@ -2479,12 +2479,12 @@ Pass    Pass
 {HCP 11 7 14 8}
 {TP 12 8 15 9}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
 1S      X       2S      Pass
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -2501,11 +2501,11 @@ Pass
 {HCP 10 6 14 10}
 {TP 11 6 15 10}
 {Losers 7 11 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -2526,9 +2526,9 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    2C      Pass    2H
-Pass    2NT     Pass    4H
+Pass    2N     Pass    4H
 Pass    Pass    Pass    
 
 
@@ -2585,11 +2585,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 11 12 8}
 {TP 10 11 12 8}
 {Losers 9 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -2626,11 +2626,11 @@ Pass    Pass    Pass
 {HCP 8 11 13 8}
 {TP 8 11 14 8}
 {Losers 9 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -2749,11 +2749,11 @@ Pass    Pass    Pass    Pass
 {HCP 8 11 12 9}
 {TP 9 11 12 9}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -2792,11 +2792,11 @@ Pass
 {HCP 11 11 13 5}
 {TP 11 11 13 6}
 {Losers 7 8 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    2NT     Pass    Pass
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -2834,11 +2834,11 @@ Pass
 {HCP 8 9 13 10}
 {TP 9 9 14 11}
 {Losers 9 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -2997,11 +2997,11 @@ Pass    Pass    Pass    Pass
 {HCP 8 9 13 10}
 {TP 9 9 13 10}
 {Losers 9 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -3185,7 +3185,7 @@ Pass    Pass    Pass    1D
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1NT     Pass    2H
+Pass    1N     Pass    2H
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
 
@@ -3272,7 +3272,7 @@ Pass    Pass    2H      Pass
 [Declarer "W"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-1H      2H      X       2NT
+1H      2H      X       2N
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -3353,11 +3353,11 @@ Pass    Pass
 {HCP 8 10 14 8}
 {TP 9 10 14 8}
 {Losers 8 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -3460,7 +3460,7 @@ Pass    Pass    Pass    Pass
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    2S      Pass    Pass
 Pass    
 
@@ -3478,11 +3478,11 @@ Pass
 {HCP 9 10 13 8}
 {TP 9 10 13 8}
 {Losers 9 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -3519,11 +3519,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 11 12 7}
 {TP 10 12 12 8}
 {Losers 9 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -3786,11 +3786,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 7 13 11}
 {TP 10 7 14 12}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-X       1S      Pass    1NT
+X       1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -3827,11 +3827,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 11 12 8}
 {TP 9 11 12 8}
 {Losers 9 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -3853,7 +3853,7 @@ Pass
 [Auction "W"]
 Pass    Pass    Pass    1C
 1S      X       2C      2H
-Pass    3H      Pass    3NT
+Pass    3H      Pass    3N
 Pass    4H      Pass    Pass
 Pass    
 
@@ -3959,7 +3959,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 X       Pass    2S      X
 Pass    Pass    Pass    
 
@@ -3977,11 +3977,11 @@ Pass    Pass    Pass
 {HCP 7 9 14 10}
 {TP 8 9 14 10}
 {Losers 9 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -4002,7 +4002,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    2S      Pass    Pass
 Pass    
 
@@ -4020,11 +4020,11 @@ Pass
 {HCP 6 10 14 10}
 {TP 7 11 14 10}
 {Losers 10 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 Pass    Pass    
 
 
@@ -4041,11 +4041,11 @@ Pass    Pass
 {HCP 9 10 12 9}
 {TP 10 10 12 9}
 {Losers 8 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -4089,8 +4089,8 @@ Pass
 [Auction "W"]
 Pass    Pass    Pass    1C
 Pass    1H      Pass    1S
-Pass    1NT     Pass    2C
-Pass    2NT     Pass    3C
+Pass    1N     Pass    2C
+Pass    2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -4107,11 +4107,11 @@ Pass    Pass    Pass
 {HCP 8 10 13 9}
 {TP 9 10 13 9}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -4128,12 +4128,12 @@ Pass    Pass    Pass
 {HCP 10 8 12 10}
 {TP 11 8 14 10}
 {Losers 9 10 6 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1H
 Pass    1S      Pass    2D
-Pass    2NT     Pass    Pass
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -4234,11 +4234,11 @@ Pass    1H      X       XX
 {HCP 7 11 14 8}
 {TP 7 11 14 8}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -4279,7 +4279,7 @@ Pass    Pass    Pass    Pass
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    2D      Pass    Pass
 Pass    
 
@@ -4344,7 +4344,7 @@ Pass
 [Auction "W"]
 Pass    Pass    Pass    1C
 Pass    1H      Pass    2H
-Pass    2S      Pass    2NT
+Pass    2S      Pass    2N
 Pass    4H      Pass    Pass
 Pass    
 
@@ -4442,12 +4442,12 @@ Pass    Pass    Pass    Pass
 {HCP 9 10 15 6}
 {TP 9 10 16 7}
 {Losers 10 8 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    2C
-Pass    3C      Pass    3NT
+Pass    1N     Pass    2C
+Pass    3C      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -4468,7 +4468,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1NT     Pass    2D
+Pass    1N     Pass    2D
 Pass    Pass    2H      3D
 3H      Pass    4H      Pass
 Pass    X       Pass    Pass
@@ -4528,11 +4528,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 10 13 8}
 {TP 9 10 13 9}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -4612,11 +4612,11 @@ Pass
 {HCP 10 8 12 10}
 {TP 10 8 12 10}
 {Losers 7 10 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -4633,12 +4633,12 @@ Pass
 {HCP 11 11 12 6}
 {TP 11 11 13 6}
 {Losers 7 9 6 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
-Pass    2NT     Pass    Pass
+Pass    1S      Pass    1N
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -4655,11 +4655,11 @@ Pass
 {HCP 11 9 13 7}
 {TP 11 9 13 7}
 {Losers 8 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    2NT     Pass    Pass
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -4866,11 +4866,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 9 12 9}
 {TP 10 10 12 10}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-1H      X       1NT     Pass
+1H      X       1N     Pass
 Pass    Pass    
 
 
@@ -5031,11 +5031,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 7 12 11}
 {TP 10 8 12 12}
 {Losers 8 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -5052,11 +5052,11 @@ Pass
 {HCP 8 10 13 9}
 {TP 8 10 13 9}
 {Losers 8 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -5113,11 +5113,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 11 12 7}
 {TP 11 11 12 7}
 {Losers 8 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -5180,7 +5180,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    2S      Pass    Pass
 Pass    
 
@@ -5198,11 +5198,11 @@ Pass
 {HCP 11 7 13 9}
 {TP 11 8 14 10}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -5219,11 +5219,11 @@ Pass    Pass    Pass
 {HCP 9 9 12 10}
 {TP 9 10 12 10}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -5300,11 +5300,11 @@ Pass    Pass    Pass    Pass
 {HCP 7 10 12 11}
 {TP 8 10 12 11}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -5442,11 +5442,11 @@ Pass    Pass    Pass    Pass
 {HCP 6 11 12 11}
 {TP 7 11 12 12}
 {Losers 9 8 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-1H      X       1NT     Pass
+1H      X       1N     Pass
 Pass    Pass    
 
 
@@ -5463,11 +5463,11 @@ Pass    Pass
 {HCP 8 10 12 10}
 {TP 9 11 12 10}
 {Losers 9 9 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -5569,11 +5569,11 @@ Pass    Pass    Pass
 {HCP 10 11 13 6}
 {TP 10 12 13 7}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -5610,12 +5610,12 @@ Pass    Pass    Pass    Pass
 {HCP 11 11 12 6}
 {TP 12 12 14 8}
 {Losers 8 7 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    2NT     Pass    3H
-Pass    3NT     Pass    Pass
+Pass    2N     Pass    3H
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -5712,12 +5712,12 @@ Pass    Pass    Pass    Pass
 {HCP 7 11 11 11}
 {TP 7 12 13 11}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
 Pass    1D      Pass    1S
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -5734,12 +5734,12 @@ Pass
 {HCP 6 11 12 11}
 {TP 6 11 12 11}
 {Losers 10 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
 Pass    1H      Pass    1S
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -5798,11 +5798,11 @@ Pass    2H      Pass    Pass
 {HCP 9 9 13 9}
 {TP 9 9 14 10}
 {Losers 9 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -5879,11 +5879,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 10 12 8}
 {TP 10 10 12 9}
 {Losers 9 7 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -5920,11 +5920,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 9 13 9}
 {TP 10 9 13 10}
 {Losers 9 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -6023,11 +6023,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 9 13 8}
 {TP 10 10 14 9}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-1D      1S      1NT     Pass
+1D      1S      1N     Pass
 Pass    Pass    
 
 
@@ -6064,12 +6064,12 @@ Pass    Pass    Pass    Pass
 {HCP 11 10 13 6}
 {TP 11 10 13 6}
 {Losers 8 10 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
-Pass    2NT     Pass    Pass
+Pass    1S      Pass    1N
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -6086,11 +6086,11 @@ Pass
 {HCP 7 11 14 8}
 {TP 8 11 14 8}
 {Losers 8 8 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -6131,7 +6131,7 @@ Pass    Pass    Pass    Pass
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1NT     Pass    2H
+Pass    1N     Pass    2H
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
 
@@ -6295,11 +6295,11 @@ Pass
 {HCP 10 10 12 8}
 {TP 10 10 12 8}
 {Losers 8 8 9 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -6316,11 +6316,11 @@ Pass
 {HCP 10 8 14 8}
 {TP 10 8 15 9}
 {Losers 10 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -6337,11 +6337,11 @@ Pass    Pass    Pass
 {HCP 10 10 13 7}
 {TP 10 10 13 9}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -6358,12 +6358,12 @@ Pass    Pass    Pass
 {HCP 10 9 12 9}
 {TP 11 9 12 9}
 {Losers 7 10 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
 Pass    1D      Pass    1S
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -6463,11 +6463,11 @@ Pass
 {HCP 8 9 13 10}
 {TP 8 10 13 10}
 {Losers 10 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -6484,11 +6484,11 @@ Pass
 {HCP 6 11 13 10}
 {TP 6 12 13 10}
 {Losers 10 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -6509,7 +6509,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-1S      1NT     2S      Pass
+1S      1N     2S      Pass
 Pass    3C      Pass    Pass
 Pass    
 
@@ -6589,14 +6589,14 @@ Pass    Pass    Pass
 {HCP 10 7 12 11}
 {TP 10 8 14 12}
 {Losers 9 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
 X       XX      1H      2C
 Pass    2D      Pass    2H
-Pass    2NT     Pass    3D
-Pass    3NT     Pass    Pass
+Pass    2N     Pass    3D
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -6613,11 +6613,11 @@ Pass
 {HCP 9 10 14 7}
 {TP 9 10 14 7}
 {Losers 8 8 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -6818,11 +6818,11 @@ Pass    Pass    Pass    Pass
 {HCP 7 9 14 10}
 {TP 8 9 14 10}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -6922,11 +6922,11 @@ Pass    Pass    Pass
 {HCP 9 10 14 7}
 {TP 9 11 14 8}
 {Losers 10 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -6943,12 +6943,12 @@ Pass    Pass    Pass
 {HCP 11 6 13 10}
 {TP 11 6 13 10}
 {Losers 8 10 8 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
-Pass    2NT     Pass    Pass
+Pass    1S      Pass    1N
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -7093,12 +7093,12 @@ Pass    Pass    Pass    Pass
 {HCP 11 9 13 7}
 {TP 12 9 15 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
 Pass    1S      Pass    2D
-Pass    2NT     Pass    3NT
+Pass    2N     Pass    3N
 Pass    Pass    Pass    
 
 
@@ -7135,11 +7135,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 11 12 8}
 {TP 9 11 12 8}
 {Losers 9 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -7181,8 +7181,8 @@ Pass    Pass    Pass    Pass
 [Auction "W"]
 Pass    Pass    Pass    1C
 Pass    1H      Pass    1S
-Pass    1NT     Pass    2C
-Pass    2NT     Pass    3C
+Pass    1N     Pass    2C
+Pass    2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -7239,11 +7239,11 @@ Pass    Pass    Pass    Pass
 {HCP 7 10 13 10}
 {TP 8 10 15 10}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -7280,12 +7280,12 @@ Pass    Pass    Pass    Pass
 {HCP 11 6 12 11}
 {TP 12 8 12 12}
 {Losers 8 8 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
 1H      Pass    1S      Pass
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -7322,11 +7322,11 @@ Pass    Pass    Pass    Pass
 {HCP 8 11 12 9}
 {TP 8 11 13 9}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-1S      X       1NT     Pass
+1S      X       1N     Pass
 Pass    Pass    
 
 
@@ -7629,11 +7629,11 @@ Pass    Pass    Pass    Pass
 {HCP 7 11 12 10}
 {TP 7 11 13 10}
 {Losers 10 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -7677,7 +7677,7 @@ Pass
 [Auction "W"]
 Pass    Pass    Pass    1D
 Pass    1H      Pass    2C
-Pass    2NT     Pass    3D
+Pass    2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -7817,11 +7817,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 8 13 10}
 {TP 10 8 13 11}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -7838,11 +7838,11 @@ Pass    Pass    Pass
 {HCP 8 11 12 9}
 {TP 8 11 13 9}
 {Losers 9 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -7924,7 +7924,7 @@ Pass    Pass    Pass    Pass
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 X       Pass    2C      Pass
 Pass    2D      Pass    Pass
 Pass    
@@ -8027,12 +8027,12 @@ Pass    Pass    Pass
 {HCP 11 11 12 6}
 {TP 11 11 12 7}
 {Losers 8 9 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
 Pass    1H      Pass    1S
-Pass    2NT     Pass    Pass
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -8110,11 +8110,11 @@ Pass    Pass    Pass
 {HCP 10 11 13 6}
 {TP 10 12 13 6}
 {Losers 8 7 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -8172,11 +8172,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 11 13 6}
 {TP 10 12 13 7}
 {Losers 9 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -8197,7 +8197,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    2D      Pass    Pass
 Pass    
 
@@ -8235,11 +8235,11 @@ Pass    Pass    Pass    Pass
 {HCP 8 8 13 11}
 {TP 9 8 14 12}
 {Losers 8 10 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-1S      X       Pass    1NT
+1S      X       Pass    1N
 Pass    Pass    Pass    
 
 
@@ -8256,12 +8256,12 @@ Pass    Pass    Pass
 {HCP 6 11 12 11}
 {TP 6 12 14 11}
 {Losers 10 7 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
 Pass    1H      Pass    1S
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -8606,11 +8606,11 @@ Pass    Pass    Pass
 {HCP 9 11 12 8}
 {TP 9 11 12 9}
 {Losers 9 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -8667,12 +8667,12 @@ Pass    Pass    Pass    Pass
 {HCP 11 8 12 9}
 {TP 12 8 13 9}
 {Losers 8 9 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1H
 Pass    1S      Pass    2D
-Pass    2NT     Pass    Pass
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -8938,11 +8938,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 9 12 10}
 {TP 9 9 12 10}
 {Losers 9 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -8979,12 +8979,12 @@ Pass    Pass    Pass    Pass
 {HCP 11 7 12 10}
 {TP 11 7 12 10}
 {Losers 8 9 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
-Pass    2NT     Pass    Pass
+Pass    1S      Pass    1N
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -9001,11 +9001,11 @@ Pass
 {HCP 8 10 12 10}
 {TP 8 10 13 10}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -9090,7 +9090,7 @@ Pass
 [Auction "W"]
 Pass    Pass    Pass    1D
 Pass    1H      Pass    2C
-Pass    2NT     Pass    4C
+Pass    2N     Pass    4C
 Pass    5D      Pass    Pass
 Pass    
 
@@ -9150,11 +9150,11 @@ Pass    Pass    Pass
 {HCP 7 11 13 9}
 {TP 8 12 13 9}
 {Losers 8 7 9 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -9191,11 +9191,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 11 12 8}
 {TP 10 12 13 8}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -9212,11 +9212,11 @@ Pass
 {HCP 8 10 13 9}
 {TP 8 11 14 9}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -9274,11 +9274,11 @@ Pass
 {HCP 9 11 14 6}
 {TP 10 11 14 6}
 {Losers 8 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -9315,12 +9315,12 @@ Pass    Pass    Pass    Pass
 {HCP 11 7 12 10}
 {TP 11 8 14 11}
 {Losers 9 9 6 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1D
 Pass    1S      Pass    2D
-Pass    2NT     Pass    Pass
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -9377,11 +9377,11 @@ Pass    Pass    Pass    Pass
 {HCP 8 10 12 10}
 {TP 8 10 12 10}
 {Losers 8 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -9458,12 +9458,12 @@ Pass    Pass    Pass    Pass
 {HCP 11 9 12 8}
 {TP 11 9 12 8}
 {Losers 8 9 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
-Pass    2NT     Pass    Pass
+Pass    1S      Pass    1N
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -9520,12 +9520,12 @@ Pass    Pass    Pass    Pass
 {HCP 10 8 13 9}
 {TP 10 8 15 10}
 {Losers 9 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
 Pass    1S      Pass    2C
-Pass    3C      Pass    3NT
+Pass    3C      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -9603,11 +9603,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 11 12 8}
 {TP 10 11 12 8}
 {Losers 8 9 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -9664,11 +9664,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 10 12 8}
 {TP 10 10 12 8}
 {Losers 9 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -9705,11 +9705,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 11 13 7}
 {TP 10 12 13 8}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -9809,11 +9809,11 @@ Pass    Pass    Pass
 {HCP 9 8 12 11}
 {TP 9 8 12 11}
 {Losers 9 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -9830,11 +9830,11 @@ Pass    Pass    Pass
 {HCP 10 10 13 7}
 {TP 10 11 13 8}
 {Losers 8 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1H
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -10223,11 +10223,11 @@ Pass    Pass    Pass    Pass
 {HCP 9 9 12 10}
 {TP 10 9 12 11}
 {Losers 9 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -10264,11 +10264,11 @@ Pass    Pass    Pass    Pass
 {HCP 10 10 13 7}
 {TP 10 11 14 7}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -10313,7 +10313,7 @@ Pass    Pass    Pass    1D
 Pass    Pass    Pass    1D
 Pass    1H      Pass    2H
 Pass    3D      Pass    3H
-Pass    3NT     Pass    4H
+Pass    3N     Pass    4H
 Pass    Pass    Pass    
 
 
@@ -10330,11 +10330,11 @@ Pass    Pass    Pass
 {HCP 10 8 13 9}
 {TP 10 8 13 10}
 {Losers 9 8 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1D
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -10393,11 +10393,11 @@ Pass    Pass    Pass    Pass
 {HCP 6 10 13 11}
 {TP 7 10 13 11}
 {Losers 9 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "W"]
 Pass    Pass    Pass    1C
-Pass    1H      Pass    1NT
+Pass    1H      Pass    1N
 Pass    Pass    Pass    
 
 

--- a/GIB/GIB_Overcall_with_4.pbn
+++ b/GIB/GIB_Overcall_with_4.pbn
@@ -138,11 +138,11 @@ Pass    Pass    Pass
 {HCP 10 6 12 12}
 {TP 13 7 13 13}
 {Losers 6 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1S      2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -180,13 +180,13 @@ Pass    Pass    Pass
 {HCP 13 0 13 14}
 {TP 14 1 15 14}
 {Losers 7 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
 2D      Pass    2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -203,10 +203,10 @@ Pass    Pass    Pass
 {HCP 4 10 14 12}
 {TP 6 12 15 12}
 {Losers 9 7 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1H      Pass    1NT
+1D      1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -244,11 +244,11 @@ Pass    Pass
 {HCP 3 12 12 13}
 {TP 3 13 12 13}
 {Losers 11 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1S      Pass    2NT
-Pass    3NT     Pass    Pass
+1D      1S      Pass    2N
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -265,10 +265,10 @@ Pass
 {HCP 6 9 13 12}
 {TP 7 10 13 13}
 {Losers 9 7 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1H      Pass    1NT
+1D      1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -413,10 +413,10 @@ Pass    Pass    Pass
 {HCP 5 8 13 14}
 {TP 7 9 13 14}
 {Losers 9 7 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1H      Pass    1NT
+1D      1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -517,11 +517,11 @@ Pass    Pass    X       Pass
 {HCP 8 7 13 12}
 {TP 9 7 14 12}
 {Losers 8 9 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -665,10 +665,10 @@ Pass    Pass
 {HCP 4 11 13 12}
 {TP 5 14 13 12}
 {Losers 10 6 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1S      Pass    1NT
+1C      1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -957,11 +957,11 @@ Pass    Pass    Pass
 {HCP 6 7 13 14}
 {TP 7 8 13 14}
 {Losers 9 9 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -978,10 +978,10 @@ Pass    Pass    Pass
 {HCP 6 11 12 11}
 {TP 8 11 13 12}
 {Losers 8 8 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1H      Pass    1NT
+1C      1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -1040,11 +1040,11 @@ Pass    Pass    Pass
 {HCP 2 11 13 14}
 {TP 3 11 13 14}
 {Losers 10 8 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 1D      1H      Pass    2D
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1103,11 +1103,11 @@ Pass    Pass
 {HCP 9 5 13 13}
 {TP 9 6 13 14}
 {Losers 9 9 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1D      1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1128,7 +1128,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1D      1H      1S      2C
-X       2NT     Pass    3C
+X       2N     Pass    3C
 Pass    Pass    3S      4C
 Pass    Pass    Pass    
 
@@ -1170,7 +1170,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1D      1H      1NT     2H
+1D      1H      1N     2H
 Pass    Pass    Pass    
 
 
@@ -1187,10 +1187,10 @@ Pass    Pass    Pass
 {HCP 3 10 13 14}
 {TP 3 11 13 14}
 {Losers 12 8 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1S      Pass    1NT
+1D      1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -1251,12 +1251,12 @@ Pass
 {HCP 12 2 13 13}
 {TP 13 2 13 14}
 {Losers 7 11 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1S      X       Pass
-1NT     Pass    2NT     Pass
-3H      Pass    3NT     Pass
+1N     Pass    2N     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1277,7 +1277,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1D      1S      X       Pass
-1NT     Pass    Pass    2S
+1N     Pass    Pass    2S
 Pass    Pass    Pass    
 
 
@@ -1298,7 +1298,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      1H      1S      Pass
-1NT     Pass    3S      Pass
+1N     Pass    3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -1336,12 +1336,12 @@ Pass    Pass    Pass
 {HCP 8 5 13 14}
 {TP 8 7 13 14}
 {Losers 9 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1S      X       3S
 Pass    Pass    X       Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1425,7 +1425,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1D      1H      Pass    1NT
+1D      1H      Pass    1N
 2C      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -1446,7 +1446,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1C      1H      X       1NT
+1C      1H      X       1N
 2S      Pass    Pass    Pass
 
 
@@ -1485,11 +1485,11 @@ Pass    Pass    Pass
 {HCP 12 4 12 12}
 {TP 13 5 12 12}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1S      2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1528,12 +1528,12 @@ Pass    Pass    X       Pass
 {HCP 4 10 14 12}
 {TP 4 11 15 13}
 {Losers 10 8 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
 1C      1D      Pass    2C
 Pass    2H      Pass    2S
-Pass    3C      Pass    3NT
+Pass    3C      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -1657,10 +1657,10 @@ Pass    Pass    3S      Pass
 {HCP 6 9 14 11}
 {TP 7 10 15 12}
 {Losers 9 7 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1H      1S      Pass    1NT
+1H      1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -1783,11 +1783,11 @@ X       Pass    4H      Pass
 {HCP 12 2 12 14}
 {TP 12 3 13 14}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1H      1S      2C      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1804,13 +1804,13 @@ Pass    Pass
 {HCP 1 11 14 14}
 {TP 2 12 15 14}
 {Losers 11 7 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 1D      1S      Pass    2C
 Pass    3C      Pass    3D
 Pass    3H      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1830,7 +1830,7 @@ Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1C      1H      Pass    1NT
+1C      1H      Pass    1N
 Pass    2D      Pass    Pass
 Pass    
 
@@ -1848,10 +1848,10 @@ Pass
 {HCP 4 11 14 11}
 {TP 5 13 14 12}
 {Losers 10 7 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1S      Pass    1NT
+1C      1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -1995,11 +1995,11 @@ Pass
 {HCP 12 3 13 12}
 {TP 13 6 14 12}
 {Losers 7 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2041,7 +2041,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1S      Pass
-1NT     Pass    2S      Pass
+1N     Pass    2S      Pass
 Pass    Pass    
 
 
@@ -2370,13 +2370,13 @@ Pass    Pass
 {HCP 10 3 14 13}
 {TP 11 4 14 13}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1S      2C      Pass
 2D      Pass    Pass    2S
-2NT     Pass    3C      Pass
-3D      Pass    3NT     Pass
+2N     Pass    3C      Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2434,10 +2434,10 @@ Pass
 {HCP 8 5 13 14}
 {TP 10 8 14 14}
 {Losers 6 7 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1H      1NT     Pass
+1D      1H      1N     Pass
 Pass    Pass    
 
 
@@ -2454,10 +2454,10 @@ Pass    Pass
 {HCP 7 8 13 12}
 {TP 7 9 14 12}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1H      Pass    1NT
+1C      1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -2558,12 +2558,12 @@ Pass
 {HCP 14 0 14 12}
 {TP 16 1 14 12}
 {Losers 5 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1H      X       Pass
 2C      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2643,11 +2643,11 @@ Pass    Pass
 {HCP 6 8 13 13}
 {TP 6 8 13 13}
 {Losers 10 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1S      X       Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2917,11 +2917,11 @@ Pass
 {HCP 1 13 13 13}
 {TP 4 14 13 13}
 {Losers 9 6 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
 1H      1S      Pass    3C
-Pass    3H      Pass    3NT
+Pass    3H      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -3003,12 +3003,12 @@ Pass
 {HCP 11 4 12 13}
 {TP 11 4 13 13}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      1H      2C      Pass
-2S      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2S      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3152,11 +3152,11 @@ Pass    Pass
 {HCP 11 6 12 11}
 {TP 11 7 12 12}
 {Losers 9 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      2H      X
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -3322,10 +3322,10 @@ Pass    Pass
 {HCP 4 11 13 12}
 {TP 6 12 13 12}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1H      Pass    1NT
+1C      1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -3407,7 +3407,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1H      1S      1NT     2S
+1H      1S      1N     2S
 Pass    Pass    Pass    
 
 
@@ -3428,7 +3428,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1D      1H      3D      X
-Pass    3NT     Pass    4H
+Pass    3N     Pass    4H
 Pass    5C      Pass    Pass
 Pass    
 
@@ -3470,7 +3470,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1D      1H      Pass    1S
-Pass    1NT     Pass    2C
+Pass    1N     Pass    2C
 Pass    Pass    Pass    
 
 
@@ -3491,7 +3491,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1C      1H      2H      X
-2NT     Pass    3C      3H
+2N     Pass    3C      3H
 Pass    Pass    Pass    
 
 
@@ -3574,10 +3574,10 @@ Pass
 {HCP 8 7 12 13}
 {TP 10 8 12 14}
 {Losers 7 9 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1H      1S      1NT     Pass
+1H      1S      1N     Pass
 Pass    Pass    
 
 
@@ -3614,11 +3614,11 @@ Pass    Pass    Pass
 {HCP 10 3 14 13}
 {TP 11 3 14 13}
 {Losers 8 10 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1S      2H      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -3635,11 +3635,11 @@ Pass    Pass    Pass
 {HCP 10 4 14 12}
 {TP 10 6 14 13}
 {Losers 7 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1D      1S      Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3677,11 +3677,11 @@ Pass
 {HCP 12 4 12 12}
 {TP 14 4 13 13}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3718,10 +3718,10 @@ Pass    Pass
 {HCP 9 7 12 12}
 {TP 9 8 12 13}
 {Losers 8 8 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1S      1NT     Pass
+1D      1S      1N     Pass
 Pass    Pass    
 
 
@@ -3932,7 +3932,7 @@ Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1C      1D      1NT     3C
+1C      1D      1N     3C
 X       Pass    Pass    3D
 Pass    Pass    Pass    
 
@@ -3950,11 +3950,11 @@ Pass    Pass    Pass
 {HCP 7 7 12 14}
 {TP 7 8 12 14}
 {Losers 10 9 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3971,10 +3971,10 @@ Pass    Pass    Pass
 {HCP 7 8 12 13}
 {TP 7 9 12 13}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1H      X       1NT
+1D      1H      X       1N
 Pass    Pass    Pass    
 
 
@@ -3991,10 +3991,10 @@ Pass    Pass    Pass
 {HCP 11 4 12 13}
 {TP 11 4 13 13}
 {Losers 8 11 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
-1H      1S      2NT     Pass
+1H      1S      2N     Pass
 Pass    Pass    
 
 
@@ -4218,10 +4218,10 @@ Pass    Pass    Pass
 {HCP 8 6 13 13}
 {TP 10 7 14 13}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1H      1S      1NT     Pass
+1H      1S      1N     Pass
 Pass    Pass    
 
 
@@ -4363,10 +4363,10 @@ Pass
 {HCP 5 9 13 13}
 {TP 5 10 13 13}
 {Losers 10 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1H      Pass    1NT
+1C      1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -4386,7 +4386,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1H      1S      1NT     Pass
+1H      1S      1N     Pass
 2D      Pass    2H      Pass
 4H      Pass    Pass    Pass
 
@@ -4469,10 +4469,10 @@ X       Pass    Pass    Pass
 {HCP 6 9 13 12}
 {TP 7 9 13 12}
 {Losers 9 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1H      X       1NT
+1D      1H      X       1N
 Pass    Pass    Pass    
 
 
@@ -4615,12 +4615,12 @@ Pass    Pass    X       Pass
 {HCP 10 6 13 11}
 {TP 11 8 14 12}
 {Losers 7 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1S      2H      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4637,11 +4637,11 @@ Pass    Pass    X       Pass
 {HCP 10 4 14 12}
 {TP 11 6 14 12}
 {Losers 7 9 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1H      1NT     2H
-3NT     Pass    Pass    Pass
+1D      1H      1N     2H
+3N     Pass    Pass    Pass
 
 
 
@@ -4745,7 +4745,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1D      1H      1NT     2H
+1D      1H      1N     2H
 3D      Pass    3H      Pass
 4D      Pass    5D      Pass
 Pass    Pass    
@@ -4995,7 +4995,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 1D      1H      Pass    2D
-Pass    2NT     Pass    3C
+Pass    2N     Pass    3C
 Pass    3D      Pass    3H
 Pass    Pass    Pass    
 
@@ -5078,7 +5078,7 @@ Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1C      1H      1S      1NT
+1C      1H      1S      1N
 Pass    2D      Pass    Pass
 2S      Pass    Pass    Pass
 
@@ -5201,11 +5201,11 @@ Pass    Pass    Pass
 {HCP 15 0 12 13}
 {TP 15 0 12 14}
 {Losers 7 12 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5312,7 +5312,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1C      1S      X       Pass
-1NT     Pass    Pass    2S
+1N     Pass    Pass    2S
 Pass    Pass    Pass    
 
 
@@ -5351,12 +5351,12 @@ Pass    Pass
 {HCP 9 4 14 13}
 {TP 10 5 15 13}
 {Losers 8 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1C      1H      1NT     Pass
+1C      1H      1N     Pass
 2C      Pass    2D      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5376,7 +5376,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "S"]
-1D      1H      1NT     3D
+1D      1H      1N     3D
 Pass    3H      Pass    Pass
 Pass    
 
@@ -5398,7 +5398,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1H      1S      X       Pass
-2H      Pass    3NT     Pass
+2H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -5416,11 +5416,11 @@ Pass
 {HCP 10 3 13 14}
 {TP 12 4 13 14}
 {Losers 7 10 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1S      X       Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5437,10 +5437,10 @@ Pass
 {HCP 5 9 13 13}
 {TP 5 10 13 13}
 {Losers 11 8 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1D      Pass    1NT
+1C      1D      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -5457,11 +5457,11 @@ Pass    Pass    Pass
 {HCP 11 4 13 12}
 {TP 12 5 15 12}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      X       Pass
-2C      Pass    3NT     Pass
+2C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5478,12 +5478,12 @@ Pass    Pass
 {HCP 14 2 12 12}
 {TP 16 4 13 12}
 {Losers 5 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      1H      1S      Pass
 2C      Pass    2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5503,7 +5503,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1D      1S      1NT     2S
+1D      1S      1N     2S
 Pass    Pass    3C      Pass
 Pass    Pass    
 
@@ -5543,12 +5543,12 @@ X       Pass    2S      4D
 {HCP 12 2 14 12}
 {TP 13 3 15 12}
 {Losers 7 11 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1D      1S      Pass
 2C      Pass    2D      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5777,12 +5777,12 @@ Pass    Pass
 {HCP 12 3 14 11}
 {TP 13 4 14 12}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1S      2D      Pass
-2H      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2H      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5804,7 +5804,7 @@ Pass    Pass
 [Auction "S"]
 1D      1S      Pass    2D
 Pass    3C      Pass    3D
-Pass    3NT     Pass    4S
+Pass    3N     Pass    4S
 Pass    Pass    Pass    
 
 
@@ -5862,10 +5862,10 @@ Pass    Pass
 {HCP 9 7 12 12}
 {TP 11 8 13 12}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1H      1S      1NT     Pass
+1H      1S      1N     Pass
 Pass    Pass    
 
 
@@ -5882,11 +5882,11 @@ Pass    Pass
 {HCP 16 1 12 11}
 {TP 16 4 13 12}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5903,12 +5903,12 @@ Pass    Pass
 {HCP 10 5 13 12}
 {TP 11 7 14 12}
 {Losers 7 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      1H      2D      Pass
 3C      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6011,10 +6011,10 @@ Pass    Pass    Pass
 {HCP 5 11 12 12}
 {TP 7 12 13 12}
 {Losers 9 8 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1H      1S      Pass    1NT
+1H      1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -6031,10 +6031,10 @@ Pass    Pass    Pass
 {HCP 10 5 12 13}
 {TP 11 6 13 13}
 {Losers 8 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1H      1NT     Pass
+1D      1H      1N     Pass
 Pass    Pass    
 
 
@@ -6113,10 +6113,10 @@ Pass    Pass    Pass
 {HCP 10 5 13 12}
 {TP 10 6 13 12}
 {Losers 8 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1S      1NT     Pass
+1D      1S      1N     Pass
 Pass    Pass    
 
 
@@ -6156,12 +6156,12 @@ Pass
 {HCP 10 5 14 11}
 {TP 12 6 14 12}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1S      2H      2S
-2NT     Pass    3C      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3C      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6178,12 +6178,12 @@ Pass
 {HCP 2 12 12 14}
 {TP 4 12 12 14}
 {Losers 9 8 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
 1C      1D      Pass    2C
-Pass    2H      Pass    2NT
-Pass    3C      Pass    3NT
+Pass    2H      Pass    2N
+Pass    3C      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -6203,7 +6203,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1C      1S      1NT     2S
+1C      1S      1N     2S
 Pass    Pass    Pass    
 
 
@@ -6264,12 +6264,12 @@ Pass    3S      4D      Pass
 {HCP 13 3 12 12}
 {TP 15 4 12 12}
 {Losers 6 10 9 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1S      X       Pass
-1NT     Pass    3D      Pass
-3H      Pass    3NT     Pass
+1N     Pass    3D      Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6329,11 +6329,11 @@ Pass    Pass    X       Pass
 {HCP 11 3 14 12}
 {TP 12 3 14 12}
 {Losers 7 11 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      1S      2C      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6353,7 +6353,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1C      1H      1NT     2H
+1C      1H      1N     2H
 Pass    Pass    X       Pass
 2S      Pass    Pass    Pass
 
@@ -6480,7 +6480,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 1D      1S      Pass    2D
-Pass    2NT     Pass    3C
+Pass    2N     Pass    3C
 Pass    3H      Pass    3S
 Pass    Pass    Pass    
 
@@ -6540,11 +6540,11 @@ Pass
 {HCP 12 2 12 14}
 {TP 13 3 12 14}
 {Losers 7 10 9 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1H      X       Pass
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 Pass    Pass    
 
 
@@ -6621,10 +6621,10 @@ Pass    Pass    Pass
 {HCP 8 7 12 13}
 {TP 9 9 12 14}
 {Losers 9 8 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      1D      1NT     Pass
+1C      1D      1N     Pass
 Pass    Pass    
 
 
@@ -6832,11 +6832,11 @@ Pass    Pass
 {HCP 4 12 12 12}
 {TP 5 13 12 12}
 {Losers 9 7 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1S      Pass    2NT
-Pass    3NT     Pass    Pass
+1D      1S      Pass    2N
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -6878,7 +6878,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 1D      1S      2H      Pass
-2NT     Pass    4H      4S
+2N     Pass    4H      4S
 X       Pass    Pass    Pass
 
 
@@ -6896,12 +6896,12 @@ X       Pass    Pass    Pass
 {HCP 3 11 13 13}
 {TP 5 12 14 13}
 {Losers 9 7 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
 1C      1D      Pass    1H
-Pass    1S      Pass    1NT
-Pass    2NT     Pass    3NT
+Pass    1S      Pass    1N
+Pass    2N     Pass    3N
 Pass    Pass    Pass    
 
 
@@ -7088,10 +7088,10 @@ Pass
 {HCP 10 4 14 12}
 {TP 10 6 14 13}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1H      1NT     Pass
+1D      1H      1N     Pass
 Pass    Pass    
 
 
@@ -7240,7 +7240,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      1S      2S      X
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 Pass    Pass    
 
 
@@ -7383,10 +7383,10 @@ Pass    Pass    Pass
 {HCP 9 5 13 13}
 {TP 9 5 14 13}
 {Losers 8 10 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1C      1H      1NT     Pass
+1C      1H      1N     Pass
 Pass    Pass    
 
 
@@ -7470,7 +7470,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      1S      2S      X
-2NT     Pass    3C      Pass
+2N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7594,11 +7594,11 @@ Pass
 {HCP 10 3 14 13}
 {TP 11 4 15 14}
 {Losers 8 10 6 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1S      X       Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7615,11 +7615,11 @@ Pass
 {HCP 9 6 13 12}
 {TP 11 7 14 12}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1S      X       Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7640,7 +7640,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 1C      1S      2S      X
-2NT     Pass    3D      Pass
+2N     Pass    3D      Pass
 Pass    Pass    
 
 
@@ -7845,11 +7845,11 @@ X       Pass    Pass    Pass
 {HCP 4 12 13 11}
 {TP 5 12 13 12}
 {Losers 10 7 9 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1H      Pass    2NT
-Pass    3NT     Pass    Pass
+1C      1H      Pass    2N
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -7866,10 +7866,10 @@ Pass
 {HCP 4 11 13 12}
 {TP 6 13 14 12}
 {Losers 8 7 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1H      Pass    1NT
+1C      1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -7907,11 +7907,11 @@ Pass    Pass
 {HCP 7 7 13 13}
 {TP 9 7 13 13}
 {Losers 8 9 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1S      X       Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7977,8 +7977,8 @@ Pass    3D      Pass    Pass
 [Auction "S"]
 1C      1H      X       Pass
 2C      Pass    2H      Pass
-2NT     Pass    3C      Pass
-3NT     Pass    5C      Pass
+2N     Pass    3C      Pass
+3N     Pass    5C      Pass
 Pass    Pass    
 
 
@@ -7995,10 +7995,10 @@ Pass    Pass
 {HCP 9 8 12 11}
 {TP 9 9 12 12}
 {Losers 10 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1H      1NT     Pass
+1D      1H      1N     Pass
 Pass    Pass    
 
 
@@ -8036,12 +8036,12 @@ Pass    Pass    Pass
 {HCP 11 3 14 12}
 {TP 11 3 14 13}
 {Losers 9 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      1S      Pass
 2S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8123,12 +8123,12 @@ Pass    Pass    Pass
 {HCP 9 5 14 12}
 {TP 10 6 15 12}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1S      1NT     2S
+1D      1S      1N     2S
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8250,10 +8250,10 @@ Pass    Pass    Pass
 {HCP 7 8 12 13}
 {TP 9 9 13 14}
 {Losers 8 8 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1D      Pass    1NT
+1C      1D      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -8333,12 +8333,12 @@ Pass
 {HCP 10 3 13 14}
 {TP 10 4 14 14}
 {Losers 9 10 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    Pass    2H
-Pass    Pass    2NT     Pass
+1N     Pass    Pass    2H
+Pass    Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8459,11 +8459,11 @@ Pass
 {HCP 0 16 12 12}
 {TP 1 16 12 13}
 {Losers 11 8 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
 1C      1D      Pass    2C
-Pass    2H      Pass    3NT
+Pass    2H      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -8480,11 +8480,11 @@ Pass    Pass    Pass
 {HCP 11 2 13 14}
 {TP 11 2 13 14}
 {Losers 7 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      1S      X       Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8505,7 +8505,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 1D      1S      X       Pass
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 Pass    Pass    
 
 
@@ -8522,11 +8522,11 @@ Pass    Pass
 {HCP 13 2 13 12}
 {TP 13 2 13 12}
 {Losers 7 12 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1S      2S      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8563,10 +8563,10 @@ Pass
 {HCP 6 9 12 13}
 {TP 7 11 12 13}
 {Losers 9 7 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1H      Pass    1NT
+1C      1H      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -8647,7 +8647,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      1S      1NT     2S
+1D      1S      1N     2S
 Pass    Pass    Pass    
 
 
@@ -8686,10 +8686,10 @@ Pass    Pass    Pass
 {HCP 9 7 12 12}
 {TP 9 8 12 13}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1H      1NT     Pass
+1D      1H      1N     Pass
 Pass    Pass    
 
 
@@ -8726,11 +8726,11 @@ Pass    Pass    Pass
 {HCP 5 8 14 13}
 {TP 8 9 15 14}
 {Losers 8 7 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "W"]
 [Auction "S"]
 1C      1D      Pass    1S
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 Pass    
 
 
@@ -8789,10 +8789,10 @@ X       Pass    Pass    Pass
 {HCP 13 1 12 14}
 {TP 13 2 13 14}
 {Losers 8 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1S      3NT     Pass
+1D      1S      3N     Pass
 Pass    Pass    
 
 
@@ -8852,12 +8852,12 @@ Pass    Pass
 {HCP 11 3 13 13}
 {TP 11 3 13 13}
 {Losers 8 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      1S      X       Pass
-2C      Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+2C      Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8959,10 +8959,10 @@ Pass    Pass    Pass
 {HCP 7 8 12 13}
 {TP 9 10 12 14}
 {Losers 7 8 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1S      X       1NT
+1C      1S      X       1N
 Pass    Pass    Pass    
 
 
@@ -9020,12 +9020,12 @@ Pass
 {HCP 7 10 12 11}
 {TP 11 12 15 12}
 {Losers 6 7 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1H      1S      Pass    1NT
+1H      1S      Pass    1N
 2D      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9042,12 +9042,12 @@ Pass    Pass
 {HCP 8 7 14 11}
 {TP 11 8 15 12}
 {Losers 6 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      1S      2C      Pass
 2S      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9212,7 +9212,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      1S      1NT     2S
+1D      1S      1N     2S
 Pass    Pass    Pass    
 
 
@@ -9336,7 +9336,7 @@ Pass    Pass    Pass
 [Contract "2SX"]
 [Declarer "W"]
 [Auction "S"]
-1D      1S      1NT     Pass
+1D      1S      1N     Pass
 2C      Pass    Pass    2S
 Pass    Pass    X       Pass
 Pass    Pass    
@@ -9396,11 +9396,11 @@ Pass    Pass    Pass
 {HCP 10 4 12 14}
 {TP 11 5 12 14}
 {Losers 8 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9421,7 +9421,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1C      1D      1S      Pass
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    Pass    Pass    
 
 
@@ -9500,11 +9500,11 @@ Pass    Pass    Pass
 {HCP 3 13 12 12}
 {TP 3 13 13 12}
 {Losers 11 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-1D      1H      Pass    2NT
-Pass    3NT     Pass    Pass
+1D      1H      Pass    2N
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -9671,10 +9671,10 @@ Pass
 {HCP 4 10 13 13}
 {TP 6 11 14 13}
 {Losers 9 8 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "E"]
 [Auction "S"]
-1C      1S      Pass    1NT
+1C      1S      Pass    1N
 Pass    Pass    Pass    
 
 
@@ -9694,7 +9694,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1D      1S      1NT     2H
+1D      1S      1N     2H
 Pass    Pass    Pass    
 
 
@@ -9752,12 +9752,12 @@ Pass    Pass    Pass
 {HCP 14 2 12 12}
 {TP 16 3 13 12}
 {Losers 6 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1H      X       Pass
-1NT     Pass    3C      Pass
-3NT     Pass    Pass    Pass
+1N     Pass    3C      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9774,12 +9774,12 @@ Pass    Pass    Pass
 {HCP 4 10 12 14}
 {TP 4 10 14 14}
 {Losers 10 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 1H      1S      Pass    2H
-Pass    2NT     Pass    3H
-Pass    3NT     Pass    Pass
+Pass    2N     Pass    3H
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -10265,10 +10265,10 @@ Pass    Pass
 {HCP 8 6 13 13}
 {TP 9 7 13 13}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "S"]
-1D      1H      1NT     Pass
+1D      1H      1N     Pass
 Pass    Pass    
 
 
@@ -10309,7 +10309,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      1S      1NT     2S
+1D      1S      1N     2S
 Pass    Pass    Pass    
 
 
@@ -10516,6 +10516,6 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1D      1S      1NT     2S
+1D      1S      1N     2S
 Pass    Pass    Pass    
 

--- a/GIB/GIB_Rule_of_16-15.pbn
+++ b/GIB/GIB_Rule_of_16-15.pbn
@@ -12,10 +12,10 @@
 {HCP 15 5 8 12}
 {TP 15 6 9 12}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -32,10 +32,10 @@
 {HCP 15 9 8 8}
 {TP 15 9 9 9}
 {Losers 6 10 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -52,10 +52,10 @@
 {HCP 15 6 9 10}
 {TP 15 8 10 11}
 {Losers 7 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -72,10 +72,10 @@
 {HCP 15 9 8 8}
 {TP 15 10 8 8}
 {Losers 8 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -92,10 +92,10 @@
 {HCP 15 6 9 10}
 {TP 15 6 11 10}
 {Losers 6 9 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -112,10 +112,10 @@
 {HCP 15 4 9 12}
 {TP 15 5 10 14}
 {Losers 6 10 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -135,7 +135,7 @@
 [Contract "2S"]
 [Declarer "W"]
 [Auction "N"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      Pass    2S
 Pass    Pass    Pass    
 
@@ -153,10 +153,10 @@ Pass    Pass    Pass
 {HCP 15 2 8 15}
 {TP 16 3 9 15}
 {Losers 7 10 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -173,10 +173,10 @@ Pass    Pass    Pass
 {HCP 15 10 9 6}
 {TP 15 10 10 7}
 {Losers 7 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -193,10 +193,10 @@ Pass    Pass    Pass
 {HCP 15 8 9 8}
 {TP 16 9 9 8}
 {Losers 7 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -216,7 +216,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "N"]
-1NT     Pass    Pass    2H
+1N     Pass    Pass    2H
 Pass    Pass    Pass    
 
 
@@ -233,10 +233,10 @@ Pass    Pass    Pass
 {HCP 15 5 9 11}
 {TP 15 6 9 12}
 {Losers 7 9 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -253,10 +253,10 @@ Pass    Pass    Pass
 {HCP 15 9 8 8}
 {TP 15 10 8 8}
 {Losers 7 8 10 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -273,10 +273,10 @@ Pass    Pass    Pass
 {HCP 15 10 9 6}
 {TP 15 10 10 9}
 {Losers 6 8 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -293,10 +293,10 @@ Pass    Pass    Pass
 {HCP 15 10 8 7}
 {TP 15 11 8 8}
 {Losers 7 8 10 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -313,10 +313,10 @@ Pass    Pass    Pass
 {HCP 15 10 9 6}
 {TP 15 10 9 6}
 {Losers 8 8 9 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -333,10 +333,10 @@ Pass    Pass    Pass
 {HCP 15 9 8 8}
 {TP 16 10 9 10}
 {Losers 7 7 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -353,10 +353,10 @@ Pass    Pass    Pass
 {HCP 15 4 8 13}
 {TP 15 4 8 13}
 {Losers 6 11 10 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -373,10 +373,10 @@ Pass    Pass    Pass
 {HCP 15 4 8 13}
 {TP 15 4 8 13}
 {Losers 7 10 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -393,10 +393,10 @@ Pass    Pass    Pass
 {HCP 15 8 8 9}
 {TP 15 8 8 10}
 {Losers 6 10 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -413,10 +413,10 @@ Pass    Pass    Pass
 {HCP 15 5 8 12}
 {TP 15 6 9 13}
 {Losers 6 10 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -433,10 +433,10 @@ Pass    Pass    Pass
 {HCP 15 7 9 9}
 {TP 15 8 10 9}
 {Losers 6 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -453,10 +453,10 @@ Pass    Pass    Pass
 {HCP 15 5 8 12}
 {TP 15 5 9 13}
 {Losers 7 11 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -473,10 +473,10 @@ Pass    Pass    Pass
 {HCP 15 5 8 12}
 {TP 15 5 9 13}
 {Losers 7 10 9 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -493,10 +493,10 @@ Pass    Pass    Pass
 {HCP 15 5 9 11}
 {TP 15 6 9 12}
 {Losers 7 9 10 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -513,10 +513,10 @@ Pass    Pass    Pass
 {HCP 15 9 9 7}
 {TP 15 10 10 7}
 {Losers 8 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -533,10 +533,10 @@ Pass    Pass    Pass
 {HCP 15 3 9 13}
 {TP 15 4 9 13}
 {Losers 7 10 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -553,10 +553,10 @@ Pass    Pass    Pass
 {HCP 15 1 8 16}
 {TP 15 2 8 16}
 {Losers 7 11 10 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -573,10 +573,10 @@ Pass    Pass    Pass
 {HCP 15 9 8 8}
 {TP 15 9 9 8}
 {Losers 7 9 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -593,10 +593,10 @@ Pass    Pass    Pass
 {HCP 15 10 9 6}
 {TP 16 10 10 7}
 {Losers 7 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -613,10 +613,10 @@ Pass    Pass    Pass
 {HCP 15 10 9 6}
 {TP 15 10 9 7}
 {Losers 7 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -633,10 +633,10 @@ Pass    Pass    Pass
 {HCP 15 8 9 8}
 {TP 15 8 9 8}
 {Losers 7 9 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -656,7 +656,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "N"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -677,7 +677,7 @@ Pass
 [Contract "3C"]
 [Declarer "W"]
 [Auction "N"]
-1NT     Pass    Pass    2C
+1N     Pass    Pass    2C
 Pass    2D      Pass    3C
 Pass    Pass    Pass    
 
@@ -695,10 +695,10 @@ Pass    Pass    Pass
 {HCP 15 8 9 8}
 {TP 15 8 10 9}
 {Losers 7 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -715,10 +715,10 @@ Pass    Pass    Pass
 {HCP 15 4 8 13}
 {TP 15 5 8 13}
 {Losers 7 10 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -735,10 +735,10 @@ Pass    Pass    Pass
 {HCP 15 7 8 10}
 {TP 16 7 8 12}
 {Losers 7 8 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -755,10 +755,10 @@ Pass    Pass    Pass
 {HCP 15 4 8 13}
 {TP 15 5 8 13}
 {Losers 7 10 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -775,10 +775,10 @@ Pass    Pass    Pass
 {HCP 15 4 8 13}
 {TP 16 5 9 13}
 {Losers 7 10 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -795,10 +795,10 @@ Pass    Pass    Pass
 {HCP 15 8 8 9}
 {TP 15 8 9 10}
 {Losers 8 10 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -815,10 +815,10 @@ Pass    Pass    Pass
 {HCP 15 8 9 8}
 {TP 15 8 10 10}
 {Losers 7 9 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -835,10 +835,10 @@ Pass    Pass    Pass
 {HCP 15 7 9 9}
 {TP 15 7 10 9}
 {Losers 7 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -855,10 +855,10 @@ Pass    Pass    Pass
 {HCP 15 8 9 8}
 {TP 15 8 9 8}
 {Losers 7 9 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -875,10 +875,10 @@ Pass    Pass    Pass
 {HCP 15 6 8 11}
 {TP 15 6 8 11}
 {Losers 7 10 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -895,10 +895,10 @@ Pass    Pass    Pass
 {HCP 15 3 8 14}
 {TP 16 5 9 14}
 {Losers 6 10 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -915,10 +915,10 @@ Pass    Pass    Pass
 {HCP 15 10 9 6}
 {TP 15 10 9 8}
 {Losers 6 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -935,10 +935,10 @@ Pass    Pass    Pass
 {HCP 15 10 8 7}
 {TP 15 10 8 7}
 {Losers 7 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -955,10 +955,10 @@ Pass    Pass    Pass
 {HCP 15 6 8 11}
 {TP 16 6 8 13}
 {Losers 7 9 8 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -975,10 +975,10 @@ Pass    Pass    Pass
 {HCP 15 8 9 8}
 {TP 15 8 9 9}
 {Losers 7 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -995,10 +995,10 @@ Pass    Pass    Pass
 {HCP 15 10 9 6}
 {TP 16 10 9 7}
 {Losers 7 8 10 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1015,10 +1015,10 @@ Pass    Pass    Pass
 {HCP 15 7 9 9}
 {TP 15 8 9 9}
 {Losers 8 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1038,7 +1038,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "N"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 2H      2S      Pass    Pass
 Pass    
 
@@ -1056,10 +1056,10 @@ Pass
 {HCP 15 4 8 13}
 {TP 15 5 8 13}
 {Losers 7 10 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1076,10 +1076,10 @@ Pass
 {HCP 15 6 9 10}
 {TP 15 6 9 11}
 {Losers 7 10 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1099,7 +1099,7 @@ Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "N"]
-1NT     Pass    Pass    3H
+1N     Pass    Pass    3H
 Pass    Pass    Pass    
 
 
@@ -1116,10 +1116,10 @@ Pass    Pass    Pass
 {HCP 15 9 8 8}
 {TP 15 10 9 8}
 {Losers 8 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1136,10 +1136,10 @@ Pass    Pass    Pass
 {HCP 15 6 8 11}
 {TP 16 6 8 11}
 {Losers 7 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1156,10 +1156,10 @@ Pass    Pass    Pass
 {HCP 15 8 8 9}
 {TP 15 8 9 9}
 {Losers 6 10 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1179,7 +1179,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "N"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 2H      2S      Pass    Pass
 Pass    
 
@@ -1197,10 +1197,10 @@ Pass
 {HCP 15 5 8 12}
 {TP 15 6 8 13}
 {Losers 7 9 8 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1217,10 +1217,10 @@ Pass
 {HCP 15 6 8 11}
 {TP 16 7 8 11}
 {Losers 6 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1237,10 +1237,10 @@ Pass
 {HCP 15 5 9 11}
 {TP 16 5 10 12}
 {Losers 7 10 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1257,10 +1257,10 @@ Pass
 {HCP 15 10 8 7}
 {TP 16 10 10 7}
 {Losers 7 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1277,10 +1277,10 @@ Pass
 {HCP 15 10 8 7}
 {TP 15 10 8 8}
 {Losers 7 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1300,8 +1300,8 @@ Pass
 [Contract "3C"]
 [Declarer "W"]
 [Auction "N"]
-1NT     Pass    Pass    2C
-Pass    2D      Pass    2NT
+1N     Pass    Pass    2C
+Pass    2D      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -1319,10 +1319,10 @@ Pass
 {HCP 15 10 9 6}
 {TP 15 11 10 7}
 {Losers 6 8 8 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1339,10 +1339,10 @@ Pass
 {HCP 15 7 8 10}
 {TP 15 7 8 10}
 {Losers 7 9 10 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1359,10 +1359,10 @@ Pass
 {HCP 15 6 9 10}
 {TP 16 7 11 11}
 {Losers 6 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1382,7 +1382,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "N"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -1400,10 +1400,10 @@ Pass
 {HCP 15 8 8 9}
 {TP 16 8 9 10}
 {Losers 6 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1420,10 +1420,10 @@ Pass
 {HCP 15 7 8 10}
 {TP 15 8 8 10}
 {Losers 8 8 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1440,10 +1440,10 @@ Pass
 {HCP 15 7 8 10}
 {TP 15 8 9 11}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1460,10 +1460,10 @@ Pass
 {HCP 15 7 8 10}
 {TP 15 8 8 11}
 {Losers 7 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1480,10 +1480,10 @@ Pass
 {HCP 15 7 8 10}
 {TP 15 7 8 10}
 {Losers 8 9 10 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1500,10 +1500,10 @@ Pass
 {HCP 15 7 9 9}
 {TP 15 8 9 10}
 {Losers 6 9 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1523,7 +1523,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "N"]
-1NT     Pass    Pass    2H
+1N     Pass    Pass    2H
 Pass    Pass    Pass    
 
 
@@ -1540,10 +1540,10 @@ Pass    Pass    Pass
 {HCP 15 5 8 12}
 {TP 16 5 9 12}
 {Losers 7 10 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1560,10 +1560,10 @@ Pass    Pass    Pass
 {HCP 15 4 8 13}
 {TP 15 6 8 13}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1580,10 +1580,10 @@ Pass    Pass    Pass
 {HCP 15 4 8 13}
 {TP 15 5 9 13}
 {Losers 8 10 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1600,10 +1600,10 @@ Pass    Pass    Pass
 {HCP 15 3 9 13}
 {TP 15 4 10 13}
 {Losers 7 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1620,10 +1620,10 @@ Pass    Pass    Pass
 {HCP 15 5 8 12}
 {TP 15 5 9 12}
 {Losers 7 10 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1640,10 +1640,10 @@ Pass    Pass    Pass
 {HCP 15 8 9 8}
 {TP 15 9 10 9}
 {Losers 7 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1663,7 +1663,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "N"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -1681,10 +1681,10 @@ Pass
 {HCP 15 5 9 11}
 {TP 15 5 10 11}
 {Losers 7 10 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1701,10 +1701,10 @@ Pass
 {HCP 15 6 9 10}
 {TP 15 6 9 11}
 {Losers 6 10 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1724,7 +1724,7 @@ Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "N"]
-1NT     Pass    Pass    X
+1N     Pass    Pass    X
 Pass    2C      Pass    Pass
 2H      Pass    Pass    3C
 Pass    Pass    Pass    
@@ -1746,7 +1746,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "N"]
-1NT     Pass    Pass    X
+1N     Pass    Pass    X
 Pass    2C      Pass    Pass
 Pass    
 
@@ -1764,10 +1764,10 @@ Pass
 {HCP 15 6 9 10}
 {TP 15 7 10 10}
 {Losers 6 10 8 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1784,10 +1784,10 @@ Pass
 {HCP 15 6 8 11}
 {TP 15 6 8 12}
 {Losers 8 9 10 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1804,10 +1804,10 @@ Pass
 {HCP 15 9 8 8}
 {TP 16 10 8 10}
 {Losers 6 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1824,10 +1824,10 @@ Pass
 {HCP 15 6 9 10}
 {TP 15 7 10 10}
 {Losers 8 9 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1844,10 +1844,10 @@ Pass
 {HCP 15 4 9 12}
 {TP 16 5 10 13}
 {Losers 7 10 8 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1864,10 +1864,10 @@ Pass
 {HCP 15 4 8 13}
 {TP 15 4 8 13}
 {Losers 7 11 10 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1884,10 +1884,10 @@ Pass
 {HCP 15 9 8 8}
 {TP 16 10 9 8}
 {Losers 6 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1904,10 +1904,10 @@ Pass
 {HCP 15 7 9 9}
 {TP 15 7 9 9}
 {Losers 8 9 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1924,10 +1924,10 @@ Pass
 {HCP 15 7 9 9}
 {TP 15 8 9 10}
 {Losers 7 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1944,10 +1944,10 @@ Pass
 {HCP 15 10 8 7}
 {TP 15 11 8 7}
 {Losers 8 7 10 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1967,7 +1967,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "N"]
-1NT     Pass    Pass    2H
+1N     Pass    Pass    2H
 Pass    Pass    Pass    
 
 
@@ -1987,7 +1987,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "N"]
-1NT     Pass    Pass    2S
+1N     Pass    Pass    2S
 Pass    Pass    Pass    
 
 
@@ -2004,9 +2004,9 @@ Pass    Pass    Pass
 {HCP 15 9 9 7}
 {TP 15 9 9 7}
 {Losers 7 9 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 

--- a/GIB/GIB_Rule_of_16-16.pbn
+++ b/GIB/GIB_Rule_of_16-16.pbn
@@ -12,10 +12,10 @@
 {HCP 8 12 15 5}
 {TP 8 12 15 5}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -32,10 +32,10 @@
 {HCP 15 7 8 10}
 {TP 15 7 8 12}
 {Losers 7 9 9 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -52,10 +52,10 @@
 {HCP 15 6 8 11}
 {TP 15 7 8 12}
 {Losers 8 8 10 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -72,11 +72,11 @@
 {HCP 9 13 15 3}
 {TP 9 13 15 3}
 {Losers 9 7 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -93,10 +93,10 @@ Pass    Pass
 {HCP 15 7 8 10}
 {TP 16 7 8 10}
 {Losers 7 10 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -113,11 +113,11 @@ Pass    Pass
 {HCP 15 9 9 7}
 {TP 15 9 9 9}
 {Losers 6 10 9 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -134,10 +134,10 @@ Pass    Pass
 {HCP 15 7 9 9}
 {TP 15 7 10 9}
 {Losers 7 9 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -157,7 +157,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -175,11 +175,11 @@ Pass    Pass
 {HCP 15 10 9 6}
 {TP 15 10 9 7}
 {Losers 7 7 10 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -199,7 +199,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -217,10 +217,10 @@ Pass    Pass
 {HCP 8 11 15 6}
 {TP 8 11 16 7}
 {Losers 9 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -237,11 +237,11 @@ Pass    Pass
 {HCP 15 8 9 8}
 {TP 15 8 9 9}
 {Losers 6 9 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -258,10 +258,10 @@ Pass    Pass
 {HCP 8 9 15 8}
 {TP 8 10 15 8}
 {Losers 10 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -278,10 +278,10 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 10 11 16 8}
 {Losers 9 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -301,7 +301,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -320,11 +320,11 @@ Pass    Pass
 {HCP 15 10 8 7}
 {TP 15 10 9 9}
 {Losers 8 8 9 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -341,11 +341,11 @@ Pass    Pass
 {HCP 15 4 9 12}
 {TP 16 4 9 12}
 {Losers 6 11 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -362,10 +362,10 @@ Pass    Pass
 {HCP 15 0 9 16}
 {TP 15 2 10 16}
 {Losers 7 10 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -382,10 +382,10 @@ Pass    Pass
 {HCP 15 10 8 7}
 {TP 16 10 8 8}
 {Losers 7 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -405,7 +405,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -423,10 +423,10 @@ Pass    Pass
 {HCP 15 5 8 12}
 {TP 16 5 8 12}
 {Losers 7 10 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -443,11 +443,11 @@ Pass    Pass
 {HCP 9 6 15 10}
 {TP 10 9 15 11}
 {Losers 9 7 6 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -467,7 +467,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -485,12 +485,12 @@ Pass    Pass
 {HCP 9 12 15 4}
 {TP 9 14 16 5}
 {Losers 9 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
-Pass    Pass    2NT     Pass
-3NT     Pass    Pass    Pass
+1N     Pass    2C      2H
+Pass    Pass    2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -507,10 +507,10 @@ Pass    Pass    2NT     Pass
 {HCP 15 8 8 9}
 {TP 15 9 8 9}
 {Losers 6 9 10 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -530,7 +530,7 @@ Pass    Pass    2NT     Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "N"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    Pass    
 
 
@@ -550,7 +550,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -568,11 +568,11 @@ Pass    Pass
 {HCP 9 9 15 7}
 {TP 10 10 15 7}
 {Losers 7 8 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -589,11 +589,11 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 9 10 15 6}
 {Losers 9 9 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -610,11 +610,11 @@ Pass    Pass
 {HCP 15 8 9 8}
 {TP 15 9 9 8}
 {Losers 7 9 9 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -631,10 +631,10 @@ Pass    Pass
 {HCP 15 3 9 13}
 {TP 16 3 10 14}
 {Losers 7 11 9 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -651,10 +651,10 @@ Pass    Pass
 {HCP 15 9 8 8}
 {TP 15 9 8 9}
 {Losers 7 9 10 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -671,10 +671,10 @@ Pass    Pass
 {HCP 9 13 15 3}
 {TP 10 13 16 4}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -691,11 +691,11 @@ Pass    Pass
 {HCP 9 11 15 5}
 {TP 9 12 15 5}
 {Losers 9 8 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -712,11 +712,11 @@ Pass    Pass
 {HCP 15 7 9 9}
 {TP 15 7 9 10}
 {Losers 6 10 9 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -733,11 +733,11 @@ Pass    Pass
 {HCP 8 14 15 3}
 {TP 9 15 15 4}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
-2D      Pass    2NT     Pass
+1N     Pass    2C      X
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -754,10 +754,10 @@ Pass    Pass
 {HCP 8 14 15 3}
 {TP 8 14 15 4}
 {Losers 10 6 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -774,11 +774,11 @@ Pass    Pass
 {HCP 15 10 9 6}
 {TP 15 11 9 6}
 {Losers 7 8 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -798,7 +798,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    Pass    2H
+1N     Pass    Pass    2H
 Pass    Pass    Pass    
 
 
@@ -815,11 +815,11 @@ Pass    Pass    Pass
 {HCP 8 14 15 3}
 {TP 9 14 15 4}
 {Losers 9 7 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -836,11 +836,11 @@ Pass    Pass
 {HCP 15 4 9 12}
 {TP 15 5 10 12}
 {Losers 8 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -857,10 +857,10 @@ Pass    Pass
 {HCP 15 9 9 7}
 {TP 15 9 10 7}
 {Losers 7 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -877,10 +877,10 @@ Pass    Pass
 {HCP 15 9 9 7}
 {TP 15 10 10 8}
 {Losers 7 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -900,7 +900,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -921,7 +921,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "N"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -939,10 +939,10 @@ Pass
 {HCP 15 2 9 14}
 {TP 16 2 10 15}
 {Losers 6 11 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -959,11 +959,11 @@ Pass    Pass
 {HCP 9 9 15 7}
 {TP 9 9 16 8}
 {Losers 9 9 6 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -983,7 +983,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -1001,12 +1001,12 @@ Pass    Pass
 {HCP 15 6 9 10}
 {TP 15 6 9 11}
 {Losers 6 10 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1023,11 +1023,11 @@ Pass    Pass
 {HCP 9 8 15 8}
 {TP 10 8 15 9}
 {Losers 7 8 9 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1047,7 +1047,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -1065,10 +1065,10 @@ Pass    Pass
 {HCP 8 12 15 5}
 {TP 8 13 15 5}
 {Losers 10 7 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1085,11 +1085,11 @@ Pass    Pass
 {HCP 15 5 9 11}
 {TP 15 6 9 11}
 {Losers 8 9 9 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1106,10 +1106,10 @@ Pass    Pass
 {HCP 8 11 15 6}
 {TP 8 11 15 6}
 {Losers 9 8 7 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1126,10 +1126,10 @@ Pass    Pass
 {HCP 15 5 8 12}
 {TP 16 6 8 13}
 {Losers 7 8 9 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1146,12 +1146,12 @@ Pass    Pass
 {HCP 9 7 15 9}
 {TP 9 8 16 9}
 {Losers 9 9 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-2NT     Pass    Pass    Pass
+2N     Pass    Pass    Pass
 
 
 
@@ -1168,10 +1168,10 @@ Pass    Pass
 {HCP 15 4 9 12}
 {TP 15 5 10 13}
 {Losers 8 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1188,11 +1188,11 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 10 12 15 6}
 {Losers 8 7 8 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1209,11 +1209,11 @@ Pass    Pass
 {HCP 15 8 9 8}
 {TP 15 8 9 9}
 {Losers 6 9 8 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2H      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1233,7 +1233,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -1251,10 +1251,10 @@ Pass    Pass
 {HCP 9 11 15 5}
 {TP 10 12 15 5}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1271,11 +1271,11 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 10 12 15 6}
 {Losers 8 6 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1292,11 +1292,11 @@ Pass    Pass
 {HCP 15 7 8 10}
 {TP 15 7 9 10}
 {Losers 7 10 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1313,11 +1313,11 @@ Pass    Pass
 {HCP 15 6 8 11}
 {TP 15 7 9 11}
 {Losers 8 9 9 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1334,10 +1334,10 @@ Pass    Pass
 {HCP 9 16 15 0}
 {TP 10 16 15 1}
 {Losers 8 6 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1354,10 +1354,10 @@ Pass    Pass
 {HCP 15 5 8 12}
 {TP 15 7 8 12}
 {Losers 6 9 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1374,11 +1374,11 @@ Pass    Pass
 {HCP 9 12 15 4}
 {TP 9 14 15 4}
 {Losers 9 7 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1395,11 +1395,11 @@ Pass    Pass
 {HCP 9 7 15 9}
 {TP 9 7 15 9}
 {Losers 8 10 8 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1416,10 +1416,10 @@ Pass    Pass
 {HCP 8 10 15 7}
 {TP 8 11 15 8}
 {Losers 9 7 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1436,11 +1436,11 @@ Pass    Pass
 {HCP 15 8 9 8}
 {TP 15 8 9 8}
 {Losers 7 9 10 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1457,11 +1457,11 @@ Pass    Pass
 {HCP 9 6 15 10}
 {TP 9 6 15 10}
 {Losers 9 9 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1478,10 +1478,10 @@ Pass    Pass
 {HCP 15 6 8 11}
 {TP 15 7 8 11}
 {Losers 8 9 10 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1501,7 +1501,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -1519,11 +1519,11 @@ Pass    Pass
 {HCP 15 7 8 10}
 {TP 16 9 9 10}
 {Losers 6 8 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1540,11 +1540,11 @@ Pass    Pass
 {HCP 15 8 9 8}
 {TP 15 8 9 9}
 {Losers 7 10 9 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1564,7 +1564,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -1582,10 +1582,10 @@ Pass    Pass
 {HCP 9 8 15 8}
 {TP 10 9 15 8}
 {Losers 9 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1602,10 +1602,10 @@ Pass    Pass
 {HCP 15 9 9 7}
 {TP 15 9 10 10}
 {Losers 6 8 9 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1622,10 +1622,10 @@ Pass    Pass
 {HCP 15 10 8 7}
 {TP 16 10 8 8}
 {Losers 7 8 9 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1645,7 +1645,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1663,11 +1663,11 @@ Pass    Pass
 {HCP 15 3 9 13}
 {TP 15 3 9 13}
 {Losers 7 11 9 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1687,7 +1687,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1708,7 +1708,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -1726,10 +1726,10 @@ Pass    Pass
 {HCP 15 10 8 7}
 {TP 16 10 8 7}
 {Losers 7 8 9 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1746,11 +1746,11 @@ Pass    Pass
 {HCP 15 10 9 6}
 {TP 15 10 9 6}
 {Losers 7 9 10 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1767,11 +1767,11 @@ Pass    Pass
 {HCP 15 6 9 10}
 {TP 15 7 9 10}
 {Losers 6 9 9 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1791,7 +1791,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "N"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
 4S      Pass    Pass    Pass
 
@@ -1813,7 +1813,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -1834,7 +1834,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -1852,11 +1852,11 @@ Pass    Pass
 {HCP 9 7 15 9}
 {TP 9 7 15 9}
 {Losers 8 10 7 9}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1873,11 +1873,11 @@ Pass    Pass
 {HCP 9 14 15 2}
 {TP 9 14 15 3}
 {Losers 9 7 7 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1894,11 +1894,11 @@ Pass    Pass
 {HCP 15 7 9 9}
 {TP 15 7 10 12}
 {Losers 6 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1915,11 +1915,11 @@ Pass    Pass
 {HCP 15 6 9 10}
 {TP 15 7 9 13}
 {Losers 7 8 9 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1936,11 +1936,11 @@ Pass    Pass
 {HCP 9 11 15 5}
 {TP 9 13 15 5}
 {Losers 8 6 7 11}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -1960,7 +1960,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2H      Pass    3H      Pass
 Pass    Pass    
 
@@ -1978,10 +1978,10 @@ Pass    Pass
 {HCP 8 8 15 9}
 {TP 8 8 15 9}
 {Losers 9 10 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1998,11 +1998,11 @@ Pass    Pass
 {HCP 9 16 15 0}
 {TP 9 18 16 2}
 {Losers 8 5 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -2022,7 +2022,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "N"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3S      Pass
 Pass    Pass    
 
@@ -2040,10 +2040,10 @@ Pass    Pass
 {HCP 9 11 15 5}
 {TP 10 11 15 7}
 {Losers 9 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2060,10 +2060,10 @@ Pass    Pass
 {HCP 9 10 15 6}
 {TP 10 11 15 6}
 {Losers 8 8 7 10}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    2NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 

--- a/GIB/GIB_Runout_after_1N_X.pbn
+++ b/GIB/GIB_Runout_after_1N_X.pbn
@@ -15,7 +15,7 @@
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -33,10 +33,10 @@
 {HCP 2 5 17 16}
 {TP 3 5 17 16}
 {Losers 10 9 6 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -56,7 +56,7 @@
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    2S      Pass    3D
 Pass    Pass    Pass    
 
@@ -77,7 +77,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -98,7 +98,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -118,7 +118,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2H
 Pass    2S      Pass    Pass
 Pass    
@@ -140,7 +140,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
 Pass    3D      Pass    3S
 Pass    4S      Pass    Pass
@@ -163,7 +163,7 @@ Pass
 [Contract "2CX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    X
 Pass    Pass    Pass    
 
@@ -184,7 +184,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -205,7 +205,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -226,7 +226,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
 
@@ -244,12 +244,12 @@ Pass    Pass    Pass
 {HCP 1 7 16 16}
 {TP 2 8 16 17}
 {Losers 11 9 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2H
-Pass    3S      Pass    3NT
+Pass    3S      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -269,7 +269,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -291,8 +291,8 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      2H
-Pass    2S      Pass    2NT
+1N     X       XX      2H
+Pass    2S      Pass    2N
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -313,7 +313,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -333,7 +333,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -353,7 +353,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -374,7 +374,7 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    2S      Pass    4S
 Pass    Pass    Pass    
 
@@ -395,7 +395,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
 Pass    Pass    Pass    
 
@@ -413,10 +413,10 @@ Pass    Pass    Pass
 {HCP 5 4 15 16}
 {TP 5 5 15 17}
 {Losers 10 10 7 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -433,10 +433,10 @@ Pass    Pass    Pass
 {HCP 3 5 16 16}
 {TP 5 6 16 16}
 {Losers 9 9 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -456,7 +456,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -473,12 +473,12 @@ Pass    Pass    Pass
 {HCP 1 6 17 16}
 {TP 2 6 17 17}
 {Losers 11 10 5 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
-Pass    2H      Pass    2NT
+Pass    2H      Pass    2N
 Pass    Pass    Pass    
 
 
@@ -498,7 +498,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    3S
 Pass    4H      Pass    4S
 Pass    Pass    Pass    
@@ -520,7 +520,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 X       Pass    3D      Pass
 Pass    Pass    
 
@@ -541,7 +541,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -562,7 +562,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -582,7 +582,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -600,10 +600,10 @@ Pass    Pass    Pass
 {HCP 2 7 15 16}
 {TP 4 7 15 18}
 {Losers 10 9 7 5}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -623,7 +623,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      X       2D      3C
 Pass    3H      Pass    3S
 Pass    4H      Pass    Pass
@@ -646,7 +646,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    2S      Pass    3H
 Pass    3S      Pass    4D
 Pass    4H      Pass    Pass
@@ -669,7 +669,7 @@ Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    Pass    Pass    
 
 
@@ -689,7 +689,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2D
 Pass    Pass    Pass    
 
@@ -710,9 +710,9 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    3S
-Pass    3NT     Pass    4S
+Pass    3N     Pass    4S
 Pass    Pass    Pass    
 
 
@@ -732,7 +732,7 @@ Pass    Pass    Pass
 [Contract "4D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    3S      Pass    4D
 Pass    Pass    Pass    
 
@@ -750,10 +750,10 @@ Pass    Pass    Pass
 {HCP 1 7 16 16}
 {TP 3 9 16 16}
 {Losers 10 8 6 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -773,7 +773,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    2H      Pass    2S
 Pass    Pass    Pass    
@@ -795,7 +795,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      X       2H      2S
 4H      Pass    Pass    Pass
 
@@ -817,7 +817,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -837,7 +837,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    4H
 Pass    Pass    Pass    
 
@@ -858,7 +858,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    4S
 Pass    Pass    Pass    
 
@@ -879,7 +879,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -900,7 +900,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    Pass    Pass    
 
 
@@ -917,10 +917,10 @@ Pass    Pass    Pass
 {HCP 3 5 16 16}
 {TP 4 7 16 17}
 {Losers 10 8 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -940,7 +940,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 X       Pass    3D      Pass
 Pass    Pass    
 
@@ -958,12 +958,12 @@ Pass    Pass
 {HCP 1 8 15 16}
 {TP 2 10 15 16}
 {Losers 11 7 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -983,7 +983,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    3S
 Pass    4H      Pass    4S
 Pass    Pass    Pass    
@@ -1005,7 +1005,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -1027,7 +1027,7 @@ Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      Pass    2D
+1N     2C      Pass    2D
 Pass    2S      Pass    Pass
 X       Pass    3D      Pass
 Pass    Pass    
@@ -1049,7 +1049,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    Pass
 Pass    
 
@@ -1070,7 +1070,7 @@ Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2C
+1N     X       XX      2C
 Pass    Pass    Pass    
 
 
@@ -1090,7 +1090,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -1111,7 +1111,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2D      Pass    Pass
 Pass    
 
@@ -1132,7 +1132,7 @@ Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 X       Pass    3C      3H
 Pass    Pass    Pass    
 
@@ -1153,7 +1153,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -1173,7 +1173,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -1194,7 +1194,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    3C      Pass    4S
 Pass    Pass    Pass    
 
@@ -1215,7 +1215,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    2H      Pass    2S
 Pass    Pass    Pass    
@@ -1237,7 +1237,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -1258,7 +1258,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -1279,7 +1279,7 @@ Pass    Pass    Pass
 [Contract "2DX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      X
 Pass    Pass    Pass    
 
@@ -1300,7 +1300,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2H
 Pass    4H      Pass    Pass
 Pass    
@@ -1322,7 +1322,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2H
 Pass    3D      Pass    3H
 Pass    4H      Pass    Pass
@@ -1345,7 +1345,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2D      Pass    2S
 Pass    Pass    Pass    
 
@@ -1366,7 +1366,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -1384,12 +1384,12 @@ Pass    Pass    Pass
 {HCP 3 5 15 17}
 {TP 4 7 16 18}
 {Losers 10 8 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
-Pass    3H      Pass    3NT
+Pass    3H      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -1409,7 +1409,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -1427,10 +1427,10 @@ Pass    Pass    Pass
 {HCP 4 4 16 16}
 {TP 6 5 16 17}
 {Losers 9 10 7 5}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1450,7 +1450,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      X       2D      2S
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
@@ -1472,7 +1472,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -1493,7 +1493,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    3H      Pass    Pass
 Pass    
 
@@ -1514,7 +1514,7 @@ Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -1535,7 +1535,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -1555,7 +1555,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -1576,7 +1576,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    2S      Pass    3D
 Pass    Pass    Pass    
 
@@ -1597,7 +1597,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -1615,10 +1615,10 @@ Pass    Pass    Pass
 {HCP 4 5 15 16}
 {TP 5 6 15 16}
 {Losers 9 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1638,7 +1638,7 @@ Pass    Pass    Pass
 [Contract "2DX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      X
 Pass    Pass    Pass    
 
@@ -1659,7 +1659,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -1680,7 +1680,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -1701,7 +1701,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 3C      3H      Pass    Pass
 Pass    
 
@@ -1722,7 +1722,7 @@ Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -1743,7 +1743,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -1764,9 +1764,9 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    3D
-Pass    3H      Pass    3NT
+Pass    3H      Pass    3N
 Pass    4H      Pass    Pass
 Pass    
 
@@ -1787,7 +1787,7 @@ Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      3D      Pass    Pass
 Pass    
 
@@ -1808,7 +1808,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    3C      Pass    3D
 Pass    4H      Pass    Pass
 Pass    
@@ -1830,7 +1830,7 @@ Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -1851,7 +1851,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2S
 Pass    4S      Pass    Pass
 Pass    
@@ -1873,7 +1873,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2H
 Pass    4H      Pass    Pass
 Pass    
@@ -1895,7 +1895,7 @@ Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -1916,7 +1916,7 @@ Pass    Pass
 [Contract "2DX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      X
 Pass    Pass    Pass    
 
@@ -1937,7 +1937,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -1955,10 +1955,10 @@ Pass    Pass    Pass
 {HCP 3 5 16 16}
 {TP 4 7 17 17}
 {Losers 11 8 6 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1978,7 +1978,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    Pass    Pass    
 
 
@@ -1998,7 +1998,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      X       2D      Pass
 Pass    2S      Pass    Pass
 Pass    
@@ -2017,13 +2017,13 @@ Pass
 {HCP 2 5 15 18}
 {TP 4 6 15 18}
 {Losers 10 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2H
 Pass    3D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -2043,7 +2043,7 @@ Pass
 [Contract "2DX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      X
 Pass    Pass    Pass    
 
@@ -2064,7 +2064,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      2C
+1N     X       XX      2C
 Pass    2H      Pass    Pass
 Pass    
 
@@ -2085,7 +2085,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    2H      Pass    4D
 Pass    4H      Pass    Pass
 Pass    
@@ -2107,7 +2107,7 @@ Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    Pass    Pass    
 
 
@@ -2124,10 +2124,10 @@ Pass    Pass    Pass
 {HCP 0 7 17 16}
 {TP 1 8 18 18}
 {Losers 11 9 5 5}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2147,7 +2147,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2H
 Pass    Pass    Pass    
 
@@ -2168,7 +2168,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2S
 Pass    3D      Pass    3S
 Pass    4S      Pass    Pass
@@ -2191,7 +2191,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    2H      Pass    2S
 Pass    Pass    Pass    
@@ -2213,7 +2213,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      3S
 Pass    4H      Pass    4S
 Pass    Pass    Pass    
@@ -2232,10 +2232,10 @@ Pass    Pass    Pass
 {HCP 2 6 16 16}
 {TP 4 8 16 17}
 {Losers 10 8 7 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2255,7 +2255,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -2275,7 +2275,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -2296,7 +2296,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    Pass
 Pass    
 
@@ -2317,7 +2317,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     Pass    Pass    2D
+1N     Pass    Pass    2D
 2H      4H      Pass    Pass
 Pass    
 
@@ -2338,7 +2338,7 @@ Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2D
 Pass    2H      Pass    Pass
 3C      Pass    Pass    Pass
@@ -2361,7 +2361,7 @@ Pass    2H      Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      X       2D      3C
 Pass    Pass    Pass    
 
@@ -2382,7 +2382,7 @@ Pass    Pass    Pass
 [Contract "2DX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      X
 Pass    Pass    Pass    
 
@@ -2403,7 +2403,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -2423,7 +2423,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      X       2D      Pass
 Pass    Pass    
 
@@ -2444,7 +2444,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2H
 Pass    2S      Pass    Pass
 Pass    
@@ -2466,7 +2466,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -2486,7 +2486,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -2503,12 +2503,12 @@ Pass    Pass    Pass
 {HCP 2 5 15 18}
 {TP 3 7 15 18}
 {Losers 11 9 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -2528,7 +2528,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    Pass
 Pass    
 
@@ -2549,7 +2549,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2D      Pass    2H
 Pass    Pass    Pass    
 
@@ -2570,7 +2570,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    Pass    Pass    
 
 
@@ -2590,7 +2590,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -2608,10 +2608,10 @@ Pass    Pass    Pass
 {HCP 2 5 17 16}
 {TP 4 6 17 17}
 {Losers 9 9 8 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2631,7 +2631,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
 Pass    4S      Pass    Pass
 Pass    
@@ -2653,7 +2653,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -2673,7 +2673,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 X       3C      Pass    3H
 Pass    Pass    Pass    
 
@@ -2694,7 +2694,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2C
+1N     X       XX      2C
 Pass    Pass    Pass    
 
 
@@ -2711,10 +2711,10 @@ Pass    Pass    Pass
 {HCP 4 4 16 16}
 {TP 6 6 16 17}
 {Losers 9 8 7 5}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2734,7 +2734,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -2755,7 +2755,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    Pass
 Pass    
 
@@ -2776,7 +2776,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -2798,7 +2798,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -2818,7 +2818,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -2838,7 +2838,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -2859,7 +2859,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2H
 Pass    2S      Pass    Pass
 Pass    
@@ -2881,7 +2881,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      2C
+1N     X       XX      2C
 Pass    2H      Pass    4H
 Pass    Pass    Pass    
 
@@ -2902,7 +2902,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      X       2D      Pass
 Pass    2S      Pass    3C
 Pass    Pass    Pass    
@@ -2924,7 +2924,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2S
 Pass    Pass    Pass    
 
@@ -2945,7 +2945,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    3D
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
@@ -2967,7 +2967,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -2988,7 +2988,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -3009,7 +3009,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    3C
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
@@ -3031,7 +3031,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    3C
 Pass    4S      Pass    Pass
 Pass    
@@ -3053,7 +3053,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -3075,7 +3075,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    2S
 Pass    Pass    Pass    
 
@@ -3096,7 +3096,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -3116,7 +3116,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2C
+1N     X       XX      2C
 Pass    2D      Pass    2S
 Pass    Pass    Pass    
 
@@ -3137,7 +3137,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -3159,7 +3159,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -3179,7 +3179,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -3199,7 +3199,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2D      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -3218,10 +3218,10 @@ Pass
 {HCP 3 5 16 16}
 {TP 4 6 16 17}
 {Losers 10 10 8 5}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3241,7 +3241,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
 
@@ -3262,7 +3262,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -3279,10 +3279,10 @@ Pass    Pass    Pass
 {HCP 4 3 17 16}
 {TP 6 4 17 16}
 {Losers 9 10 6 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3302,7 +3302,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -3323,7 +3323,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    3H
 Pass    Pass    Pass    
 
@@ -3344,7 +3344,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    2S      Pass    Pass
 Pass    
 
@@ -3365,7 +3365,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -3385,7 +3385,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    3H
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
@@ -3407,7 +3407,7 @@ Pass    Pass    Pass
 [Contract "2DX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      X
 Pass    Pass    Pass    
 
@@ -3428,7 +3428,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    Pass
 
 
@@ -3449,7 +3449,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    2S      Pass    3D
 Pass    Pass    Pass    
 
@@ -3470,7 +3470,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -3491,7 +3491,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    2H      Pass    Pass
 Pass    
 
@@ -3512,7 +3512,7 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      2D
+1N     X       XX      2D
 Pass    2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -3534,7 +3534,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    2H      Pass    Pass
 Pass    
@@ -3556,7 +3556,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    3D
 Pass    4H      Pass    Pass
 Pass    
@@ -3578,7 +3578,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -3600,7 +3600,7 @@ Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2H
 Pass    2S      Pass    3C
 Pass    Pass    Pass    
@@ -3622,7 +3622,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      3H      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -3644,7 +3644,7 @@ Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    3S      Pass    Pass
 Pass    
 
@@ -3665,7 +3665,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -3685,7 +3685,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       XX      2C
+1N     X       XX      2C
 Pass    Pass    2D      Pass
 2S      Pass    Pass    Pass
 
@@ -3707,7 +3707,7 @@ Pass    Pass    2D      Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    2S      Pass    Pass
 X       Pass    3D      Pass
@@ -3727,13 +3727,13 @@ Pass    Pass
 {HCP 1 7 15 17}
 {TP 2 7 15 18}
 {Losers 10 9 8 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2H
 Pass    3C      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -3753,7 +3753,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -3773,7 +3773,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    2H      Pass    Pass
 Pass    
@@ -3792,10 +3792,10 @@ Pass
 {HCP 1 3 16 20}
 {TP 3 6 16 21}
 {Losers 10 8 7 4}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3815,7 +3815,7 @@ Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2D
 Pass    Pass    Pass    
 
@@ -3833,10 +3833,10 @@ Pass    Pass    Pass
 {HCP 3 6 15 16}
 {TP 5 8 16 17}
 {Losers 9 8 7 5}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3856,7 +3856,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    Pass
 Pass    
 
@@ -3877,7 +3877,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2S
 Pass    4S      Pass    Pass
 Pass    
@@ -3899,7 +3899,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2H
 Pass    4H      Pass    Pass
 Pass    
@@ -3921,7 +3921,7 @@ Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -3941,7 +3941,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    2S
 Pass    Pass    Pass    
 
@@ -3962,7 +3962,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 Pass    Pass    Pass    
 
 
@@ -3982,7 +3982,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      2H
 Pass    2S      Pass    Pass
 Pass    
@@ -4004,7 +4004,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -4026,7 +4026,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -4046,7 +4046,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2S
 Pass    4S      Pass    Pass
 Pass    
@@ -4068,7 +4068,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2H
 Pass    2S      Pass    3D
 Pass    3H      Pass    4H
@@ -4091,7 +4091,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 X       Pass    3D      Pass
 Pass    4H      Pass    Pass
 Pass    
@@ -4113,7 +4113,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -4135,7 +4135,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -4155,7 +4155,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      3H
 Pass    3S      Pass    4H
 Pass    Pass    Pass    
@@ -4177,7 +4177,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -4198,7 +4198,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    2D      Pass
 Pass    Pass    
 
@@ -4219,7 +4219,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2H
 Pass    4H      Pass    Pass
 Pass    
@@ -4241,7 +4241,7 @@ Pass
 [Contract "2D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      Pass    Pass    2D
 Pass    Pass    Pass    
 
@@ -4262,7 +4262,7 @@ Pass    Pass    Pass
 [Contract "4C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    3H      Pass    4C
 Pass    Pass    Pass    
 
@@ -4283,7 +4283,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -4300,12 +4300,12 @@ Pass    Pass    Pass
 {HCP 2 5 15 18}
 {TP 2 6 15 19}
 {Losers 11 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2S      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -4322,10 +4322,10 @@ Pass
 {HCP 2 7 15 16}
 {TP 3 9 15 18}
 {Losers 10 8 7 5}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4345,7 +4345,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 Pass    Pass    Pass    
 
 
@@ -4365,7 +4365,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      2H      Pass    2S
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
@@ -4387,7 +4387,7 @@ Pass    Pass    Pass
 [Contract "2C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       XX      2C
+1N     X       XX      2C
 Pass    Pass    Pass    
 
 
@@ -4407,7 +4407,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 X       3C      3D      Pass
 Pass    Pass    
 
@@ -4425,12 +4425,12 @@ Pass    Pass
 {HCP 1 7 15 17}
 {TP 3 10 15 18}
 {Losers 10 7 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       XX      Pass
+1N     X       XX      Pass
 2C      X       2D      3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -4450,7 +4450,7 @@ Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      2S
+1N     X       XX      2S
 X       Pass    3C      Pass
 Pass    Pass    
 
@@ -4471,7 +4471,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     X       XX      2H
+1N     X       XX      2H
 X       2S      3C      Pass
 Pass    Pass    
 
@@ -4489,9 +4489,9 @@ Pass    Pass
 {HCP 5 4 15 16}
 {TP 7 5 15 16}
 {Losers 9 9 7 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 

--- a/GIB/GIB_Sandwich_NT_BPH.pbn
+++ b/GIB/GIB_Sandwich_NT_BPH.pbn
@@ -12,7 +12,7 @@
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -29,7 +29,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3C
+1N     2H      2S      3C
 Pass    4H      Pass    Pass
 Pass    
 
@@ -47,7 +47,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -64,7 +64,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       4C      X
+1N     X       4C      X
 Pass    4D      Pass    4S
 Pass    Pass    Pass    
 
@@ -82,7 +82,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -100,7 +100,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3C      Pass    3H
 Pass    Pass    Pass    
 
@@ -118,7 +118,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 Pass    Pass    
 
 
@@ -135,7 +135,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2C      X
+1N     X       2C      X
 Pass    2D      Pass    3D
 Pass    Pass    Pass    
 
@@ -153,7 +153,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -170,7 +170,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     X       2H      Pass
+1N     X       2H      Pass
 Pass    Pass    
 
 
@@ -187,7 +187,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     Pass    2H      3D
+1N     Pass    2H      3D
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -205,7 +205,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2C      Pass
+1N     X       2C      Pass
 Pass    Pass    
 
 
@@ -222,7 +222,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2D      2H      3D
+1N     2D      2H      3D
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -240,7 +240,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -257,7 +257,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2C      2H
+1N     X       2C      2H
 Pass    Pass    3C      Pass
 Pass    Pass    
 
@@ -275,7 +275,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -292,7 +292,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -309,7 +309,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    Pass    Pass    
 
 
@@ -326,7 +326,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      4H      4S
+1N     2S      4H      4S
 Pass    Pass    Pass    
 
 
@@ -343,7 +343,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2D      2S
+1N     X       2D      2S
 Pass    Pass    Pass    
 
 
@@ -360,7 +360,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -377,7 +377,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3C
+1N     2S      Pass    3C
 Pass    4S      Pass    Pass
 Pass    
 
@@ -395,7 +395,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3C
+1N     2H      2S      3C
 Pass    3H      Pass    Pass
 Pass    
 
@@ -413,7 +413,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -430,7 +430,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2D      2H
+1N     X       2D      2H
 Pass    Pass    3D      Pass
 Pass    Pass    
 
@@ -448,7 +448,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -465,7 +465,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      X
+1N     X       2H      X
 Pass    3C      Pass    3H
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
@@ -484,7 +484,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     Pass    2S      3D
+1N     Pass    2S      3D
 Pass    Pass    Pass    
 
 
@@ -501,7 +501,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -518,7 +518,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2C      2H
+1N     X       2C      2H
 Pass    Pass    Pass    
 
 
@@ -535,7 +535,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     X       2C      2S
+1N     X       2C      2S
 Pass    Pass    Pass    
 
 
@@ -552,7 +552,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -570,7 +570,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      3C
+1N     X       2S      3C
 Pass    Pass    Pass    
 
 
@@ -587,7 +587,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -605,7 +605,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2C      X
+1N     X       2C      X
 Pass    2D      Pass    3D
 Pass    Pass    Pass    
 
@@ -623,7 +623,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3C      Pass    3D
 Pass    Pass    3S      Pass
 Pass    Pass    
@@ -642,7 +642,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -659,7 +659,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       4C      4D
+1N     X       4C      4D
 Pass    Pass    Pass    
 
 
@@ -676,7 +676,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     Pass    2H      3H
+1N     Pass    2H      3H
 Pass    4D      Pass    Pass
 Pass    
 
@@ -694,7 +694,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -711,7 +711,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     2C      2S      3C
+1N     2C      2S      3C
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -729,7 +729,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2C      2D
+1N     X       2C      2D
 Pass    Pass    3C      Pass
 Pass    3D      Pass    Pass
 Pass    
@@ -744,11 +744,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "None"]
 [Deal "N:Q943.98764.K7.A6 KJT65.K5.83.K732 72.2.AJT92.QJT94 A8.AQJT3.Q654.85"]
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -765,7 +765,7 @@ Pass    1H      Pass    1S
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       4C      X
+1N     X       4C      X
 Pass    4S      Pass    Pass
 Pass    
 
@@ -783,7 +783,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2C      2S
+1N     X       2C      2S
 Pass    Pass    3C      Pass
 Pass    Pass    
 
@@ -801,7 +801,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -818,7 +818,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -835,7 +835,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2D      2S
+1N     X       2D      2S
 Pass    Pass    3D      Pass
 Pass    Pass    
 
@@ -853,7 +853,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      3C
+1N     X       2S      3C
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -871,7 +871,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -888,7 +888,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -906,7 +906,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -924,7 +924,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      X
+1N     X       2H      X
 Pass    3C      Pass    3S
 Pass    Pass    Pass    
 
@@ -942,7 +942,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -959,7 +959,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     X       2C      Pass
+1N     X       2C      Pass
 Pass    Pass    
 
 
@@ -976,7 +976,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -993,7 +993,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -1010,7 +1010,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1027,7 +1027,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       4C      Pass
+1N     X       4C      Pass
 Pass    Pass    
 
 
@@ -1044,7 +1044,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -1061,7 +1061,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     X       2D      2S
+1N     X       2D      2S
 Pass    Pass    3D      3H
 Pass    3S      Pass    Pass
 Pass    
@@ -1080,7 +1080,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2C      2S
+1N     X       2C      2S
 Pass    Pass    3C      3D
 Pass    3S      Pass    Pass
 Pass    
@@ -1099,7 +1099,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     X       2D      Pass
+1N     X       2D      Pass
 Pass    Pass    
 
 
@@ -1116,7 +1116,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2C      2S      Pass
+1N     2C      2S      Pass
 Pass    Pass    
 
 
@@ -1133,7 +1133,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     Pass    2H      3C
+1N     Pass    2H      3C
 Pass    Pass    Pass    
 
 
@@ -1150,7 +1150,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -1167,7 +1167,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      3H      4S
+1N     2S      3H      4S
 Pass    Pass    Pass    
 
 
@@ -1184,7 +1184,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1201,7 +1201,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      Pass
+1N     X       2H      Pass
 Pass    Pass    
 
 
@@ -1218,7 +1218,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      3H      3S
+1N     2S      3H      3S
 Pass    Pass    Pass    
 
 
@@ -1252,7 +1252,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -1270,7 +1270,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     X       2H      X
+1N     X       2H      X
 Pass    3C      Pass    3D
 Pass    Pass    3H      3S
 Pass    4D      Pass    Pass
@@ -1290,7 +1290,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2H      Pass    3H
+1N     2H      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
 
@@ -1308,7 +1308,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    4S
+1N     2S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -1325,7 +1325,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -1342,7 +1342,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -1359,7 +1359,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1394,7 +1394,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      X
+1N     X       2H      X
 Pass    3D      Pass    3S
 Pass    Pass    Pass    
 
@@ -1412,7 +1412,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3C      Pass    3H
 Pass    Pass    Pass    
 
@@ -1430,7 +1430,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    Pass    Pass    
 
 
@@ -1447,7 +1447,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2D      2S
+1N     X       2D      2S
 Pass    3C      Pass    4S
 Pass    Pass    Pass    
 
@@ -1465,7 +1465,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      Pass    4H
+1N     2H      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -1482,7 +1482,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     2D      2H      2S
+1N     2D      2H      2S
 Pass    3D      3H      Pass
 Pass    Pass    
 
@@ -1500,7 +1500,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1535,7 +1535,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      Pass    3C
+1N     2H      Pass    3C
 Pass    3H      Pass    Pass
 Pass    
 
@@ -1553,7 +1553,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     X       4C      X
+1N     X       4C      X
 Pass    4H      Pass    Pass
 Pass    
 
@@ -1571,7 +1571,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -1588,7 +1588,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       4C      4D
+1N     X       4C      4D
 Pass    Pass    Pass    
 
 
@@ -1605,7 +1605,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      4C      Pass
+1N     2S      4C      Pass
 Pass    Pass    
 
 
@@ -1622,7 +1622,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1639,7 +1639,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -1657,7 +1657,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3D
+1N     2S      Pass    3D
 Pass    3S      Pass    Pass
 Pass    
 
@@ -1675,7 +1675,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      4H
+1N     2H      2S      4H
 Pass    Pass    Pass    
 
 
@@ -1692,7 +1692,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2D      2H
+1N     X       2D      2H
 Pass    Pass    Pass    
 
 
@@ -1709,7 +1709,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -1726,7 +1726,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       4C      Pass
+1N     X       4C      Pass
 Pass    Pass    
 
 
@@ -1743,7 +1743,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -1760,7 +1760,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3D
+1N     2S      Pass    3D
 Pass    3S      Pass    Pass
 Pass    
 
@@ -1795,7 +1795,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2S      4D      Pass
+1N     2S      4D      Pass
 Pass    Pass    
 
 
@@ -1812,7 +1812,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2D      Pass    3D
+1N     2D      Pass    3D
 Pass    Pass    Pass    
 
 
@@ -1829,7 +1829,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3C      Pass    3H
 Pass    Pass    Pass    
 
@@ -1881,7 +1881,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1898,7 +1898,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -1915,7 +1915,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -1933,7 +1933,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2C      2H
+1N     X       2C      2H
 Pass    Pass    3C      Pass
 Pass    Pass    
 
@@ -1951,7 +1951,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -1968,7 +1968,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2S      4C      Pass
+1N     2S      4C      Pass
 Pass    Pass    
 
 
@@ -1985,7 +1985,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -2003,7 +2003,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     3C      Pass    3S
+1N     3C      Pass    3S
 Pass    4C      Pass    5C
 Pass    Pass    Pass    
 
@@ -2021,7 +2021,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -2039,7 +2039,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      4C      Pass
+1N     2S      4C      Pass
 Pass    Pass    
 
 
@@ -2056,7 +2056,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -2073,7 +2073,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     X       2H      Pass
+1N     X       2H      Pass
 Pass    Pass    
 
 
@@ -2090,7 +2090,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     Pass    2S      3C
+1N     Pass    2S      3C
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -2108,7 +2108,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      4H      4S
+1N     2S      4H      4S
 Pass    Pass    Pass    
 
 
@@ -2125,7 +2125,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     Pass    2S      3C
+1N     Pass    2S      3C
 Pass    Pass    Pass    
 
 
@@ -2142,7 +2142,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2D      Pass    3D
+1N     2D      Pass    3D
 Pass    Pass    Pass    
 
 
@@ -2159,7 +2159,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     X       2D      Pass
+1N     X       2D      Pass
 Pass    2H      Pass    4H
 Pass    Pass    Pass    
 
@@ -2177,7 +2177,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -2195,7 +2195,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -2212,7 +2212,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2D      2S
+1N     X       2D      2S
 Pass    Pass    3D      Pass
 Pass    Pass    
 
@@ -2248,7 +2248,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     X       2D      Pass
+1N     X       2D      Pass
 Pass    2H      Pass    4H
 Pass    Pass    Pass    
 
@@ -2266,7 +2266,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    1H
-2S      3NT     4S      5C
+2S      3N     4S      5C
 Pass    Pass    Pass    
 
 
@@ -2283,7 +2283,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    3C      Pass    4S
 Pass    Pass    Pass    
 
@@ -2301,7 +2301,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2D      2H
+1N     X       2D      2H
 Pass    Pass    3D      Pass
 Pass    Pass    
 
@@ -2319,7 +2319,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     Pass    2S      Pass
+1N     Pass    2S      Pass
 Pass    X       Pass    Pass
 Pass    
 
@@ -2337,7 +2337,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     Pass    2S      Pass
+1N     Pass    2S      Pass
 Pass    X       Pass    3H
 Pass    Pass    Pass    
 
@@ -2355,7 +2355,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -2373,7 +2373,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     Pass    2S      Pass
+1N     Pass    2S      Pass
 Pass    X       Pass    Pass
 Pass    
 
@@ -2391,7 +2391,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -2408,7 +2408,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      3D
+1N     2H      2S      3D
 Pass    4H      Pass    Pass
 Pass    
 
@@ -2426,7 +2426,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    Pass    Pass    
 
 
@@ -2443,7 +2443,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     3C      Pass    3S
+1N     3C      Pass    3S
 Pass    4C      Pass    5C
 Pass    Pass    Pass    
 
@@ -2461,7 +2461,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      4S      5H
+1N     2H      4S      5H
 Pass    Pass    Pass    
 
 
@@ -2478,7 +2478,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -2492,11 +2492,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:J5.K74.JT62.KJT5 92.982.AQ74.A864 KQT73.QJT63.53.2 A864.A5.K98.Q973"]
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    2C
-Pass    2NT     Pass    Pass
+Pass    2N     Pass    Pass
 Pass    
 
 
@@ -2513,7 +2513,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -2530,7 +2530,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-Pass    1C      Pass    1NT
+Pass    1C      Pass    1N
 2C      Pass    2S      Pass
 Pass    Pass    
 
@@ -2564,7 +2564,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2S      3D
+1N     X       2S      3D
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -2582,7 +2582,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      4D      4H
+1N     2H      4D      4H
 Pass    Pass    Pass    
 
 
@@ -2599,7 +2599,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    Pass    Pass    
 
 
@@ -2616,7 +2616,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3D
+1N     2S      Pass    3D
 Pass    4S      Pass    Pass
 Pass    
 
@@ -2634,7 +2634,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3C
+1N     2H      2S      3C
 Pass    3H      3S      4H
 Pass    Pass    Pass    
 
@@ -2652,7 +2652,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -2670,7 +2670,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -2687,7 +2687,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2D      2H      3D
+1N     2D      2H      3D
 Pass    Pass    Pass    
 
 
@@ -2704,7 +2704,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -2739,7 +2739,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     2D      2S      3D
+1N     2D      2S      3D
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -2757,7 +2757,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       4H      Pass
+1N     X       4H      Pass
 Pass    Pass    
 
 
@@ -2774,7 +2774,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      4H
+1N     2H      2S      4H
 Pass    Pass    Pass    
 
 
@@ -2791,7 +2791,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -2807,7 +2807,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-Pass    1C      Pass    1NT
+Pass    1C      Pass    1N
 2C      Pass    2S      Pass
 Pass    Pass    
 
@@ -2825,7 +2825,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     2D      2S      3D
+1N     2D      2S      3D
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -2843,7 +2843,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -2860,7 +2860,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    4S
+1N     2S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -2877,7 +2877,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3C      Pass    3H
 Pass    Pass    Pass    
 
@@ -2913,7 +2913,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -2931,7 +2931,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 Pass    Pass    Pass    
 
 
@@ -2948,7 +2948,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -2965,7 +2965,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 Pass    Pass    Pass    
 
 
@@ -2982,7 +2982,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       4S      Pass
+1N     X       4S      Pass
 Pass    Pass    
 
 
@@ -2999,7 +2999,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -3016,7 +3016,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     3C      Pass    3S
+1N     3C      Pass    3S
 Pass    4C      Pass    5C
 Pass    Pass    Pass    
 
@@ -3034,7 +3034,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-Pass    1NT     Pass    2D
+Pass    1N     Pass    2D
 Pass    Pass    Pass    
 
 
@@ -3047,11 +3047,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "NS"]
 [Deal "N:Q987.A5.Q8.98532 KJ643.K9.K743.T7 T2.QJT62.AJT52.6 A5.8743.96.AKQJ4"]
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3085,7 +3085,7 @@ Pass    1D      Pass    1H
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2C      2S
+1N     X       2C      2S
 Pass    Pass    3C      Pass
 Pass    Pass    
 
@@ -3103,7 +3103,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2D      4C      4D
+1N     2D      4C      4D
 Pass    Pass    Pass    
 
 
@@ -3116,12 +3116,12 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:642.QJ83.Q96.A97 3.AT92.AJ842.J42 QJT987.65..KQT85 AK5.K74.KT753.63"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1H
 2S      Pass    Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -3138,7 +3138,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      3S
+1N     X       2S      3S
 Pass    4H      Pass    Pass
 Pass    
 
@@ -3156,7 +3156,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      Pass    4H
+1N     2H      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -3173,7 +3173,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3C      Pass    3H
 Pass    Pass    3S      Pass
 Pass    Pass    
@@ -3192,7 +3192,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      Pass    3H
+1N     2H      Pass    3H
 Pass    Pass    Pass    
 
 
@@ -3209,7 +3209,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -3226,7 +3226,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -3243,7 +3243,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-Pass    1NT     Pass    2D
+Pass    1N     Pass    2D
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -3261,7 +3261,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    Pass    
 
 
@@ -3278,7 +3278,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3D
+1N     2S      Pass    3D
 Pass    4S      Pass    Pass
 Pass    
 
@@ -3296,7 +3296,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3309,13 +3309,13 @@ Pass
 [Dealer "S"]
 [Vulnerable "None"]
 [Deal "N:J95.Q8.QT84.Q953 AQT43.63.A7653.7 862.KJT97..AJT62 K7.A542.KJ92.K84"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     Pass    2C      2H
-Pass    2NT     Pass    3C
-Pass    3NT     Pass    Pass
+1N     Pass    2C      2H
+Pass    2N     Pass    3C
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -3332,7 +3332,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3349,7 +3349,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3C
+1N     2S      Pass    3C
 Pass    3S      Pass    Pass
 Pass    
 
@@ -3367,7 +3367,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     X       2H      Pass
+1N     X       2H      Pass
 Pass    Pass    
 
 
@@ -3384,7 +3384,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      Pass    3D
+1N     2H      Pass    3D
 Pass    4H      Pass    Pass
 Pass    
 
@@ -3398,13 +3398,13 @@ Pass
 [Dealer "S"]
 [Vulnerable "EW"]
 [Deal "N:96.8652.Q97.AK32 Q852.AKJ43.6.964 KJT43.97.AJT53.T A7.QT.K842.QJ875"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     Pass    2D      X
-Pass    2NT     Pass    3H
-Pass    3NT     Pass    Pass
+1N     Pass    2D      X
+Pass    2N     Pass    3H
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -3421,7 +3421,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -3438,7 +3438,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3C
+1N     2H      2S      3C
 Pass    4H      Pass    Pass
 Pass    
 
@@ -3456,7 +3456,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -3491,7 +3491,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3D      Pass    3H
 Pass    Pass    Pass    
 
@@ -3509,7 +3509,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -3527,7 +3527,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2C      2S
+1N     X       2C      2S
 Pass    3D      Pass    4S
 Pass    Pass    Pass    
 
@@ -3545,7 +3545,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      X
+1N     X       2H      X
 Pass    3D      Pass    Pass
 Pass    
 
@@ -3563,7 +3563,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3580,7 +3580,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3C      Pass    3H
 Pass    Pass    3S      Pass
 Pass    Pass    
@@ -3599,7 +3599,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3D      Pass    Pass
 Pass    
 
@@ -3634,7 +3634,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3647,11 +3647,11 @@ Pass
 [Dealer "S"]
 [Vulnerable "None"]
 [Deal "N:A5.KT842.T864.96 932.AQ953.KJ.843 KQT64.6.Q7.QJT52 J87.J7.A9532.AK7"]
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3668,7 +3668,7 @@ Pass    1D      Pass    1H
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -3685,7 +3685,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      3D
+1N     2H      2S      3D
 Pass    3H      Pass    Pass
 Pass    
 
@@ -3720,7 +3720,7 @@ Pass    1C      Pass    1H
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    4S
+1N     2S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -3737,7 +3737,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -3755,7 +3755,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2D      2S
+1N     X       2D      2S
 Pass    Pass    Pass    
 
 
@@ -3768,13 +3768,13 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "None"]
 [Deal "N:Q984.J62.KJT8.Q7 52.A543.AQ954.95 KJT76.T87..AJT64 A3.KQ9.7632.K832"]
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -3791,7 +3791,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2S      4D      Pass
+1N     2S      4D      Pass
 Pass    Pass    
 
 
@@ -3808,7 +3808,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     Pass    2S      Pass
+1N     Pass    2S      Pass
 Pass    Pass    
 
 
@@ -3841,7 +3841,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -3858,7 +3858,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3893,7 +3893,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      Pass
+1N     X       2H      Pass
 Pass    Pass    
 
 
@@ -3926,7 +3926,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3943,7 +3943,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -3960,7 +3960,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     3S      4D      4S
+1N     3S      4D      4S
 Pass    Pass    Pass    
 
 
@@ -3977,7 +3977,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3D
+1N     2S      Pass    3D
 Pass    4S      Pass    Pass
 Pass    
 
@@ -3995,7 +3995,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -4012,7 +4012,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -4029,7 +4029,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    4S
+1N     2S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -4046,7 +4046,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3C      Pass    3H
 Pass    Pass    3S      Pass
 Pass    Pass    
@@ -4065,7 +4065,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      Pass    3H
+1N     2H      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
 
@@ -4100,7 +4100,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -4117,7 +4117,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -4134,7 +4134,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    Pass    Pass    
 
 
@@ -4150,7 +4150,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-Pass    1C      Pass    1NT
+Pass    1C      Pass    1N
 2C      X       4H      Pass
 Pass    Pass    
 
@@ -4167,7 +4167,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "S"]
-Pass    1C      Pass    1NT
+Pass    1C      Pass    1N
 2C      Pass    2H      Pass
 Pass    Pass    
 
@@ -4201,7 +4201,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -4219,7 +4219,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -4236,7 +4236,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3C
+1N     2H      2S      3C
 Pass    4H      Pass    Pass
 Pass    
 
@@ -4254,7 +4254,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -4271,7 +4271,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -4288,7 +4288,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    Pass    Pass    
 
 
@@ -4305,7 +4305,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     3S      4C      4S
+1N     3S      4C      4S
 Pass    Pass    Pass    
 
 
@@ -4322,7 +4322,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -4339,7 +4339,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -4356,7 +4356,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     Pass    2H      3D
+1N     Pass    2H      3D
 Pass    Pass    Pass    
 
 
@@ -4373,7 +4373,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2D      Pass
+1N     X       2D      Pass
 Pass    Pass    
 
 
@@ -4390,7 +4390,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 Pass    Pass    
 
 
@@ -4407,7 +4407,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2C      X
+1N     X       2C      X
 Pass    2D      Pass    3D
 Pass    Pass    Pass    
 
@@ -4425,7 +4425,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -4442,7 +4442,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     Pass    2H      3D
+1N     Pass    2H      3D
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -4460,7 +4460,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2D      2H      3D
+1N     2D      2H      3D
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -4478,7 +4478,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     X       2C      Pass
+1N     X       2C      Pass
 Pass    2H      Pass    Pass
 Pass    
 
@@ -4496,7 +4496,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -4513,7 +4513,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2D      2S
+1N     X       2D      2S
 Pass    Pass    3D      Pass
 Pass    Pass    
 
@@ -4531,7 +4531,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2C      2H
+1N     X       2C      2H
 Pass    Pass    3C      Pass
 Pass    Pass    
 
@@ -4549,7 +4549,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -4566,7 +4566,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -4583,7 +4583,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    Pass    Pass    
 
 
@@ -4600,7 +4600,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -4617,7 +4617,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3C
+1N     2S      Pass    3C
 Pass    4S      Pass    Pass
 Pass    
 
@@ -4635,7 +4635,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3C
+1N     2H      2S      3C
 Pass    3H      Pass    Pass
 Pass    
 
@@ -4653,7 +4653,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -4670,7 +4670,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -4687,7 +4687,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      X
+1N     X       2H      X
 Pass    3C      Pass    3H
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
@@ -4706,7 +4706,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -4723,7 +4723,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -4740,7 +4740,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2C      2H
+1N     X       2C      2H
 Pass    Pass    Pass    
 
 
@@ -4757,7 +4757,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     X       2C      2S
+1N     X       2C      2S
 Pass    Pass    Pass    
 
 
@@ -4774,7 +4774,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -4791,7 +4791,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    Pass    Pass    
 
 
@@ -4808,7 +4808,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    Pass    Pass    
 
 
@@ -4825,7 +4825,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -4843,7 +4843,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2C      2H
+1N     X       2C      2H
 Pass    Pass    3C      Pass
 Pass    Pass    
 
@@ -4861,7 +4861,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      3C
+1N     X       2S      3C
 Pass    Pass    Pass    
 
 
@@ -4878,7 +4878,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -4896,7 +4896,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2C      X
+1N     X       2C      X
 Pass    2D      Pass    3D
 Pass    Pass    Pass    
 
@@ -4914,7 +4914,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     X       2S      X
+1N     X       2S      X
 Pass    3C      Pass    3D
 Pass    Pass    3S      Pass
 Pass    Pass    
@@ -4933,7 +4933,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -4950,7 +4950,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     Pass    2H      3H
+1N     Pass    2H      3H
 Pass    4D      Pass    Pass
 Pass    
 
@@ -4968,7 +4968,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -4985,7 +4985,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -5002,7 +5002,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -5019,7 +5019,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -5036,7 +5036,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -5053,7 +5053,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1D
-1NT     2C      2S      3C
+1N     2C      2S      3C
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -5071,7 +5071,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2C      2D
+1N     X       2C      2D
 Pass    Pass    3C      Pass
 Pass    3D      Pass    Pass
 Pass    
@@ -5090,7 +5090,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    Pass    Pass    
 
 
@@ -5107,7 +5107,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -5124,7 +5124,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -5142,7 +5142,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    4S
+1N     2S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -5155,11 +5155,11 @@ Pass    Pass    Pass
 [Dealer "S"]
 [Vulnerable "All"]
 [Deal "N:Q943.98764.K7.A6 KJT65.K5.83.K732 72.2.AJT92.QJT94 A8.AQJT3.Q654.85"]
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5176,7 +5176,7 @@ Pass    1H      Pass    1S
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5193,7 +5193,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    3H      Pass
 Pass    Pass    
 
@@ -5211,7 +5211,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -5228,7 +5228,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -5245,7 +5245,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -5262,7 +5262,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -5279,7 +5279,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 Pass    X       Pass    3C
 Pass    Pass    Pass    
 
@@ -5297,7 +5297,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2C      2S
+1N     X       2C      2S
 Pass    Pass    3C      Pass
 Pass    Pass    
 
@@ -5315,7 +5315,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    Pass    Pass    
 
 
@@ -5332,7 +5332,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2H      2S
+1N     X       2H      2S
 Pass    Pass    Pass    
 
 
@@ -5349,7 +5349,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5366,7 +5366,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2D      2S
+1N     X       2D      2S
 Pass    Pass    3D      Pass
 Pass    Pass    
 
@@ -5384,7 +5384,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      3C
+1N     X       2H      3C
 Pass    Pass    Pass    
 
 
@@ -5401,7 +5401,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      3C
+1N     X       2S      3C
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -5419,7 +5419,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       4C      Pass
+1N     X       4C      Pass
 Pass    Pass    
 
 
@@ -5436,7 +5436,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -5453,7 +5453,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     X       2C      2H
+1N     X       2C      2H
 Pass    Pass    Pass    
 
 
@@ -5470,7 +5470,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -5488,7 +5488,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -5505,7 +5505,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    3S
+1N     2S      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -5523,7 +5523,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2H      X
+1N     X       2H      X
 Pass    3C      Pass    3S
 Pass    Pass    Pass    
 
@@ -5541,7 +5541,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      3H      3S
+1N     2S      3H      3S
 Pass    Pass    Pass    
 
 
@@ -5558,7 +5558,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     3S      Pass    4S
+1N     3S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -5575,7 +5575,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     X       2D      2S
+1N     X       2D      2S
 Pass    Pass    3D      Pass
 Pass    Pass    
 
@@ -5593,7 +5593,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -5610,7 +5610,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     X       2S      Pass
+1N     X       2S      Pass
 Pass    Pass    
 
 
@@ -5627,7 +5627,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     3H      Pass    4H
+1N     3H      Pass    4H
 Pass    Pass    Pass    
 
 
@@ -5644,7 +5644,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -5661,7 +5661,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5678,7 +5678,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5695,7 +5695,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    Pass    3S      Pass
 Pass    Pass    
 
@@ -5713,7 +5713,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -5730,7 +5730,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1D      Pass    1S
-1NT     X       2C      2S
+1N     X       2C      2S
 Pass    Pass    3C      3D
 Pass    3S      Pass    Pass
 Pass    
@@ -5749,7 +5749,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1H      Pass    1S
-1NT     X       2D      Pass
+1N     X       2D      Pass
 Pass    Pass    
 
 
@@ -5766,7 +5766,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1S
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5783,7 +5783,7 @@ Pass
 [Declarer "N"]
 [Auction "S"]
 Pass    1D      Pass    1H
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -5800,6 +5800,6 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 Pass    1C      Pass    1H
-1NT     3H      3S      4H
+1N     3H      3S      4H
 Pass    Pass    Pass    
 

--- a/GIB/GIB_Splinter_after_Minor.pbn
+++ b/GIB/GIB_Splinter_after_Minor.pbn
@@ -33,11 +33,11 @@ Pass    Pass
 {HCP 13 4 13 10}
 {TP 15 7 13 11}
 {Losers 6 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -79,7 +79,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -97,11 +97,11 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 15 8 14 8}
 {Losers 6 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -122,7 +122,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -143,7 +143,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -207,7 +207,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -225,11 +225,11 @@ Pass    Pass
 {HCP 13 4 13 10}
 {TP 15 7 13 10}
 {Losers 6 7 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -250,8 +250,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5S      Pass
+5N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -272,8 +272,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4D      Pass
-4NT     Pass    5H      Pass
+3N     Pass    4D      Pass
+4N     Pass    5H      Pass
 6C      Pass    Pass    Pass
 
 
@@ -295,7 +295,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -313,11 +313,11 @@ Pass    Pass
 {HCP 13 12 12 3}
 {TP 14 14 12 4}
 {Losers 7 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -338,7 +338,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -356,11 +356,11 @@ Pass    Pass
 {HCP 14 9 12 5}
 {TP 15 11 13 7}
 {Losers 5 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -377,11 +377,11 @@ Pass    Pass
 {HCP 12 13 12 3}
 {TP 15 15 12 4}
 {Losers 6 6 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -398,11 +398,11 @@ Pass    Pass
 {HCP 13 10 12 5}
 {TP 15 11 12 6}
 {Losers 6 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -423,9 +423,9 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    3NT     Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6D      Pass
+3S      Pass    3N     Pass
+4N     Pass    5S      Pass
+5N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -446,7 +446,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -510,7 +510,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    6C      Pass
 Pass    Pass    
 
@@ -532,8 +532,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5S      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5S      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -597,8 +597,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    3NT     Pass
-4NT     Pass    5D      Pass
+3S      Pass    3N     Pass
+4N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -619,7 +619,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -641,8 +641,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5H      Pass
+5N     Pass    6C      Pass
 7D      Pass    Pass    Pass
 
 
@@ -664,7 +664,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -686,8 +686,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5S      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5S      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -731,8 +731,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5C      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5C      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -754,7 +754,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6D      Pass    Pass    Pass
 
 
@@ -772,11 +772,11 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 15 8 13 7}
 {Losers 6 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -793,11 +793,11 @@ Pass    Pass
 {HCP 14 8 13 5}
 {TP 15 8 13 5}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -818,8 +818,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5H      Pass
+5N     Pass    6C      Pass
 7D      Pass    Pass    Pass
 
 
@@ -841,8 +841,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5S      Pass
+5N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -884,7 +884,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -906,8 +906,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5S      Pass
+5N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -928,7 +928,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -1014,8 +1014,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    7C      Pass
 Pass    Pass    
 
@@ -1059,7 +1059,7 @@ Pass    Pass    4D      Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -1081,7 +1081,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -1120,11 +1120,11 @@ Pass    Pass
 {HCP 14 14 12 0}
 {TP 15 15 12 2}
 {Losers 6 6 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1141,11 +1141,11 @@ Pass    Pass
 {HCP 13 7 14 6}
 {TP 15 9 14 6}
 {Losers 6 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1183,11 +1183,11 @@ Pass    Pass
 {HCP 11 11 12 6}
 {TP 14 11 12 6}
 {Losers 5 8 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1208,7 +1208,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    6D      Pass
+4N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -1250,7 +1250,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    5C      Pass
+3N     Pass    5C      Pass
 Pass    Pass    
 
 
@@ -1271,7 +1271,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -1293,7 +1293,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -1311,11 +1311,11 @@ Pass    Pass
 {HCP 13 11 13 3}
 {TP 14 14 13 4}
 {Losers 6 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1336,7 +1336,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4C      Pass    4NT     Pass
+4C      Pass    4N     Pass
 5C      Pass    5H      Pass
 6D      Pass    Pass    Pass
 
@@ -1359,7 +1359,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -1381,7 +1381,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -1403,7 +1403,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -1421,11 +1421,11 @@ Pass    Pass
 {HCP 13 11 13 3}
 {TP 15 11 13 3}
 {Losers 6 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1446,8 +1446,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4S      Pass
-4NT     Pass    6C      Pass
+3N     Pass    4S      Pass
+4N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -1512,8 +1512,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4D      Pass
-4NT     Pass    5NT     Pass
+3N     Pass    4D      Pass
+4N     Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -1535,7 +1535,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -1557,8 +1557,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5S      Pass
+5N     Pass    6C      Pass
 7D      Pass    Pass    Pass
 
 
@@ -1580,7 +1580,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5H      X
+4N     Pass    5H      X
 6D      Pass    Pass    Pass
 
 
@@ -1602,8 +1602,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    7C      Pass
 Pass    Pass    
 
@@ -1625,7 +1625,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -1643,11 +1643,11 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 16 8 13 8}
 {Losers 6 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1686,11 +1686,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 16 9 12 7}
 {Losers 5 8 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1711,7 +1711,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -1750,11 +1750,11 @@ Pass    Pass
 {HCP 15 9 14 2}
 {TP 16 10 14 2}
 {Losers 7 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1796,7 +1796,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6D      Pass    Pass    Pass
 
 
@@ -1835,11 +1835,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 14 8 15 6}
 {Losers 6 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1856,11 +1856,11 @@ Pass    Pass
 {HCP 14 12 12 2}
 {TP 16 14 12 3}
 {Losers 6 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1881,7 +1881,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      X
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -1921,11 +1921,11 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 15 8 12 8}
 {Losers 6 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1942,11 +1942,11 @@ Pass    Pass
 {HCP 13 7 14 6}
 {TP 14 9 14 8}
 {Losers 6 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1967,8 +1967,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5C      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5C      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -2032,7 +2032,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -2054,7 +2054,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    5H      Pass
 5S      Pass    6C      Pass
 Pass    Pass    
@@ -2073,11 +2073,11 @@ Pass    Pass
 {HCP 13 11 13 3}
 {TP 15 12 13 5}
 {Losers 6 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2098,7 +2098,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      X
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -2141,7 +2141,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -2163,7 +2163,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5S      Pass    6C      Pass
 Pass    Pass    
 
@@ -2244,11 +2244,11 @@ Pass    Pass
 {HCP 13 6 13 8}
 {TP 15 7 13 8}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2265,11 +2265,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 16 8 12 10}
 {Losers 5 9 9 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2290,8 +2290,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3S      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3S      Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -2313,7 +2313,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      X
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -2335,7 +2335,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 4H      Pass    5C      Pass
 Pass    Pass    
 
@@ -2379,8 +2379,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3S      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3S      Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    7C      Pass
 Pass    Pass    
 
@@ -2398,11 +2398,11 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 16 7 13 7}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2444,7 +2444,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    6C      Pass
+3N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -2465,7 +2465,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6D      Pass    Pass    Pass
 
 
@@ -2487,7 +2487,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6D      Pass    Pass    Pass
 
 
@@ -2509,7 +2509,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -2531,8 +2531,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    4NT     Pass
-5C      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5C      Pass    5N     Pass
 6C      Pass    7C      Pass
 Pass    Pass    
 
@@ -2554,7 +2554,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -2640,8 +2640,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4C      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+4C      Pass    4N     Pass
+5D      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -2663,7 +2663,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6C      Pass    Pass    Pass
 
 
@@ -2685,7 +2685,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4C      Pass    4NT     Pass
+4C      Pass    4N     Pass
 5D      Pass    6D      Pass
 Pass    Pass    
 
@@ -2729,7 +2729,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    5C      Pass
+3N     Pass    5C      Pass
 Pass    Pass    
 
 
@@ -2750,8 +2750,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5S      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5S      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -2773,7 +2773,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      X
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -2795,7 +2795,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -2813,11 +2813,11 @@ Pass    Pass
 {HCP 14 10 13 3}
 {TP 15 10 13 3}
 {Losers 7 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2838,8 +2838,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    7C      Pass
 Pass    Pass    
 
@@ -2857,11 +2857,11 @@ Pass    Pass
 {HCP 15 6 13 6}
 {TP 16 7 13 7}
 {Losers 5 9 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2926,7 +2926,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -2944,11 +2944,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 14 10 14 5}
 {Losers 6 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2965,11 +2965,11 @@ Pass    Pass
 {HCP 13 5 12 10}
 {TP 15 5 14 11}
 {Losers 5 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3007,11 +3007,11 @@ Pass    Pass
 {HCP 13 8 13 6}
 {TP 15 8 13 7}
 {Losers 6 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3032,8 +3032,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5D      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5D      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -3055,7 +3055,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -3073,11 +3073,11 @@ Pass    Pass
 {HCP 13 11 14 2}
 {TP 15 14 14 3}
 {Losers 6 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3098,7 +3098,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 5D      Pass    Pass    Pass
 
 
@@ -3164,7 +3164,7 @@ Pass    Pass    1C      Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -3208,8 +3208,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -3227,11 +3227,11 @@ Pass    Pass
 {HCP 14 11 14 1}
 {TP 16 11 14 2}
 {Losers 6 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3252,7 +3252,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    5C      Pass
+3N     Pass    5C      Pass
 Pass    Pass    
 
 
@@ -3290,11 +3290,11 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 15 10 13 5}
 {Losers 7 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3315,7 +3315,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -3337,7 +3337,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 6D      Pass    Pass    Pass
 
 
@@ -3359,7 +3359,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -3381,7 +3381,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -3399,11 +3399,11 @@ Pass    Pass
 {HCP 14 10 13 3}
 {TP 16 12 13 5}
 {Losers 6 5 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3424,7 +3424,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6C      Pass    Pass    Pass
 
 
@@ -3446,7 +3446,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -3468,7 +3468,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 6D      Pass    Pass    Pass
 
 
@@ -3490,7 +3490,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -3512,7 +3512,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      X
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -3530,11 +3530,11 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 16 5 13 7}
 {Losers 7 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3555,7 +3555,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5S      Pass    6C      Pass
 Pass    Pass    
 
@@ -3599,7 +3599,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6C      Pass    7D      Pass
 Pass    Pass    
 
@@ -3621,7 +3621,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 6D      Pass    Pass    Pass
 
 
@@ -3661,11 +3661,11 @@ Pass    Pass
 {HCP 13 12 13 2}
 {TP 15 12 13 4}
 {Losers 7 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3686,7 +3686,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -3708,7 +3708,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -3725,11 +3725,11 @@ Pass    Pass
 {HCP 14 5 12 9}
 {TP 16 6 12 9}
 {Losers 6 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3750,7 +3750,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -3767,11 +3767,11 @@ Pass    Pass
 {HCP 15 12 13 0}
 {TP 16 13 13 1}
 {Losers 7 7 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3792,7 +3792,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -3814,7 +3814,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      X
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -3879,7 +3879,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -3922,7 +3922,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -3939,11 +3939,11 @@ Pass    Pass
 {HCP 15 4 13 8}
 {TP 16 7 13 9}
 {Losers 5 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3964,7 +3964,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -3981,11 +3981,11 @@ Pass    Pass
 {HCP 13 8 13 6}
 {TP 15 9 13 7}
 {Losers 6 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4002,11 +4002,11 @@ Pass    Pass
 {HCP 13 4 14 9}
 {TP 15 5 14 9}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4027,7 +4027,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -4049,7 +4049,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -4071,7 +4071,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -4109,11 +4109,11 @@ Pass    Pass
 {HCP 13 7 13 7}
 {TP 15 8 13 8}
 {Losers 6 9 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4177,7 +4177,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -4220,7 +4220,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -4263,7 +4263,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -4285,8 +4285,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5H      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -4308,7 +4308,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -4330,7 +4330,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    5C      Pass
+3N     Pass    5C      Pass
 6D      Pass    Pass    Pass
 
 
@@ -4352,7 +4352,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -4370,11 +4370,11 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 14 11 13 7}
 {Losers 6 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4395,7 +4395,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 5C      Pass    Pass    Pass
 
 
@@ -4413,11 +4413,11 @@ Pass    Pass
 {HCP 15 9 13 3}
 {TP 16 9 14 4}
 {Losers 5 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4438,8 +4438,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5C      Pass
+5N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -4482,7 +4482,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -4504,7 +4504,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -4526,7 +4526,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -4548,7 +4548,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -4571,7 +4571,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    3H      X
 3S      Pass    4H      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -4593,7 +4593,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -4611,11 +4611,11 @@ Pass    Pass
 {HCP 14 9 14 3}
 {TP 15 10 14 4}
 {Losers 6 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4636,7 +4636,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-5NT     Pass    6D      Pass
+5N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -4653,11 +4653,11 @@ Pass    Pass
 {HCP 13 12 13 2}
 {TP 14 12 13 4}
 {Losers 5 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4674,11 +4674,11 @@ Pass    Pass
 {HCP 14 5 12 9}
 {TP 15 6 12 9}
 {Losers 6 10 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4699,7 +4699,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -4717,11 +4717,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 15 10 12 4}
 {Losers 7 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4759,11 +4759,11 @@ Pass    Pass
 {HCP 15 7 15 3}
 {TP 16 11 15 4}
 {Losers 6 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4784,7 +4784,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    6D      Pass
+4N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -4805,8 +4805,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
-5S      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5S      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -4828,7 +4828,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -4850,7 +4850,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -4893,8 +4893,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      X
-3NT     Pass    4C      Pass
-4NT     Pass    5NT     Pass
+3N     Pass    4C      Pass
+4N     Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -4916,8 +4916,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5S      Pass
+5N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -4938,7 +4938,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    6D      Pass
 Pass    Pass    
 
@@ -4956,11 +4956,11 @@ Pass    Pass
 {HCP 15 9 13 3}
 {TP 16 11 13 5}
 {Losers 5 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4981,7 +4981,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -4998,11 +4998,11 @@ Pass    Pass
 {HCP 13 10 13 4}
 {TP 14 12 14 5}
 {Losers 6 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5019,11 +5019,11 @@ Pass    Pass
 {HCP 13 10 14 3}
 {TP 15 12 14 4}
 {Losers 6 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5082,11 +5082,11 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 14 10 12 7}
 {Losers 6 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5107,7 +5107,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -5129,7 +5129,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -5151,7 +5151,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 7C      Pass    Pass    Pass
 
 
@@ -5173,8 +5173,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4H      Pass
-4NT     Pass    5H      Pass
+3N     Pass    4H      Pass
+4N     Pass    5H      Pass
 6C      Pass    Pass    Pass
 
 
@@ -5218,7 +5218,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -5240,7 +5240,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -5279,11 +5279,11 @@ Pass    Pass
 {HCP 10 10 14 6}
 {TP 14 12 15 7}
 {Losers 4 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5300,11 +5300,11 @@ Pass    Pass
 {HCP 14 5 14 7}
 {TP 16 7 14 8}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5325,7 +5325,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -5343,11 +5343,11 @@ Pass    Pass
 {HCP 13 6 14 7}
 {TP 15 8 14 9}
 {Losers 5 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5364,11 +5364,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 16 9 13 6}
 {Losers 6 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5385,11 +5385,11 @@ Pass    Pass
 {HCP 14 10 15 1}
 {TP 16 12 16 2}
 {Losers 5 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5406,11 +5406,11 @@ Pass    Pass
 {HCP 11 11 14 4}
 {TP 14 12 14 6}
 {Losers 6 7 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5452,8 +5452,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5C      Pass
+5N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -5474,8 +5474,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5S      Pass
+5N     Pass    6C      Pass
 7C      Pass    Pass    Pass
 
 
@@ -5497,7 +5497,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -5519,7 +5519,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -5541,7 +5541,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    6C      Pass
+3N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -5605,8 +5605,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5C      Pass
+5N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -5627,7 +5627,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 5C      Pass    Pass    Pass
 
 
@@ -5670,8 +5670,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
-5S      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5S      Pass    5N     Pass
 6C      Pass    7C      Pass
 Pass    Pass    
 
@@ -5689,11 +5689,11 @@ Pass    Pass
 {HCP 14 7 14 5}
 {TP 16 9 14 5}
 {Losers 5 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5737,8 +5737,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5C      Pass
+5N     Pass    6D      Pass
 7D      Pass    Pass    Pass
 
 
@@ -5760,7 +5760,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -5778,11 +5778,11 @@ Pass    Pass
 {HCP 13 9 14 4}
 {TP 15 9 14 6}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5803,8 +5803,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5D      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5D      Pass
+5N     Pass    6C      Pass
 7D      Pass    Pass    Pass
 
 
@@ -5826,7 +5826,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    6C      Pass
+3N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -5847,7 +5847,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -5869,7 +5869,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -5890,7 +5890,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -5913,7 +5913,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    3H      Pass
 3S      Pass    4C      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5S      Pass    6C      Pass
 Pass    Pass    
 
@@ -5957,7 +5957,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    6D      Pass
+4N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -5978,7 +5978,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      X
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -6021,7 +6021,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -6039,11 +6039,11 @@ Pass    Pass
 {HCP 13 7 13 7}
 {TP 15 7 13 8}
 {Losers 6 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6172,7 +6172,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -6216,7 +6216,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -6238,7 +6238,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -6260,7 +6260,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -6278,11 +6278,11 @@ Pass    Pass
 {HCP 13 13 12 2}
 {TP 16 14 13 4}
 {Losers 5 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6303,7 +6303,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -6343,11 +6343,11 @@ Pass    Pass
 {HCP 15 11 12 2}
 {TP 16 13 13 4}
 {Losers 5 7 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6368,7 +6368,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      X
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -6390,8 +6390,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6D      Pass    7D      Pass
 Pass    Pass    
 
@@ -6413,8 +6413,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3S      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+3S      Pass    4N     Pass
+5S      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -6436,8 +6436,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-4D      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4D      Pass    4N     Pass
+5C      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -6459,7 +6459,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -6481,7 +6481,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -6499,11 +6499,11 @@ Pass    Pass
 {HCP 15 5 13 7}
 {TP 16 8 13 7}
 {Losers 6 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6524,7 +6524,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      X
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -6546,7 +6546,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 6D      Pass    Pass    Pass
 
 
@@ -6564,11 +6564,11 @@ Pass    Pass
 {HCP 14 10 13 3}
 {TP 15 10 13 5}
 {Losers 6 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6589,7 +6589,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -6607,11 +6607,11 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 15 9 12 8}
 {Losers 6 7 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6632,8 +6632,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -6651,11 +6651,11 @@ Pass    Pass
 {HCP 13 11 12 4}
 {TP 15 12 12 4}
 {Losers 6 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6672,11 +6672,11 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 14 9 13 7}
 {Losers 6 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6693,11 +6693,11 @@ Pass    Pass
 {HCP 14 9 13 4}
 {TP 16 9 13 5}
 {Losers 5 10 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6718,8 +6718,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5H      Pass
+5N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -6740,7 +6740,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -6780,11 +6780,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 15 7 13 7}
 {Losers 6 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6805,7 +6805,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -6869,8 +6869,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5C      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5C      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -6892,7 +6892,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -6914,7 +6914,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -6936,8 +6936,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    7C      Pass
 Pass    Pass    
 
@@ -6959,8 +6959,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5S      Pass
+5N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -7002,8 +7002,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    4S      Pass
-4NT     Pass    5H      Pass
+3N     Pass    4S      Pass
+4N     Pass    5H      Pass
 6C      Pass    Pass    Pass
 
 
@@ -7021,11 +7021,11 @@ Pass    Pass
 {HCP 13 4 13 10}
 {TP 15 7 13 10}
 {Losers 5 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7085,11 +7085,11 @@ Pass    Pass
 {HCP 14 7 12 7}
 {TP 16 8 12 9}
 {Losers 6 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7110,8 +7110,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      X
-3NT     Pass    4D      Pass
-4NT     Pass    5S      Pass
+3N     Pass    4D      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -7133,7 +7133,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      X
-3NT     Pass    5C      Pass
+3N     Pass    5C      Pass
 Pass    Pass    
 
 
@@ -7175,8 +7175,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4C      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4C      Pass    4N     Pass
+5C      Pass    5N     Pass
 6D      Pass    7D      Pass
 Pass    Pass    
 
@@ -7220,8 +7220,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -7239,11 +7239,11 @@ Pass    Pass
 {HCP 13 10 13 4}
 {TP 15 13 13 4}
 {Losers 5 6 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7264,7 +7264,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -7286,8 +7286,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5H      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -7327,11 +7327,11 @@ Pass    Pass
 {HCP 13 11 13 3}
 {TP 15 12 13 4}
 {Losers 6 6 9 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7348,11 +7348,11 @@ Pass    Pass
 {HCP 14 10 13 3}
 {TP 15 10 13 5}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7373,7 +7373,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -7396,7 +7396,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    3H      Pass
 3S      Pass    4S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -7418,8 +7418,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4C      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+4C      Pass    4N     Pass
+5D      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -7441,7 +7441,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -7505,7 +7505,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -7527,7 +7527,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -7548,8 +7548,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5S      Pass
+5N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -7614,8 +7614,8 @@ Pass    Pass    4D      Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      X
-3NT     Pass    4C      Pass
-4NT     Pass    5C      Pass
+3N     Pass    4C      Pass
+4N     Pass    5C      Pass
 6D      Pass    Pass    Pass
 
 
@@ -7633,11 +7633,11 @@ Pass    Pass    4D      Pass
 {HCP 14 7 14 5}
 {TP 15 7 14 7}
 {Losers 6 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7654,11 +7654,11 @@ Pass    Pass    4D      Pass
 {HCP 13 7 14 6}
 {TP 15 10 15 7}
 {Losers 6 6 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      3S
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7679,7 +7679,7 @@ Pass    Pass    4D      Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -7717,11 +7717,11 @@ Pass    Pass
 {HCP 13 11 12 4}
 {TP 16 12 12 6}
 {Losers 5 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7763,7 +7763,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      X
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -7785,7 +7785,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -7849,7 +7849,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      X
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -7870,7 +7870,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      X
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -7888,11 +7888,11 @@ Pass    Pass
 {HCP 13 7 13 7}
 {TP 15 9 13 8}
 {Losers 5 7 9 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7913,8 +7913,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3S      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3S      Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -7936,7 +7936,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -7958,8 +7958,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6D      Pass    7D      Pass
 Pass    Pass    
 
@@ -7977,11 +7977,11 @@ Pass    Pass
 {HCP 13 6 13 8}
 {TP 15 7 13 8}
 {Losers 6 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7998,11 +7998,11 @@ Pass    Pass
 {HCP 16 9 12 3}
 {TP 17 11 12 5}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8023,7 +8023,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -8045,8 +8045,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5S      Pass
+5N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -8063,11 +8063,11 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 16 8 14 7}
 {Losers 6 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8132,7 +8132,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      X
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 6D      Pass    Pass    Pass
 
 
@@ -8150,11 +8150,11 @@ Pass    Pass
 {HCP 14 10 12 4}
 {TP 15 10 12 4}
 {Losers 6 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8175,7 +8175,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6D      Pass
 Pass    Pass    
 
@@ -8219,7 +8219,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    3H      X
 3S      Pass    4S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -8237,11 +8237,11 @@ Pass    Pass
 {HCP 13 9 12 6}
 {TP 14 10 12 7}
 {Losers 6 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8258,11 +8258,11 @@ Pass    Pass
 {HCP 14 7 13 6}
 {TP 15 7 13 8}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8279,11 +8279,11 @@ Pass    Pass
 {HCP 14 9 12 5}
 {TP 16 9 12 5}
 {Losers 5 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8304,8 +8304,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5C      Pass
-5H      Pass    5NT     Pass
+4N     Pass    5C      Pass
+5H      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -8327,7 +8327,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -8392,7 +8392,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -8414,7 +8414,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6D      Pass    Pass    Pass
 
 
@@ -8432,11 +8432,11 @@ Pass    Pass
 {HCP 13 9 12 6}
 {TP 14 10 12 6}
 {Losers 5 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8501,8 +8501,8 @@ Pass    Pass    1C      1H
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -8524,7 +8524,7 @@ Pass    Pass    1C      1H
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -8547,7 +8547,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    3H      Pass
 3S      Pass    4S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -8565,11 +8565,11 @@ Pass    Pass
 {HCP 13 10 12 5}
 {TP 14 11 13 6}
 {Losers 5 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8586,11 +8586,11 @@ Pass    Pass
 {HCP 13 9 13 5}
 {TP 15 11 13 7}
 {Losers 6 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8611,7 +8611,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5H      X
+4N     Pass    5H      X
 6D      Pass    Pass    Pass
 
 
@@ -8629,11 +8629,11 @@ Pass    Pass
 {HCP 14 9 12 5}
 {TP 16 9 12 6}
 {Losers 5 9 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8654,7 +8654,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4S      Pass
+3N     Pass    4S      Pass
 5C      Pass    Pass    Pass
 
 
@@ -8676,7 +8676,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    6D      Pass
+4N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -8697,7 +8697,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -8719,7 +8719,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      X
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -8783,7 +8783,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -8801,11 +8801,11 @@ Pass    Pass
 {HCP 15 6 12 7}
 {TP 16 8 12 8}
 {Losers 6 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8826,7 +8826,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -8848,7 +8848,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -8871,7 +8871,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    3H      X
 3S      Pass    4C      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -8889,11 +8889,11 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 16 7 13 9}
 {Losers 6 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8914,7 +8914,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -8932,11 +8932,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 14 11 14 5}
 {Losers 6 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8957,8 +8957,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4D      Pass
-4NT     Pass    5H      Pass
+3N     Pass    4D      Pass
+4N     Pass    5H      Pass
 6C      Pass    Pass    Pass
 
 
@@ -8980,7 +8980,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -9002,7 +9002,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    4H      Pass
+3N     Pass    4H      Pass
 5C      Pass    6C      Pass
 Pass    Pass    
 
@@ -9020,11 +9020,11 @@ Pass    Pass
 {HCP 13 7 14 6}
 {TP 14 9 14 6}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9108,7 +9108,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -9131,7 +9131,7 @@ Pass    Pass
 [Auction "S"]
 1C      Pass    3H      Pass
 3S      Pass    4D      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6C      Pass    Pass    Pass
 
 
@@ -9174,7 +9174,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -9192,11 +9192,11 @@ Pass    Pass
 {HCP 13 5 12 10}
 {TP 15 6 13 10}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9213,11 +9213,11 @@ Pass    Pass
 {HCP 15 11 12 2}
 {TP 16 11 12 3}
 {Losers 6 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9238,8 +9238,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5S      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5S      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -9261,8 +9261,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5S      Pass
+5N     Pass    6C      Pass
 7C      Pass    Pass    Pass
 
 
@@ -9284,7 +9284,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      X
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -9322,11 +9322,11 @@ Pass    Pass
 {HCP 13 5 12 10}
 {TP 15 6 12 10}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9368,8 +9368,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      X
-4NT     Pass    5C      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5C      Pass
+5N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -9386,11 +9386,11 @@ Pass    Pass
 {HCP 13 6 12 9}
 {TP 14 7 13 10}
 {Losers 6 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9407,11 +9407,11 @@ Pass    Pass
 {HCP 13 9 14 4}
 {TP 15 10 14 6}
 {Losers 5 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9432,7 +9432,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -9454,7 +9454,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6C      Pass    Pass    Pass
 
 
@@ -9472,11 +9472,11 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 15 7 13 8}
 {Losers 6 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9519,7 +9519,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -9541,8 +9541,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4H      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5D      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -9564,7 +9564,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      X
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -9581,11 +9581,11 @@ Pass    Pass
 {HCP 16 5 14 5}
 {TP 17 8 14 6}
 {Losers 6 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9606,8 +9606,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
-5D      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5D      Pass    5N     Pass
 6C      Pass    7C      Pass
 Pass    Pass    
 
@@ -9629,7 +9629,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -9669,11 +9669,11 @@ Pass    Pass
 {HCP 11 9 13 7}
 {TP 14 12 13 10}
 {Losers 5 6 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9694,7 +9694,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -9712,11 +9712,11 @@ Pass    Pass
 {HCP 13 11 14 2}
 {TP 15 15 14 3}
 {Losers 6 5 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9737,8 +9737,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5S      Pass
+5N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -9759,7 +9759,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -9803,8 +9803,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5H      Pass
+5N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -9825,8 +9825,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-4D      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4D      Pass    4N     Pass
+5C      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -9844,11 +9844,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 15 9 14 7}
 {Losers 6 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9869,8 +9869,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4D      Pass
-4NT     Pass    5D      Pass
+3N     Pass    4D      Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -9892,7 +9892,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -9914,7 +9914,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -9932,11 +9932,11 @@ Pass    Pass
 {HCP 15 4 14 7}
 {TP 16 4 14 7}
 {Losers 6 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9979,8 +9979,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
-5H      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -9998,11 +9998,11 @@ Pass    Pass
 {HCP 13 11 12 4}
 {TP 16 12 12 5}
 {Losers 5 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10023,7 +10023,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -10041,11 +10041,11 @@ Pass    Pass
 {HCP 13 9 12 6}
 {TP 15 11 13 7}
 {Losers 5 8 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10062,11 +10062,11 @@ Pass    Pass
 {HCP 13 8 14 5}
 {TP 14 10 14 6}
 {Losers 6 8 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10087,7 +10087,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5S      Pass    6C      Pass
 Pass    Pass    
 
@@ -10130,7 +10130,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -10152,7 +10152,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6D      Pass    Pass    Pass
 
 
@@ -10195,7 +10195,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -10213,11 +10213,11 @@ Pass    Pass
 {HCP 13 10 14 3}
 {TP 15 11 14 4}
 {Losers 5 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10255,11 +10255,11 @@ Pass    Pass
 {HCP 13 3 14 10}
 {TP 15 5 14 10}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10276,11 +10276,11 @@ Pass    Pass
 {HCP 14 13 12 1}
 {TP 16 14 13 1}
 {Losers 6 5 8 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10301,7 +10301,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -10323,8 +10323,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5C      Pass
+5N     Pass    6C      Pass
 7D      Pass    Pass    Pass
 
 
@@ -10363,11 +10363,11 @@ Pass    Pass
 {HCP 14 5 13 8}
 {TP 15 7 14 8}
 {Losers 5 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10388,7 +10388,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -10410,7 +10410,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -10470,11 +10470,11 @@ Pass    Pass
 {HCP 13 10 12 5}
 {TP 15 11 12 5}
 {Losers 5 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10495,7 +10495,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3H      X
-3NT     Pass    5D      Pass
+3N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -10516,7 +10516,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -10534,11 +10534,11 @@ Pass    Pass
 {HCP 14 6 13 7}
 {TP 15 9 13 7}
 {Losers 6 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10555,11 +10555,11 @@ Pass    Pass
 {HCP 13 7 13 7}
 {TP 14 7 13 8}
 {Losers 6 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10580,7 +10580,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      4S
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -10602,7 +10602,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -10620,11 +10620,11 @@ Pass    Pass
 {HCP 13 11 13 3}
 {TP 16 13 14 3}
 {Losers 5 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10641,11 +10641,11 @@ Pass    Pass
 {HCP 13 7 12 8}
 {TP 14 10 12 8}
 {Losers 6 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10667,7 +10667,7 @@ Pass    Pass
 [Auction "S"]
 1D      Pass    3H      X
 3S      Pass    4S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -10710,7 +10710,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      X
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -10728,11 +10728,11 @@ Pass    Pass
 {HCP 13 4 14 9}
 {TP 15 5 14 9}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10749,11 +10749,11 @@ Pass    Pass
 {HCP 13 8 12 7}
 {TP 15 10 12 7}
 {Losers 6 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10774,7 +10774,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-4NT     Pass    6D      Pass
+4N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -10795,8 +10795,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    4C      Pass
-4NT     Pass    5C      Pass
-5H      Pass    5NT     Pass
+4N     Pass    5C      Pass
+5H      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -10814,11 +10814,11 @@ Pass    Pass
 {HCP 15 8 14 3}
 {TP 16 11 14 3}
 {Losers 6 6 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10835,10 +10835,10 @@ Pass    Pass
 {HCP 12 11 12 5}
 {TP 15 12 12 6}
 {Losers 5 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    3S      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 

--- a/GIB/GIB_Splinters.pbn
+++ b/GIB/GIB_Splinters.pbn
@@ -101,7 +101,7 @@
 [Auction "S"]
 1S      Pass    4C      Pass
 4D      Pass    4H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -165,7 +165,7 @@
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6H      Pass
 Pass    Pass    
 
@@ -229,7 +229,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    Pass    Pass
 
 
@@ -251,7 +251,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 6H      Pass    6S      Pass
 Pass    Pass    
 
@@ -273,7 +273,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    Pass    Pass
 
 
@@ -295,7 +295,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -317,8 +317,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      X
-4D      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+4D      Pass    4N     Pass
+5D      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -341,8 +341,8 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    3S      Pass
 4C      Pass    4D      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6H      Pass
+4N     Pass    5H      Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -405,8 +405,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6S      Pass
+4N     Pass    5S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -490,7 +490,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -533,7 +533,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -576,7 +576,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    6H      Pass
 6S      Pass    Pass    Pass
 
@@ -620,7 +620,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      X
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6S      Pass    Pass    Pass
 
 
@@ -663,7 +663,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -707,7 +707,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6S      Pass    Pass    Pass
 
 
@@ -772,8 +772,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6H      Pass
+4N     Pass    5H      Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -837,7 +837,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    Pass    Pass
 
 
@@ -859,7 +859,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -923,7 +923,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -945,7 +945,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4NT     Pass    6H      Pass
+4N     Pass    6H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -1009,7 +1009,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -1052,8 +1052,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4D      Pass    4NT     Pass
-5NT     Pass    6S      Pass
+4D      Pass    4N     Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -1074,7 +1074,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 6H      Pass    Pass    Pass
 
 
@@ -1096,7 +1096,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -1118,7 +1118,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -1161,7 +1161,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      X
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5S      Pass    Pass    Pass
 
 
@@ -1246,7 +1246,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 5S      Pass    Pass    Pass
 
 
@@ -1332,7 +1332,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    Pass    Pass
 
 
@@ -1375,7 +1375,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    5D      Pass
 6D      Pass    6H      Pass
 Pass    Pass    
@@ -1420,7 +1420,7 @@ Pass    Pass
 [Auction "S"]
 1S      Pass    4C      Pass
 4D      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -1463,7 +1463,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    6D      Pass
+4N     Pass    6D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -1506,7 +1506,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -1549,7 +1549,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -1571,8 +1571,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6S      Pass
+4N     Pass    5C      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -1593,7 +1593,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -1615,7 +1615,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    Pass    Pass
 
@@ -1638,7 +1638,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5D      X
+4N     Pass    5D      X
 Pass    Pass    5S      Pass
 Pass    Pass    
 
@@ -1703,7 +1703,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -1788,7 +1788,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    Pass    Pass
 
 
@@ -1810,7 +1810,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -1916,7 +1916,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    Pass    Pass
 
 
@@ -1938,7 +1938,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -1960,7 +1960,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -1982,8 +1982,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6H      Pass
+4N     Pass    5C      Pass
+5N     Pass    6H      Pass
 7H      Pass    Pass    Pass
 
 
@@ -2026,7 +2026,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    6C      Pass
 6S      Pass    Pass    Pass
 
@@ -2049,7 +2049,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -2071,7 +2071,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -2135,7 +2135,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -2179,7 +2179,7 @@ Pass    Pass
 [Auction "S"]
 1S      Pass    4C      X
 4D      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -2201,7 +2201,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -2265,7 +2265,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -2308,7 +2308,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
 6D      Pass    6S      Pass
 Pass    Pass    
@@ -2352,7 +2352,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -2395,7 +2395,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      X
-4C      4S      4NT     Pass
+4C      4S      4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -2501,7 +2501,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -2522,7 +2522,7 @@ Pass    Pass
 [Contract "6CX"]
 [Declarer "W"]
 [Auction "S"]
-1H      Pass    4D      4NT
+1H      Pass    4D      4N
 Pass    5C      Pass    Pass
 5H      Pass    Pass    6C
 X       Pass    Pass    Pass
@@ -2546,9 +2546,9 @@ X       Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    5D      Pass
-5NT     Pass    6H      Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -2569,7 +2569,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -2612,7 +2612,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -2635,7 +2635,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      X
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -2657,7 +2657,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -2679,7 +2679,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -2764,7 +2764,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      X
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 6S      Pass    Pass    Pass
 
 
@@ -2828,7 +2828,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4C      Pass    4NT     Pass
+4C      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -2850,8 +2850,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6S      Pass
+4N     Pass    5S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -2893,7 +2893,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -2980,7 +2980,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -3107,7 +3107,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -3150,7 +3150,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -3193,7 +3193,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5D      Pass    6H      Pass
 Pass    Pass    
 
@@ -3236,7 +3236,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -3258,7 +3258,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -3301,8 +3301,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6S      Pass
+4N     Pass    5S      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -3323,7 +3323,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    Pass    Pass
 
 
@@ -3366,7 +3366,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -3430,7 +3430,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
 6C      Pass    6S      Pass
 Pass    Pass    
@@ -3453,7 +3453,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -3475,7 +3475,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -3498,7 +3498,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    3S      Pass
 4C      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    Pass    Pass
 
@@ -3563,7 +3563,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -3648,7 +3648,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -3670,8 +3670,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6D      Pass    6S      Pass
 Pass    Pass    
 
@@ -3756,7 +3756,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -3800,8 +3800,8 @@ Pass    Pass
 [Auction "S"]
 1S      Pass    4C      Pass
 4D      Pass    4H      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5H      Pass
+5N     Pass    6D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -3844,7 +3844,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -3888,7 +3888,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4H      Pass    Pass    4NT
+4H      Pass    Pass    4N
 Pass    5C      Pass    Pass
 5H      X       Pass    Pass
 Pass    
@@ -3932,7 +3932,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    6H      Pass
 6S      Pass    Pass    Pass
 
@@ -3955,7 +3955,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -4020,7 +4020,7 @@ Pass
 [Auction "S"]
 1H      Pass    3S      Pass
 4C      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -4148,7 +4148,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -4233,7 +4233,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    6D      Pass
 6S      Pass    Pass    Pass
 
@@ -4278,7 +4278,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    5S      Pass
 Pass    Pass    
 
@@ -4300,7 +4300,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6S      Pass    Pass    Pass
 
 
@@ -4469,8 +4469,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5H      Pass
+5N     Pass    6C      Pass
 6S      Pass    Pass    Pass
 
 
@@ -4556,7 +4556,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      X
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6S      Pass
 Pass    Pass    
@@ -4600,7 +4600,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -4622,7 +4622,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -4665,7 +4665,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 Pass    Pass    
 
 
@@ -4707,7 +4707,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -4750,7 +4750,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    Pass    Pass
 
 
@@ -4772,7 +4772,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 Pass    Pass    
 
 
@@ -4793,7 +4793,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -4858,7 +4858,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -4943,7 +4943,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5H      Pass    5S      Pass
 Pass    Pass    
 
@@ -4965,7 +4965,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -5008,7 +5008,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -5093,8 +5093,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5D      Pass
-5S      Pass    5NT     Pass
+4N     Pass    5D      Pass
+5S      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -5138,7 +5138,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -5160,7 +5160,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5S      Pass    6H      Pass
 Pass    Pass    
 
@@ -5182,7 +5182,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    5D      Pass
 6C      Pass    6H      Pass
 Pass    Pass    
@@ -5205,7 +5205,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -5290,8 +5290,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5H      Pass
+5N     Pass    6C      Pass
 6S      Pass    Pass    Pass
 
 
@@ -5313,7 +5313,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 6C      Pass    6S      Pass
 Pass    Pass    
 
@@ -5377,7 +5377,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -5399,7 +5399,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    5H      Pass
 6H      Pass    Pass    Pass
 
@@ -5422,7 +5422,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    Pass    Pass
 
@@ -5445,7 +5445,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -5509,7 +5509,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -5531,8 +5531,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      X
-4NT     Pass    5H      Pass
-5NT     Pass    6H      Pass
+4N     Pass    5H      Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -5553,8 +5553,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4D      Pass    4NT     Pass
-5NT     Pass    6S      Pass
+4D      Pass    4N     Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -5617,7 +5617,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6H      Pass    Pass    Pass
 
 
@@ -5702,7 +5702,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    Pass    Pass
 
 
@@ -5725,7 +5725,7 @@ Pass    Pass
 [Auction "S"]
 1S      Pass    4C      Pass
 4D      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -5770,7 +5770,7 @@ Pass    Pass
 [Auction "S"]
 1S      Pass    4C      Pass
 4D      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    6C      Pass
 6S      Pass    Pass    Pass
 
@@ -5793,7 +5793,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6H      Pass
 Pass    Pass    
@@ -5816,7 +5816,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      X
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6H      Pass    Pass    Pass
 
 
@@ -5859,7 +5859,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 5S      Pass    Pass    Pass
 
 
@@ -5902,7 +5902,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -5945,7 +5945,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    Pass    Pass
 
 
@@ -6052,7 +6052,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 5S      Pass    Pass    Pass
 
 
@@ -6074,7 +6074,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -6098,7 +6098,7 @@ Pass    Pass
 [Auction "S"]
 1S      Pass    4C      Pass
 4D      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    Pass    Pass
 
 
@@ -6120,7 +6120,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5S      Pass    Pass    Pass
 
 
@@ -6142,7 +6142,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -6164,7 +6164,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 6D      Pass    6H      Pass
 Pass    Pass    
 
@@ -6186,8 +6186,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4D      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4D      Pass    4N     Pass
+5C      Pass    5N     Pass
 6C      Pass    7H      Pass
 Pass    Pass    
 
@@ -6209,8 +6209,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4NT     Pass    5H      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5H      Pass
+5N     Pass    6C      Pass
 6S      Pass    Pass    Pass
 
 
@@ -6253,7 +6253,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -6275,8 +6275,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6H      Pass
+4N     Pass    5H      Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -6360,7 +6360,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      X
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -6403,7 +6403,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -6446,7 +6446,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -6638,7 +6638,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    3S      X
 4C      Pass    4D      Pass
-4NT     Pass    6H      Pass
+4N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -6701,7 +6701,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5S      Pass
 Pass    Pass    
 
@@ -6723,7 +6723,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4C      Pass    4NT     Pass
+4C      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -6766,8 +6766,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5S      Pass
-5NT     Pass    6H      Pass
+4N     Pass    5S      Pass
+5N     Pass    6H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -6789,7 +6789,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -6811,7 +6811,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5S      Pass    Pass    Pass
 
 
@@ -6897,7 +6897,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -6961,8 +6961,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4H      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5S      Pass    5N     Pass
 6D      Pass    6S      Pass
 Pass    Pass    
 
@@ -7005,7 +7005,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 5S      Pass    Pass    Pass
 
 
@@ -7027,7 +7027,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -7049,7 +7049,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -7071,7 +7071,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -7114,7 +7114,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -7136,7 +7136,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5D      Pass    5H      Pass
 6H      Pass    Pass    Pass
 
@@ -7201,8 +7201,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4S      Pass    4NT     Pass
-5NT     Pass    6H      Pass
+4S      Pass    4N     Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -7223,7 +7223,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -7266,7 +7266,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    6C      Pass
 6S      Pass    Pass    Pass
 
@@ -7310,7 +7310,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -7395,7 +7395,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -7417,7 +7417,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -7439,7 +7439,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 6S      Pass    Pass    Pass
 
 
@@ -7482,7 +7482,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 6C      Pass    6S      Pass
 Pass    Pass    
@@ -7505,7 +7505,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      X
 5H      Pass    6S      Pass
 Pass    Pass    
@@ -7528,8 +7528,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4NT     Pass    5C      Pass
-5NT     Pass    6S      Pass
+4N     Pass    5C      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -7550,7 +7550,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    6C      Pass
 6S      Pass    Pass    Pass
 
@@ -7573,8 +7573,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4H      Pass    4NT     Pass
-5NT     Pass    6S      Pass
+4H      Pass    4N     Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -7638,7 +7638,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    3S      Pass
 4D      Pass    4S      Pass
-4NT     Pass    6H      Pass
+4N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -7701,7 +7701,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -7786,7 +7786,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -7872,7 +7872,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -7894,7 +7894,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -7916,7 +7916,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 Pass    Pass    
 
 
@@ -7959,7 +7959,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    6H      Pass
+4N     Pass    6H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -8003,7 +8003,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    3S      Pass
 4C      Pass    4D      Pass
-4NT     Pass    6H      Pass
+4N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -8025,7 +8025,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    3S      Pass
 4C      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -8047,7 +8047,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -8090,7 +8090,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    5S      Pass
 Pass    Pass    
 
@@ -8112,7 +8112,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5S      Pass
 Pass    Pass    
 
@@ -8134,7 +8134,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 6H      Pass    Pass    Pass
 
 
@@ -8178,7 +8178,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    3S      Pass
 4D      Pass    4S      Pass
-4NT     Pass    6H      Pass
+4N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -8262,8 +8262,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      X
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6D      Pass    6S      Pass
 Pass    Pass    
 
@@ -8306,7 +8306,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    6D      Pass
+4N     Pass    6D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -8370,7 +8370,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5S      Pass    Pass    Pass
 
 
@@ -8393,7 +8393,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    4C      Pass
 4D      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -8436,7 +8436,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -8479,7 +8479,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      X
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -8503,7 +8503,7 @@ Pass    Pass
 1H      Pass    3S      X
 4C      Pass    4S      X
 Pass    Pass    XX      Pass
-4NT     Pass    6H      Pass
+4N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -8524,8 +8524,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      X
-4NT     Pass    5C      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5C      Pass
+5N     Pass    6C      Pass
 6H      Pass    Pass    Pass
 
 
@@ -8568,7 +8568,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -8590,7 +8590,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -8612,7 +8612,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    5S      Pass
 Pass    Pass    
 
@@ -8634,7 +8634,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
 6D      Pass    6S      Pass
 Pass    Pass    
@@ -8657,7 +8657,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -8700,7 +8700,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      X
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 6H      Pass    Pass    Pass
 
 
@@ -8764,7 +8764,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6H      Pass
 Pass    Pass    
 
@@ -8870,8 +8870,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6H      Pass
+4N     Pass    5C      Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -8914,7 +8914,7 @@ Pass    Pass
 [Auction "S"]
 1S      Pass    4C      Pass
 4D      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -8957,8 +8957,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6H      Pass
+4N     Pass    5C      Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -9001,7 +9001,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -9044,7 +9044,7 @@ X       Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5H      Pass    6H      Pass
 Pass    Pass    
 
@@ -9066,7 +9066,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -9088,7 +9088,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -9174,7 +9174,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6S      Pass    Pass    Pass
 
 
@@ -9217,7 +9217,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -9239,7 +9239,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    6H      Pass
 6S      Pass    Pass    Pass
 
@@ -9283,7 +9283,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -9432,7 +9432,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -9454,7 +9454,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 5S      Pass    Pass    Pass
 
 
@@ -9497,7 +9497,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 5S      Pass    Pass    Pass
 
 
@@ -9519,7 +9519,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5D      X
+4N     Pass    5D      X
 6S      Pass    Pass    Pass
 
 
@@ -9562,7 +9562,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 6C      Pass    6S      Pass
 Pass    Pass    
@@ -9627,7 +9627,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -9712,8 +9712,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6D      Pass
+4N     Pass    5H      Pass
+5N     Pass    6D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -9777,7 +9777,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6S      Pass    Pass    Pass
 
 
@@ -9799,7 +9799,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -9821,7 +9821,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 6D      Pass    6S      Pass
 Pass    Pass    
@@ -9844,7 +9844,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -9887,7 +9887,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -9972,7 +9972,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      X
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -9994,7 +9994,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -10016,8 +10016,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6S      Pass
+4N     Pass    5C      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -10038,7 +10038,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5H      Pass    Pass    Pass
 
 
@@ -10102,7 +10102,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    3S      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6H      Pass
 Pass    Pass    
@@ -10125,8 +10125,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5C      Pass
-5NT     Pass    6S      Pass
+4N     Pass    5C      Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -10233,7 +10233,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -10298,7 +10298,7 @@ Pass    Pass
 [Auction "S"]
 1H      Pass    3S      Pass
 4C      Pass    4D      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -10320,7 +10320,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -10342,7 +10342,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    6C      Pass
 6S      Pass    Pass    Pass
 
@@ -10407,8 +10407,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5H      Pass
+5N     Pass    6C      Pass
 6H      Pass    Pass    Pass
 
 
@@ -10472,8 +10472,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4D      Pass
-4S      Pass    4NT     Pass
-5NT     Pass    6H      Pass
+4S      Pass    4N     Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -10599,7 +10599,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 6S      Pass    Pass    Pass
 
 
@@ -10621,7 +10621,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      Pass    4C      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6S      Pass    Pass    Pass
 
 
@@ -10643,7 +10643,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      Pass    4C      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -10750,8 +10750,8 @@ Pass    Pass
 [Auction "S"]
 1S      Pass    4C      Pass
 4D      Pass    4H      Pass
-4NT     Pass    5H      Pass
-5NT     Pass    6S      Pass
+4N     Pass    5H      Pass
+5N     Pass    6S      Pass
 7S      Pass    Pass    Pass
 
 

--- a/GIB/Michaels_after_1m.pbn
+++ b/GIB/Michaels_after_1m.pbn
@@ -33,11 +33,11 @@ Pass
 {HCP 14 5 13 8}
 {TP 14 9 14 11}
 {Losers 8 7 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2C      2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -74,11 +74,11 @@ Pass    Pass    Pass
 {HCP 12 3 17 8}
 {TP 12 5 18 11}
 {Losers 7 9 5 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      1S      X       Pass
-2S      Pass    3NT     Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -138,11 +138,11 @@ X       Pass    Pass    Pass
 {HCP 8 2 13 17}
 {TP 8 2 15 20}
 {Losers 9 11 6 3}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      3D      Pass
-3S      X       3NT     Pass
+3S      X       3N     Pass
 Pass    Pass    
 
 
@@ -242,12 +242,12 @@ Pass    Pass
 {HCP 13 3 14 10}
 {TP 13 5 14 13}
 {Losers 8 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -411,11 +411,11 @@ Pass    Pass
 {HCP 8 8 18 6}
 {TP 10 9 18 10}
 {Losers 7 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -689,7 +689,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      3H
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5S      Pass    6D      Pass
 Pass    Pass    
 
@@ -832,11 +832,11 @@ Pass    Pass    Pass
 {HCP 9 3 19 9}
 {TP 12 5 19 12}
 {Losers 6 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -916,11 +916,11 @@ X       Pass    Pass    Pass
 {HCP 12 3 13 12}
 {TP 12 6 13 15}
 {Losers 7 8 9 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1188,12 +1188,12 @@ Pass    Pass    Pass
 {HCP 10 5 12 13}
 {TP 14 6 12 16}
 {Losers 5 10 8 4}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      2S
 Pass    3C      3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1256,8 +1256,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      2C      2H      3H
-4C      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+4C      Pass    4N     Pass
+5S      Pass    5N     Pass
 6C      Pass    Pass    Pass
 
 
@@ -1364,7 +1364,7 @@ Pass    Pass
 [Auction "S"]
 1D      2D      3D      3H
 3S      Pass    4D      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6D      Pass    Pass    Pass
 
 
@@ -1821,11 +1821,11 @@ Pass    Pass    Pass
 {HCP 12 0 15 13}
 {TP 12 2 16 16}
 {Losers 7 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2C      2H      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1846,7 +1846,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
-3NT     Pass    4C      Pass
+3N     Pass    4C      Pass
 5D      Pass    6D      Pass
 Pass    Pass    
 
@@ -1931,7 +1931,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1D      2D      2H      Pass
-3D      Pass    3NT     4S
+3D      Pass    3N     4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -1975,7 +1975,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      2S
-3D      Pass    4NT     Pass
+3D      Pass    4N     Pass
 5S      Pass    6D      Pass
 Pass    Pass    
 
@@ -1993,12 +1993,12 @@ Pass    Pass
 {HCP 12 2 16 10}
 {TP 12 5 17 15}
 {Losers 8 8 5 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      2H      Pass
-2S      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2S      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2204,11 +2204,11 @@ Pass    Pass    Pass
 {HCP 7 5 18 10}
 {TP 9 8 18 12}
 {Losers 8 8 5 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2C      3C      3S
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2397,7 +2397,7 @@ Pass    Pass    Pass
 [Auction "S"]
 1C      2C      2H      Pass
 3C      Pass    3S      Pass
-3NT     Pass    6C      Pass
+3N     Pass    6C      Pass
 Pass    Pass    
 
 
@@ -2459,7 +2459,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
-3D      Pass    3NT     4C
+3D      Pass    3N     4C
 4D      Pass    Pass    Pass
 
 
@@ -2521,12 +2521,12 @@ Pass    Pass
 {HCP 9 3 15 13}
 {TP 10 5 16 15}
 {Losers 7 9 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2543,11 +2543,11 @@ Pass    Pass
 {HCP 13 1 13 13}
 {TP 13 2 13 15}
 {Losers 9 11 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3154,11 +3154,11 @@ Pass    Pass    Pass
 {HCP 10 6 14 10}
 {TP 11 7 14 13}
 {Losers 7 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      2H      3H
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3322,11 +3322,11 @@ Pass    Pass    Pass
 {HCP 12 6 12 10}
 {TP 12 8 12 13}
 {Losers 9 8 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      2H      3H
-Pass    Pass    3NT     Pass
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3348,7 +3348,7 @@ Pass    Pass
 [Auction "S"]
 1D      2D      2H      Pass
 3D      3H      3S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6D      Pass    Pass    Pass
 
 
@@ -3412,7 +3412,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 1C      2C      2H      3H
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    4H      X       Pass
 Pass    Pass    
 
@@ -3578,7 +3578,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1D      2D      3D      3NT
+1D      2D      3D      3N
 Pass    4H      Pass    Pass
 Pass    
 
@@ -3705,8 +3705,8 @@ Pass    Pass
 [Auction "S"]
 1D      2D      2H      Pass
 2S      Pass    3D      Pass
-4D      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+4D      Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    7D      Pass
 Pass    Pass    
 
@@ -3749,7 +3749,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
-3NT     Pass    4D      Pass
+3N     Pass    4D      Pass
 5D      Pass    Pass    Pass
 
 
@@ -3792,7 +3792,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
-3D      3H      3NT     4H
+3D      3H      3N     4H
 5D      Pass    Pass    Pass
 
 
@@ -3836,9 +3836,9 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
-2S      Pass    2NT     Pass
-3D      Pass    3NT     Pass
-4NT     Pass    5D      Pass
+2S      Pass    2N     Pass
+3D      Pass    3N     Pass
+4N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -3942,7 +3942,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      2S
-3D      Pass    4NT     Pass
+3D      Pass    4N     Pass
 5C      Pass    5D      Pass
 Pass    Pass    
 
@@ -4362,11 +4362,11 @@ Pass    Pass
 {HCP 14 4 12 10}
 {TP 14 6 12 13}
 {Losers 8 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2C      2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4383,11 +4383,11 @@ Pass    Pass
 {HCP 11 11 12 6}
 {TP 11 12 14 10}
 {Losers 8 7 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      Pass    1S      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4618,7 +4618,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
-2S      Pass    2NT     Pass
+2S      Pass    2N     Pass
 3D      Pass    5D      Pass
 Pass    Pass    
 
@@ -4851,12 +4851,12 @@ Pass    Pass    Pass
 {HCP 12 1 13 14}
 {TP 12 2 13 15}
 {Losers 7 11 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2C      2H      Pass
 3C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5120,12 +5120,12 @@ Pass    Pass    Pass
 {HCP 10 5 14 11}
 {TP 13 5 14 14}
 {Losers 6 10 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2C      2H      Pass
 3C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5142,11 +5142,11 @@ Pass    Pass    Pass
 {HCP 7 5 18 10}
 {TP 9 7 19 13}
 {Losers 8 8 5 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2C      3C      3S
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5403,7 +5403,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1C      2C      2H      Pass
-3C      3H      3NT     Pass
+3C      3H      3N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -5551,7 +5551,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1C      2C      2H      3H
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -5929,7 +5929,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1D      2D      Pass    3D
-Pass    3H      Pass    3NT
+Pass    3H      Pass    3N
 Pass    4S      Pass    Pass
 Pass    
 
@@ -6137,11 +6137,11 @@ Pass    Pass    3S      Pass
 {HCP 12 8 14 6}
 {TP 13 10 14 9}
 {Losers 7 7 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    2C      Pass
-2NT     Pass    3NT     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6372,12 +6372,12 @@ Pass
 {HCP 11 8 12 9}
 {TP 13 11 13 15}
 {Losers 6 7 7 3}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2C      2H      Pass
 3C      3H      3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6669,11 +6669,11 @@ Pass    Pass
 {HCP 14 4 13 9}
 {TP 14 6 13 12}
 {Losers 7 9 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6690,11 +6690,11 @@ Pass    Pass
 {HCP 7 6 18 9}
 {TP 10 6 19 13}
 {Losers 7 9 4 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      2S
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6838,12 +6838,12 @@ Pass
 {HCP 10 9 13 8}
 {TP 11 10 13 11}
 {Losers 8 8 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      1S      2S      Pass
-2NT     Pass    3D      Pass
-3NT     Pass    Pass    Pass
+2N     Pass    3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7059,7 +7059,7 @@ Pass    Pass
 [Auction "S"]
 1D      2D      2H      Pass
 2S      Pass    3D      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    5D      Pass
 Pass    Pass    
 
@@ -7101,7 +7101,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      3H
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5S      Pass    6D      Pass
 Pass    Pass    
 
@@ -7224,12 +7224,12 @@ Pass
 {HCP 12 9 12 7}
 {TP 14 11 14 10}
 {Losers 5 7 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      2C
 Pass    Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7328,12 +7328,12 @@ Pass    Pass    Pass
 {HCP 12 4 14 10}
 {TP 12 5 15 13}
 {Losers 8 9 5 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2C      2H      Pass
 2S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7375,8 +7375,8 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1C      Pass    3S      Pass
-4NT     Pass    5D      Pass
-5NT     Pass    6C      Pass
+4N     Pass    5D      Pass
+5N     Pass    6C      Pass
 7C      Pass    Pass    Pass
 
 
@@ -7643,12 +7643,12 @@ Pass    Pass    Pass
 {HCP 16 1 12 11}
 {TP 16 4 13 17}
 {Losers 5 9 6 3}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
 3D      3H      3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7691,7 +7691,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      3H
-3S      Pass    3NT     4H
+3S      Pass    3N     4H
 5D      X       Pass    Pass
 Pass    
 
@@ -8222,12 +8222,12 @@ Pass
 {HCP 12 4 14 10}
 {TP 13 5 14 13}
 {Losers 7 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8412,12 +8412,12 @@ Pass    Pass    Pass
 {HCP 12 4 14 10}
 {TP 13 5 16 12}
 {Losers 7 9 5 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      2H      Pass
-2S      Pass    2NT     Pass
-3D      Pass    3NT     Pass
+2S      Pass    2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8540,11 +8540,11 @@ Pass    Pass    Pass
 {HCP 8 4 16 12}
 {TP 9 7 16 13}
 {Losers 7 8 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      3D      3H
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8649,7 +8649,7 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1C      Pass    1D      1NT
+1C      Pass    1D      1N
 Pass    2D      4C      Pass
 Pass    4S      Pass    Pass
 Pass    
@@ -8752,12 +8752,12 @@ Pass
 {HCP 10 5 14 11}
 {TP 10 7 16 16}
 {Losers 8 8 5 4}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      2H      Pass
-2S      X       2NT     Pass
-3D      Pass    3NT     Pass
+2S      X       2N     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8970,8 +8970,8 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      3H
-3S      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+3S      Pass    4N     Pass
+5S      Pass    5N     Pass
 6D      Pass    Pass    Pass
 
 
@@ -9247,7 +9247,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      3D      3H
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5C      Pass    5H      Pass
 5S      Pass    6D      Pass
 Pass    Pass    
@@ -9481,7 +9481,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      Pass    1H      Pass
-2C      Pass    2NT     Pass
+2C      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -9543,7 +9543,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1D      Pass    2NT     Pass
+1D      Pass    2N     Pass
 3D      Pass    Pass    Pass
 
 
@@ -9565,7 +9565,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      3H
-3S      Pass    4NT     Pass
+3S      Pass    4N     Pass
 5S      Pass    6D      Pass
 Pass    Pass    
 
@@ -9628,7 +9628,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1D      2D      2H      3H
-Pass    Pass    3NT     4H
+Pass    Pass    3N     4H
 X       Pass    Pass    Pass
 
 
@@ -9837,12 +9837,12 @@ Pass    Pass    Pass
 {HCP 13 5 12 10}
 {TP 14 5 12 13}
 {Losers 7 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9948,8 +9948,8 @@ Pass
 [Auction "S"]
 1D      1S      X       Pass
 3C      Pass    3D      Pass
-3NT     Pass    4NT     Pass
-5C      Pass    5NT     Pass
+3N     Pass    4N     Pass
+5C      Pass    5N     Pass
 6C      Pass    6D      Pass
 Pass    Pass    
 
@@ -10111,11 +10111,11 @@ Pass    Pass    Pass
 {HCP 12 4 14 10}
 {TP 13 7 14 13}
 {Losers 6 8 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      3S
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10302,7 +10302,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1C      2C      3C      3S
-3NT     4S      Pass    Pass
+3N     4S      Pass    Pass
 X       Pass    Pass    Pass
 
 
@@ -10425,12 +10425,12 @@ Pass
 {HCP 12 3 16 9}
 {TP 12 5 18 13}
 {Losers 7 9 5 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      2H      Pass
 3C      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10511,11 +10511,11 @@ Pass
 {HCP 12 3 10 15}
 {TP 12 5 14 16}
 {Losers 8 9 5 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1C      2C      2H      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 

--- a/GIB/Michaels_and_Unusual.pbn
+++ b/GIB/Michaels_and_Unusual.pbn
@@ -15,7 +15,7 @@
 [Contract "5C"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3D      Pass
+1C      2N     3D      Pass
 3H      X       5C      Pass
 Pass    Pass    
 
@@ -141,7 +141,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3H      Pass
+1H      2N     3H      Pass
 Pass    Pass    
 
 
@@ -161,7 +161,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3C      Pass
+1H      2N     3C      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -182,7 +182,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     Pass    4H
+1C      2N     Pass    4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -223,7 +223,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     Pass    4C
+1S      2N     Pass    4C
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -288,7 +288,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     3D      4H
+1C      2N     3D      4H
 Pass    Pass    Pass    
 
 
@@ -308,7 +308,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3D      Pass
+1C      2N     3D      Pass
 3S      Pass    4C      Pass
 5C      Pass    Pass    Pass
 
@@ -371,7 +371,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1C      2C      Pass    2NT
+1C      2C      Pass    2N
 Pass    3H      Pass    4D
 Pass    4H      Pass    Pass
 Pass    
@@ -414,7 +414,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
+1S      2N     3C      Pass
 3H      X       4S      Pass
 Pass    Pass    
 
@@ -478,7 +478,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
+1S      2N     3C      Pass
 4S      Pass    Pass    Pass
 
 
@@ -517,11 +517,11 @@ Pass
 {HCP 4 14 8 14}
 {TP 5 16 11 14}
 {Losers 10 5 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1S      2S      X       2NT
-3NT     Pass    Pass    Pass
+1S      2S      X       2N
+3N     Pass    Pass    Pass
 
 
 
@@ -561,7 +561,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3C      3D
+1H      2N     3C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -646,9 +646,9 @@ Pass
 [Contract "6D"]
 [Declarer "E"]
 [Auction "E"]
-2C      2H      2NT     Pass
+2C      2H      2N     Pass
 3D      Pass    4D      4H
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6D      Pass    Pass    Pass
 
 
@@ -754,7 +754,7 @@ Pass    Pass
 [Contract "5HX"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     Pass    3D
+1H      2N     Pass    3D
 X       Pass    4H      Pass
 Pass    X       Pass    5D
 Pass    Pass    X       Pass
@@ -778,7 +778,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3D      Pass
+1H      2N     3D      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -841,7 +841,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3H      Pass
+1C      2N     3H      Pass
 3S      X       Pass    4H
 4S      Pass    Pass    Pass
 
@@ -881,11 +881,11 @@ Pass    Pass    Pass
 {HCP 2 15 8 15}
 {TP 5 16 12 16}
 {Losers 9 5 5 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
 1D      2H      3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1012,7 +1012,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
+1S      2N     3C      Pass
 4S      Pass    Pass    Pass
 
 
@@ -1033,7 +1033,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3H      3S      4H      Pass
 Pass    Pass    
 
@@ -1054,7 +1054,7 @@ Pass    Pass
 [Contract "5HX"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     3H      4H
+1C      2N     3H      4H
 4S      Pass    Pass    X
 Pass    5H      Pass    Pass
 X       Pass    Pass    Pass
@@ -1077,7 +1077,7 @@ X       Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     4H      Pass
+1H      2N     4H      Pass
 Pass    Pass    
 
 
@@ -1097,7 +1097,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     3H      Pass
+1D      2N     3H      Pass
 3S      X       Pass    4H
 4S      Pass    Pass    Pass
 
@@ -1119,7 +1119,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3H      Pass
+1H      2N     3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -1161,7 +1161,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "N"]
 [Auction "E"]
-1S      2NT     3S      4D
+1S      2N     3S      4D
 Pass    Pass    Pass    
 
 
@@ -1181,7 +1181,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     Pass    3C
+1D      2N     Pass    3C
 Pass    Pass    X       Pass
 3D      Pass    Pass    Pass
 
@@ -1203,7 +1203,7 @@ Pass    Pass    X       Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3D      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -1246,7 +1246,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      X
+1S      2N     3C      X
 3H      Pass    4S      Pass
 Pass    Pass    
 
@@ -1288,7 +1288,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3H      Pass
+1H      2N     3H      Pass
 Pass    Pass    
 
 
@@ -1373,7 +1373,7 @@ Pass
 [Contract "3SX"]
 [Declarer "E"]
 [Auction "E"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    3C      3D      X
 Pass    Pass    3S      Pass
 Pass    X       Pass    Pass
@@ -1393,11 +1393,11 @@ Pass
 {HCP 5 19 8 8}
 {TP 5 19 11 8}
 {Losers 9 5 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
 1D      1S      Pass    Pass
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1417,7 +1417,7 @@ Pass    Pass
 [Contract "3DX"]
 [Declarer "S"]
 [Auction "E"]
-1H      2H      X       2NT
+1H      2H      X       2N
 X       3D      Pass    Pass
 X       Pass    Pass    Pass
 
@@ -1439,7 +1439,7 @@ X       Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      2NT     3C      4D
+1D      2N     3C      4D
 Pass    4H      Pass    Pass
 Pass    
 
@@ -1460,7 +1460,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3D      Pass
+1H      2N     3D      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -1481,7 +1481,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     X       3C
+1D      2N     X       3C
 Pass    Pass    Pass    
 
 
@@ -1501,7 +1501,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     Pass    3H
+1C      2N     Pass    3H
 Pass    Pass    Pass    
 
 
@@ -1521,7 +1521,7 @@ Pass    Pass    Pass
 [Contract "5CX"]
 [Declarer "N"]
 [Auction "E"]
-1S      2NT     3C      3H
+1S      2N     3C      3H
 4S      Pass    Pass    5C
 X       Pass    Pass    Pass
 
@@ -1543,7 +1543,7 @@ X       Pass    Pass    Pass
 [Contract "4C"]
 [Declarer "W"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3D      4C      Pass
 Pass    Pass    
 
@@ -1564,7 +1564,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3D      4H
+1C      2N     3D      4H
 5C      Pass    Pass    Pass
 
 
@@ -1586,7 +1586,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1D      2D      2H      3S
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -1607,7 +1607,7 @@ X       Pass    3NT     Pass
 [Contract "4HX"]
 [Declarer "S"]
 [Auction "E"]
-1C      2NT     3H      X
+1C      2N     3H      X
 Pass    4H      X       Pass
 Pass    Pass    
 
@@ -1751,7 +1751,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1C      2NT     3D      Pass
+1C      2N     3D      Pass
 3H      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -1773,7 +1773,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
+1S      2N     3C      Pass
 3S      Pass    Pass    Pass
 
 
@@ -1877,11 +1877,11 @@ Pass    Pass
 {HCP 2 12 15 11}
 {TP 3 15 18 11}
 {Losers 10 6 4 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
 1C      2C      X       2S
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1922,7 +1922,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      2NT     3H      X
+1D      2N     3H      X
 Pass    4H      Pass    Pass
 Pass    
 
@@ -1964,7 +1964,7 @@ Pass
 [Contract "5H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3H      3S      4H      4S
 5H      Pass    Pass    Pass
 
@@ -2009,7 +2009,7 @@ X       Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2H      X       2NT
+1H      2H      X       2N
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2030,7 +2030,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "E"]
-1D      2NT     3H      Pass
+1D      2N     3H      Pass
 4D      Pass    4S      Pass
 Pass    X       Pass    Pass
 Pass    
@@ -2138,7 +2138,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3C      Pass
+1H      2N     3C      Pass
 4H      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -2181,7 +2181,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     3D      4H
+1D      2N     3D      4H
 Pass    Pass    Pass    
 
 
@@ -2201,7 +2201,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     Pass    3C
+1D      2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -2243,7 +2243,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-1C      2NT     3D      3S
+1C      2N     3D      3S
 Pass    4D      Pass    5D
 Pass    Pass    Pass    
 
@@ -2264,7 +2264,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1D      2NT     3D      Pass
+1D      2N     3D      Pass
 Pass    3H      Pass    Pass
 Pass    
 
@@ -2282,11 +2282,11 @@ Pass
 {HCP 3 16 10 11}
 {TP 5 18 13 12}
 {Losers 9 5 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
 1D      2D      X       2S
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2482,7 +2482,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3C      Pass    3H
 Pass    4C      Pass    5C
 Pass    Pass    Pass    
@@ -2525,7 +2525,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2H      X       2NT
+1H      2H      X       2N
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2588,7 +2588,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3S      Pass
+1S      2N     3S      Pass
 Pass    Pass    
 
 
@@ -2650,7 +2650,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     4D      Pass
+1H      2N     4D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2692,7 +2692,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3C      Pass
+1H      2N     3C      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2713,7 +2713,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3S      Pass
+1S      2N     3S      Pass
 Pass    Pass    
 
 
@@ -2733,7 +2733,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3H      3S      4H      Pass
 Pass    Pass    
 
@@ -2797,7 +2797,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "E"]
 1C      1S      2S      Pass
-3NT     Pass    6D      Pass
+3N     Pass    6D      Pass
 Pass    Pass    
 
 
@@ -2923,7 +2923,7 @@ Pass
 [Declarer "W"]
 [Auction "E"]
 1C      1H      1S      Pass
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -2945,7 +2945,7 @@ Pass
 [Declarer "E"]
 [Auction "E"]
 1D      2D      2H      Pass
-3D      3S      3NT     Pass
+3D      3S      3N     Pass
 5D      Pass    Pass    Pass
 
 
@@ -2986,7 +2986,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "E"]
-1S      2NT     X       3C
+1S      2N     X       3C
 X       Pass    3H      Pass
 Pass    Pass    
 
@@ -3028,7 +3028,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3D      Pass
+1C      2N     3D      Pass
 3S      Pass    4C      Pass
 5C      Pass    Pass    Pass
 
@@ -3114,7 +3114,7 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1D      2NT     3C      3H
+1D      2N     3C      3H
 X       Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -3136,7 +3136,7 @@ X       Pass    3S      Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     Pass    3H
+1D      2N     Pass    3H
 3S      X       4S      Pass
 Pass    Pass    
 
@@ -3154,11 +3154,11 @@ Pass    Pass
 {HCP 2 17 9 12}
 {TP 4 18 12 13}
 {Losers 9 6 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1S      2S      X       2NT
-3NT     Pass    Pass    Pass
+1S      2S      X       2N
+3N     Pass    Pass    Pass
 
 
 
@@ -3199,7 +3199,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     Pass    3D
+1C      2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -3240,7 +3240,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3H      Pass
+1C      2N     3H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3281,7 +3281,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3302,7 +3302,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3C      Pass
+1H      2N     3C      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3323,7 +3323,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
+1S      2N     3C      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3449,7 +3449,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1S      2S      3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -3555,7 +3555,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1H      1S      1NT
+1D      1H      1S      1N
 2S      Pass    Pass    X
 Pass    3C      3D      Pass
 3S      4H      Pass    Pass
@@ -3617,11 +3617,11 @@ Pass    Pass
 {HCP 3 14 9 14}
 {TP 5 16 14 14}
 {Losers 9 5 4 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
-1H      2H      X       2NT
-3D      3S      3NT     Pass
+1H      2H      X       2N
+3D      3S      3N     Pass
 Pass    Pass    
 
 
@@ -3662,7 +3662,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3S      Pass
+1S      2N     3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3683,7 +3683,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     Pass    3C
+1D      2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -3703,7 +3703,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     4H      Pass
+1H      2N     4H      Pass
 Pass    Pass    
 
 
@@ -3723,7 +3723,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
+1S      2N     3C      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3744,7 +3744,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "S"]
 [Auction "E"]
-1H      2H      X       2NT
+1H      2H      X       2N
 Pass    4D      Pass    Pass
 Pass    
 
@@ -3808,7 +3808,7 @@ Pass    Pass    Pass
 [Contract "4C"]
 [Declarer "S"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    4C      Pass    Pass
 Pass    
 
@@ -3829,8 +3829,8 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2H      Pass    2NT
-3C      Pass    3NT     Pass
+1H      2H      Pass    2N
+3C      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -3915,8 +3915,8 @@ Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1H      2H      3S      Pass
-4D      Pass    4NT     Pass
-5NT     Pass    6H      Pass
+4D      Pass    4N     Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -3955,11 +3955,11 @@ Pass    Pass
 {HCP 5 14 11 10}
 {TP 7 16 14 11}
 {Losers 9 5 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
-1C      2NT     X       3D
-3H      Pass    3NT     Pass
+1C      2N     X       3D
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4021,7 +4021,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     Pass    3H
+1D      2N     Pass    3H
 Pass    Pass    Pass    
 
 
@@ -4064,7 +4064,7 @@ Pass    Pass    Pass
 [Auction "E"]
 1C      2H      Pass    Pass
 3C      Pass    3H      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -4085,7 +4085,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3D      Pass
+1H      2N     3D      Pass
 3S      X       4S      Pass
 Pass    Pass    
 
@@ -4146,7 +4146,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     3H      Pass
+1D      2N     3H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4167,7 +4167,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     Pass    3H
+1C      2N     Pass    3H
 Pass    Pass    Pass    
 
 
@@ -4187,7 +4187,7 @@ Pass    Pass    Pass
 [Contract "4C"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3D      Pass
+1C      2N     3D      Pass
 4C      Pass    Pass    Pass
 
 
@@ -4423,7 +4423,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      X
+1S      2N     3C      X
 4S      Pass    Pass    Pass
 
 
@@ -4465,7 +4465,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     3H      Pass
+1D      2N     3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4483,11 +4483,11 @@ Pass    Pass
 {HCP 4 13 10 13}
 {TP 6 14 14 14}
 {Losers 9 7 5 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
 1D      2C      3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4551,7 +4551,7 @@ Pass    Pass
 [Auction "E"]
 1D      2D      2S      Pass
 3D      3H      3S      Pass
-4C      Pass    4NT     Pass
+4C      Pass    4N     Pass
 5H      Pass    6C      Pass
 Pass    Pass    
 
@@ -4593,7 +4593,7 @@ Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3H      Pass
+1H      2N     3H      Pass
 Pass    Pass    
 
 
@@ -4635,7 +4635,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
+1S      2N     3C      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4678,7 +4678,7 @@ Pass    Pass
 [Auction "E"]
 1D      2D      Pass    2S
 3D      3S      4D      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    Pass    Pass
 
 
@@ -4696,11 +4696,11 @@ Pass    Pass
 {HCP 7 13 10 10}
 {TP 7 16 13 11}
 {Losers 10 4 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
 1D      1H      X       2H
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4783,7 +4783,7 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1D      2NT     4S      Pass
+1D      2N     4S      Pass
 Pass    Pass    
 
 
@@ -4804,7 +4804,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1S      2S      3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      X       5S      Pass
 Pass    Pass    
 
@@ -4909,7 +4909,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "S"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    4C      Pass    Pass
 Pass    
 
@@ -4951,7 +4951,7 @@ Pass    Pass    Pass
 [Contract "4C"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3D      Pass
+1C      2N     3D      Pass
 4C      Pass    Pass    Pass
 
 
@@ -4972,7 +4972,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     Pass    3D
+1C      2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -5055,7 +5055,7 @@ Pass    Pass
 [Contract "3CX"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3C      X
+1C      2N     3C      X
 Pass    Pass    Pass    
 
 
@@ -5093,12 +5093,12 @@ Pass
 {HCP 3 15 8 14}
 {TP 4 18 10 15}
 {Losers 10 5 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1H      2H      X       2NT
+1H      2H      X       2N
 3C      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5162,7 +5162,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1C      1H      X       1NT
+1C      1H      X       1N
 2S      Pass    Pass    Pass
 
 
@@ -5227,7 +5227,7 @@ Pass    Pass
 [Auction "E"]
 1C      2C      2S      Pass
 3D      Pass    3S      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5H      Pass    6D      Pass
 Pass    Pass    
 
@@ -5268,7 +5268,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     Pass    3H
+1D      2N     Pass    3H
 Pass    Pass    Pass    
 
 
@@ -5309,7 +5309,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3S      Pass
+1S      2N     3S      Pass
 Pass    Pass    
 
 
@@ -5350,7 +5350,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     4C      X
+1H      2N     4C      X
 4H      Pass    Pass    Pass
 
 
@@ -5393,7 +5393,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     3D      4D
+1C      2N     3D      4D
 Pass    Pass    Pass    
 
 
@@ -5456,7 +5456,7 @@ Pass    Pass    Pass
 [Auction "E"]
 1H      2H      2S      Pass
 3C      Pass    3S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 6H      Pass    Pass    Pass
 
 
@@ -5498,7 +5498,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     X       3C
+1S      2N     X       3C
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5540,7 +5540,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3H      Pass
+1C      2N     3H      Pass
 4S      Pass    Pass    Pass
 
 
@@ -5582,7 +5582,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3H      Pass
+1H      2N     3H      Pass
 Pass    Pass    
 
 
@@ -5642,11 +5642,11 @@ Pass    Pass
 {HCP 4 14 10 12}
 {TP 8 17 14 13}
 {Losers 6 4 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     X       3H
-3NT     Pass    Pass    Pass
+1C      2N     X       3H
+3N     Pass    Pass    Pass
 
 
 
@@ -5666,7 +5666,7 @@ Pass    Pass
 [Contract "3CX"]
 [Declarer "S"]
 [Auction "E"]
-1D      2D      X       2NT
+1D      2D      X       2N
 Pass    3C      Pass    Pass
 X       Pass    Pass    Pass
 
@@ -5688,7 +5688,7 @@ X       Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     Pass    3H
+1C      2N     Pass    3H
 Pass    Pass    Pass    
 
 
@@ -5708,7 +5708,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3H      Pass
+1H      2N     3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5750,7 +5750,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      2NT     3C      Pass
+1D      2N     3C      Pass
 3D      4H      Pass    Pass
 Pass    
 
@@ -5792,7 +5792,7 @@ Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3C      Pass    3S
 Pass    Pass    Pass    
 
@@ -5813,7 +5813,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3C      X
+1H      2N     3C      X
 4H      Pass    Pass    Pass
 
 
@@ -5855,7 +5855,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3C      3D      Pass
 Pass    3S      4D      Pass
 Pass    Pass    
@@ -5898,7 +5898,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      2NT     3D      Pass
+1D      2N     3D      Pass
 Pass    4H      Pass    Pass
 Pass    
 
@@ -5941,7 +5941,7 @@ Pass
 [Contract "5D"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     3C      Pass
+1D      2N     3C      Pass
 3D      3H      Pass    4H
 5D      Pass    Pass    Pass
 
@@ -6026,8 +6026,8 @@ Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1H      2H      2S      Pass
-4H      Pass    4NT     Pass
-5NT     Pass    6H      Pass
+4H      Pass    4N     Pass
+5N     Pass    6H      Pass
 Pass    Pass    
 
 
@@ -6047,7 +6047,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     3H      Pass
+1D      2N     3H      Pass
 3S      X       4S      Pass
 Pass    Pass    
 
@@ -6068,7 +6068,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3C      Pass    3H
 Pass    5C      Pass    Pass
 Pass    
@@ -6111,7 +6111,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3H      3S      4H      Pass
 Pass    Pass    
 
@@ -6129,11 +6129,11 @@ Pass    Pass
 {HCP 8 11 10 11}
 {TP 11 13 14 11}
 {Losers 7 7 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "E"]
 1H      2D      Pass    2S
-Pass    3C      Pass    3NT
+Pass    3C      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -6153,7 +6153,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3D      3H
+1C      2N     3D      3H
 X       Pass    4C      Pass
 5C      Pass    Pass    Pass
 
@@ -6219,7 +6219,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     3D      Pass
+1C      2N     3D      Pass
 4C      X       Pass    4D
 Pass    Pass    Pass    
 
@@ -6261,7 +6261,7 @@ Pass    Pass    Pass
 [Contract "5H"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     3H      4H
+1D      2N     3H      4H
 4S      Pass    Pass    X
 Pass    5H      Pass    Pass
 Pass    
@@ -6300,13 +6300,13 @@ Pass    Pass    Pass
 {HCP 6 15 11 8}
 {TP 9 18 13 10}
 {Losers 7 3 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
 1C      1H      Pass    Pass
-2S      Pass    2NT     Pass
+2S      Pass    2N     Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6431,7 +6431,7 @@ X       Pass    Pass    Pass
 [Contract "3HX"]
 [Declarer "N"]
 [Auction "E"]
-1S      2S      X       2NT
+1S      2S      X       2N
 Pass    3D      Pass    Pass
 X       Pass    Pass    3H
 X       Pass    Pass    Pass
@@ -6454,7 +6454,7 @@ X       Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "E"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -6539,7 +6539,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     3C      X
+1D      2N     3C      X
 3D      Pass    Pass    4H
 Pass    Pass    Pass    
 
@@ -6560,8 +6560,8 @@ Pass    Pass    Pass
 [Contract "6S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
-4S      Pass    4NT     Pass
+1S      2N     3C      Pass
+4S      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -6582,7 +6582,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "E"]
 [Auction "E"]
-1S      2S      3NT     Pass
+1S      2S      3N     Pass
 4D      Pass    5D      Pass
 Pass    Pass    
 
@@ -6667,9 +6667,9 @@ Pass
 [Contract "6CX"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3D      3H
+1C      2N     3D      3H
 4C      4H      Pass    Pass
-4NT     Pass    5D      X
+4N     Pass    5D      X
 6C      X       Pass    Pass
 Pass    
 
@@ -6712,7 +6712,7 @@ Pass
 [Contract "4D"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     Pass    3D
+1C      2N     Pass    3D
 Pass    Pass    X       Pass
 3S      X       Pass    4D
 Pass    Pass    Pass    
@@ -6755,7 +6755,7 @@ Pass    Pass    Pass
 [Contract "4D"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     3C      Pass
+1D      2N     3C      Pass
 3D      Pass    Pass    3H
 3S      Pass    4D      Pass
 Pass    Pass    
@@ -6839,7 +6839,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     Pass    3D
+1C      2N     Pass    3D
 Pass    Pass    Pass    
 
 
@@ -6880,7 +6880,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1D      2NT     3D      Pass
+1D      2N     3D      Pass
 Pass    3H      Pass    Pass
 Pass    
 
@@ -6921,7 +6921,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3D      Pass
+1C      2N     3D      Pass
 3H      X       3S      Pass
 4C      X       5C      Pass
 Pass    Pass    
@@ -6943,7 +6943,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     4S      5C
+1D      2N     4S      5C
 Pass    Pass    Pass    
 
 
@@ -6983,7 +6983,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     4H      Pass
+1H      2N     4H      Pass
 Pass    Pass    
 
 
@@ -7191,7 +7191,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3D      Pass
+1H      2N     3D      Pass
 4H      Pass    Pass    Pass
 
 
@@ -7212,7 +7212,7 @@ Pass    Pass    Pass
 [Contract "4D"]
 [Declarer "S"]
 [Auction "E"]
-1C      2NT     3C      Pass
+1C      2N     3C      Pass
 Pass    3D      Pass    4D
 Pass    Pass    Pass    
 
@@ -7254,7 +7254,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     Pass    3C
+1D      2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -7274,7 +7274,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -7338,8 +7338,8 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1H      2H      2S      Pass
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -7465,7 +7465,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3H      Pass
+1C      2N     3H      Pass
 3S      X       4S      Pass
 Pass    Pass    
 
@@ -7507,7 +7507,7 @@ Pass
 [Contract "3CX"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     X       3C
+1D      2N     X       3C
 X       Pass    Pass    Pass
 
 
@@ -7649,12 +7649,12 @@ Pass    Pass
 {HCP 5 11 8 16}
 {TP 8 14 12 18}
 {Losers 8 5 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
 1H      Pass    2C      Pass
 2H      Pass    3D      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7674,7 +7674,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3H      4C
+1H      2N     3H      4C
 4H      Pass    Pass    Pass
 
 
@@ -7802,7 +7802,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1C      2NT     X       3D
+1C      2N     X       3D
 3H      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -7933,7 +7933,7 @@ X       Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1C      2NT     3C      Pass
+1C      2N     3C      Pass
 Pass    3H      Pass    Pass
 4C      X       Pass    4H
 Pass    Pass    Pass    
@@ -8084,7 +8084,7 @@ X       Pass    3C      Pass
 [Declarer "E"]
 [Auction "E"]
 1S      2S      3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 6D      Pass    6S      Pass
 Pass    Pass    
 
@@ -8102,11 +8102,11 @@ Pass    Pass
 {HCP 3 18 9 10}
 {TP 5 19 12 10}
 {Losers 9 5 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
 1D      2D      X       2S
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8126,7 +8126,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
+1S      2N     3C      Pass
 4S      Pass    Pass    Pass
 
 
@@ -8169,7 +8169,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     3D      3H
+1C      2N     3D      3H
 4C      4H      Pass    Pass
 Pass    
 
@@ -8190,7 +8190,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     4S      Pass
+1S      2N     4S      Pass
 Pass    Pass    
 
 
@@ -8251,7 +8251,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     4S      Pass
+1S      2N     4S      Pass
 Pass    Pass    
 
 
@@ -8293,7 +8293,7 @@ Pass    Pass
 [Declarer "W"]
 [Auction "E"]
 1D      2C      2S      3C
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -8314,7 +8314,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3C      4C
+1H      2N     3C      4C
 4H      Pass    Pass    Pass
 
 
@@ -8377,7 +8377,7 @@ Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3S      Pass
+1S      2N     3S      Pass
 Pass    Pass    
 
 
@@ -8397,7 +8397,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     4D      Pass
+1H      2N     4D      Pass
 6H      Pass    Pass    Pass
 
 
@@ -8438,7 +8438,7 @@ Pass    Pass    Pass
 [Contract "3CX"]
 [Declarer "N"]
 [Auction "E"]
-1S      2NT     X       3C
+1S      2N     X       3C
 X       Pass    Pass    Pass
 
 
@@ -8480,7 +8480,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     Pass    3H
+1C      2N     Pass    3H
 3S      X       Pass    4D
 Pass    4H      4S      Pass
 Pass    Pass    
@@ -8625,7 +8625,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
+1S      2N     3C      Pass
 3H      Pass    3S      Pass
 Pass    Pass    
 
@@ -8646,7 +8646,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3H      4C
+1H      2N     3H      4C
 4H      Pass    Pass    Pass
 
 
@@ -8667,7 +8667,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3D      Pass
+1C      2N     3D      Pass
 4C      Pass    Pass    Pass
 
 
@@ -8774,7 +8774,7 @@ Pass    Pass    Pass
 [Contract "3DX"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     3C      X
+1D      2N     3C      X
 Pass    Pass    3D      Pass
 Pass    X       Pass    Pass
 Pass    
@@ -8796,7 +8796,7 @@ Pass
 [Contract "5D"]
 [Declarer "W"]
 [Auction "E"]
-1S      2S      X       2NT
+1S      2S      X       2N
 Pass    3C      3D      Pass
 4D      Pass    5D      Pass
 Pass    Pass    
@@ -8860,7 +8860,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     3C      X
+1D      2N     3C      X
 3D      Pass    3H      Pass
 4D      Pass    Pass    Pass
 
@@ -8946,7 +8946,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3D      X
+1H      2N     3D      X
 3H      Pass    Pass    Pass
 
 
@@ -9030,7 +9030,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     Pass    3D
+1C      2N     Pass    3D
 Pass    Pass    X       Pass
 3S      X       Pass    4D
 Pass    Pass    4S      Pass
@@ -9075,7 +9075,7 @@ Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1D      2NT     Pass    3H
+1D      2N     Pass    3H
 X       Pass    4S      Pass
 Pass    Pass    
 
@@ -9096,7 +9096,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     3H      Pass
+1D      2N     3H      Pass
 3S      X       4S      Pass
 Pass    X       Pass    Pass
 Pass    
@@ -9163,7 +9163,7 @@ X       Pass    3C      Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
+1S      2N     3C      Pass
 4S      Pass    Pass    Pass
 
 
@@ -9205,8 +9205,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "E"]
-1H      2NT     3D      Pass
-3NT     Pass    4S      Pass
+1H      2N     3D      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -9247,7 +9247,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-1C      2NT     4S      5D
+1C      2N     4S      5D
 Pass    Pass    Pass    
 
 
@@ -9264,12 +9264,12 @@ Pass    Pass    Pass
 {HCP 7 12 11 10}
 {TP 8 14 13 10}
 {Losers 9 6 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
 1D      2D      X       2H
-2S      Pass    2NT     Pass
-3C      Pass    3NT     Pass
+2S      Pass    2N     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9308,11 +9308,11 @@ Pass    Pass    3S      Pass
 {HCP 5 12 10 13}
 {TP 5 13 13 13}
 {Losers 10 7 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
 1D      1H      2H      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9332,7 +9332,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3D      Pass
+1C      2N     3D      Pass
 3H      Pass    4C      Pass
 5C      Pass    Pass    Pass
 
@@ -9395,7 +9395,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     3C      Pass
+1D      2N     3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9583,7 +9583,7 @@ Pass    Pass    Pass
 [Contract "5H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3C      4D
+1H      2N     3C      4D
 4H      Pass    Pass    5D
 5H      Pass    Pass    Pass
 
@@ -9626,7 +9626,7 @@ Pass    Pass    Pass
 [Contract "4HX"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     Pass    4H
+1D      2N     Pass    4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -9667,7 +9667,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3H      4D
+1C      2N     3H      4D
 4S      Pass    Pass    Pass
 
 
@@ -9688,7 +9688,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2H      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -9752,7 +9752,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      4D
+1S      2N     3C      4D
 4S      Pass    Pass    Pass
 
 
@@ -9839,7 +9839,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "E"]
-1D      2NT     Pass    3C
+1D      2N     Pass    3C
 Pass    Pass    Pass    
 
 
@@ -9898,10 +9898,10 @@ Pass    Pass    Pass
 {HCP 9 11 11 9}
 {TP 12 13 15 10}
 {Losers 6 7 5 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      2NT     Pass    3NT
+1C      2N     Pass    3N
 Pass    Pass    Pass    
 
 
@@ -9962,11 +9962,11 @@ Pass    Pass
 {HCP 0 13 11 16}
 {TP 2 16 14 18}
 {Losers 10 6 5 5}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "W"]
 [Auction "E"]
 1H      2H      X       2S
-3S      Pass    6NT     Pass
+3S      Pass    6N     Pass
 Pass    Pass    
 
 
@@ -9983,11 +9983,11 @@ Pass    Pass
 {HCP 9 13 8 10}
 {TP 11 15 11 11}
 {Losers 7 6 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "E"]
 1D      1S      2H      3H
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -10007,7 +10007,7 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     4H      5C
+1H      2N     4H      5C
 5H      Pass    Pass    Pass
 
 
@@ -10049,7 +10049,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      X
+1S      2N     3C      X
 3H      Pass    4S      Pass
 Pass    Pass    
 
@@ -10091,7 +10091,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3C      Pass
+1H      2N     3C      Pass
 4H      Pass    Pass    Pass
 
 
@@ -10133,7 +10133,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "E"]
 [Auction "E"]
-1C      2NT     3H      Pass
+1C      2N     3H      Pass
 4C      Pass    5C      Pass
 Pass    Pass    
 
@@ -10155,7 +10155,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1C      1H      2H      X
-2NT     Pass    3D      Pass
+2N     Pass    3D      Pass
 4C      Pass    Pass    Pass
 
 
@@ -10281,7 +10281,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2NT     3C      Pass
+1S      2N     3C      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10325,7 +10325,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1C      1H      X       Pass
-1S      2D      3NT     Pass
+1S      2D      3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -10346,7 +10346,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2S      3NT     4H
+1S      2S      3N     4H
 Pass    Pass    4S      Pass
 5D      Pass    6S      Pass
 Pass    Pass    
@@ -10389,7 +10389,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3H      Pass
+1H      2N     3H      Pass
 Pass    Pass    
 
 
@@ -10513,7 +10513,7 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "E"]
 [Auction "E"]
-1D      2NT     3C      Pass
+1D      2N     3C      Pass
 3H      Pass    3S      Pass
 6D      Pass    Pass    Pass
 

--- a/GIB/Minor_Suit_Transfer.pbn
+++ b/GIB/Minor_Suit_Transfer.pbn
@@ -15,7 +15,7 @@
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -36,7 +36,7 @@
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -57,7 +57,7 @@
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -78,7 +78,7 @@
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -99,7 +99,7 @@
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -120,7 +120,7 @@
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -141,7 +141,7 @@
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -159,10 +159,10 @@
 {HCP 7 8 17 8}
 {TP 9 9 17 8}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -182,7 +182,7 @@
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -203,7 +203,7 @@
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -224,7 +224,7 @@
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -242,11 +242,11 @@
 {HCP 7 10 16 7}
 {TP 9 11 16 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
-3D      Pass    3NT     Pass
+1N     Pass    3C      Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -266,7 +266,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -284,12 +284,12 @@ Pass    Pass
 {HCP 7 10 17 6}
 {TP 9 10 17 8}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -309,7 +309,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -330,7 +330,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -351,7 +351,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -372,7 +372,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -393,7 +393,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -414,7 +414,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -435,7 +435,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -453,12 +453,12 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 8 17 9}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -475,10 +475,10 @@ Pass    Pass
 {HCP 7 9 17 7}
 {TP 9 9 17 8}
 {Losers 8 8 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -498,7 +498,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -519,7 +519,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -540,7 +540,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -561,7 +561,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -582,7 +582,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -603,7 +603,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -624,7 +624,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -645,7 +645,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -666,7 +666,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -684,10 +684,10 @@ Pass    Pass
 {HCP 7 9 15 9}
 {TP 9 10 15 9}
 {Losers 8 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -707,7 +707,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -728,7 +728,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -749,7 +749,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -770,7 +770,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -791,7 +791,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -812,7 +812,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -833,7 +833,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -854,7 +854,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -875,7 +875,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -896,7 +896,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -917,7 +917,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -938,7 +938,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -956,10 +956,10 @@ Pass    Pass
 {HCP 7 8 17 8}
 {TP 9 9 17 8}
 {Losers 8 8 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -979,7 +979,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1000,7 +1000,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1018,10 +1018,10 @@ Pass    Pass
 {HCP 7 6 17 10}
 {TP 9 6 17 10}
 {Losers 7 10 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1041,7 +1041,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1059,10 +1059,10 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 10 15 9}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1082,7 +1082,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1100,10 +1100,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 9 16 10}
 {Losers 8 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1123,7 +1123,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1144,7 +1144,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1165,7 +1165,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1186,7 +1186,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1207,7 +1207,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1225,10 +1225,10 @@ Pass    Pass
 {HCP 7 10 16 7}
 {TP 9 11 16 7}
 {Losers 8 8 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1248,7 +1248,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1269,7 +1269,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1290,7 +1290,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1311,7 +1311,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1329,10 +1329,10 @@ Pass    Pass
 {HCP 7 8 15 10}
 {TP 9 8 15 10}
 {Losers 8 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1349,10 +1349,10 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 10 16 9}
 {Losers 8 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1372,7 +1372,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1390,10 +1390,10 @@ Pass    Pass
 {HCP 7 10 16 7}
 {TP 9 11 16 7}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1413,7 +1413,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1434,7 +1434,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1455,7 +1455,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1476,7 +1476,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1497,7 +1497,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1518,7 +1518,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1539,7 +1539,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1560,7 +1560,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1581,9 +1581,9 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
-3D      Pass    3NT     Pass
-4NT     Pass    5D      Pass
+1N     Pass    3C      Pass
+3D      Pass    3N     Pass
+4N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -1603,7 +1603,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1624,7 +1624,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1645,7 +1645,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1666,7 +1666,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1684,10 +1684,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 7 18 9}
 {Losers 8 10 5 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1707,7 +1707,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1725,10 +1725,10 @@ Pass    Pass
 {HCP 7 8 15 10}
 {TP 9 9 16 10}
 {Losers 8 9 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1748,7 +1748,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1769,7 +1769,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1790,7 +1790,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1811,7 +1811,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1829,10 +1829,10 @@ Pass    Pass
 {HCP 7 9 16 8}
 {TP 9 9 16 9}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1852,7 +1852,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1870,10 +1870,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 8 16 10}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1890,10 +1890,10 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 10 15 8}
 {Losers 8 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1913,7 +1913,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -1931,10 +1931,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 7 18 10}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1951,10 +1951,10 @@ Pass    Pass
 {HCP 7 8 15 10}
 {TP 9 8 15 10}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -1974,7 +1974,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -1992,10 +1992,10 @@ Pass    Pass
 {HCP 7 9 16 8}
 {TP 9 9 16 8}
 {Losers 8 9 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2015,7 +2015,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2036,7 +2036,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2057,7 +2057,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2078,7 +2078,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2099,7 +2099,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2120,7 +2120,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2141,7 +2141,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2162,7 +2162,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2180,10 +2180,10 @@ Pass    Pass
 {HCP 7 6 17 10}
 {TP 9 6 17 10}
 {Losers 8 10 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2203,7 +2203,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2224,7 +2224,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2245,7 +2245,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2266,7 +2266,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2287,7 +2287,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2308,7 +2308,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2329,7 +2329,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2350,7 +2350,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2371,7 +2371,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2392,7 +2392,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2413,7 +2413,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2434,7 +2434,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2455,7 +2455,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2476,7 +2476,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2497,7 +2497,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2515,10 +2515,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 8 17 9}
 {Losers 8 8 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2538,7 +2538,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2559,7 +2559,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2577,10 +2577,10 @@ Pass    Pass
 {HCP 7 10 16 7}
 {TP 9 10 16 8}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2600,7 +2600,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2621,7 +2621,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2642,7 +2642,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2660,12 +2660,12 @@ Pass    Pass
 {HCP 7 10 17 6}
 {TP 9 10 17 7}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2685,7 +2685,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2706,7 +2706,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2727,7 +2727,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2745,10 +2745,10 @@ Pass    Pass
 {HCP 7 10 16 7}
 {TP 9 10 16 7}
 {Losers 8 9 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2765,10 +2765,10 @@ Pass    Pass
 {HCP 7 10 16 7}
 {TP 9 10 17 7}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -2788,7 +2788,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2809,7 +2809,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2830,7 +2830,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2851,7 +2851,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2872,7 +2872,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2893,7 +2893,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2914,7 +2914,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2935,7 +2935,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -2956,7 +2956,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2977,7 +2977,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -2995,10 +2995,10 @@ Pass    Pass
 {HCP 7 8 17 8}
 {TP 9 8 17 9}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3018,7 +3018,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3039,7 +3039,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3060,7 +3060,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3081,7 +3081,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3102,7 +3102,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3123,7 +3123,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3144,7 +3144,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3165,7 +3165,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3186,7 +3186,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3207,8 +3207,8 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
-3D      Pass    3NT     Pass
+1N     Pass    3C      Pass
+3D      Pass    3N     Pass
 4S      Pass    5D      Pass
 Pass    Pass    
 
@@ -3226,10 +3226,10 @@ Pass    Pass
 {HCP 7 10 16 7}
 {TP 9 11 16 8}
 {Losers 8 8 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3249,7 +3249,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3270,7 +3270,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3288,10 +3288,10 @@ Pass    Pass
 {HCP 7 8 16 9}
 {TP 9 8 16 9}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3308,10 +3308,10 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 10 15 9}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3328,10 +3328,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 10 16 10}
 {Losers 8 7 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3351,7 +3351,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3372,7 +3372,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3393,7 +3393,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3414,7 +3414,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3435,7 +3435,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3456,7 +3456,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3477,7 +3477,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3498,7 +3498,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3516,10 +3516,10 @@ Pass    Pass
 {HCP 7 9 17 7}
 {TP 9 9 17 9}
 {Losers 8 10 5 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3539,7 +3539,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3560,7 +3560,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3581,7 +3581,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3599,10 +3599,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 9 17 11}
 {Losers 8 8 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3619,10 +3619,10 @@ Pass    Pass
 {HCP 7 9 15 9}
 {TP 9 9 15 10}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3642,7 +3642,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3663,9 +3663,9 @@ Pass    Pass
 [Contract "6D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
-3D      Pass    3NT     Pass
-4NT     Pass    5H      Pass
+1N     Pass    3C      Pass
+3D      Pass    3N     Pass
+4N     Pass    5H      Pass
 6D      Pass    Pass    Pass
 
 
@@ -3686,7 +3686,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3707,7 +3707,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3728,7 +3728,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3746,10 +3746,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 9 17 9}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3769,7 +3769,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3790,7 +3790,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3811,7 +3811,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3832,7 +3832,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3853,7 +3853,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3871,10 +3871,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 8 17 10}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3894,7 +3894,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3915,7 +3915,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3936,7 +3936,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -3957,7 +3957,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -3975,10 +3975,10 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 11 15 9}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3998,7 +3998,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4019,7 +4019,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4040,7 +4040,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4061,7 +4061,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4082,7 +4082,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4103,7 +4103,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4124,7 +4124,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4142,10 +4142,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 8 17 9}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4165,7 +4165,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4186,7 +4186,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4207,7 +4207,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4228,7 +4228,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4249,7 +4249,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4270,7 +4270,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4291,7 +4291,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4312,7 +4312,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4333,7 +4333,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4354,7 +4354,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4375,7 +4375,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4396,7 +4396,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4417,7 +4417,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4438,7 +4438,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4459,7 +4459,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4477,10 +4477,10 @@ Pass    Pass
 {HCP 7 9 17 7}
 {TP 9 10 17 8}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4500,7 +4500,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4521,7 +4521,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4539,10 +4539,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 8 18 9}
 {Losers 8 8 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4562,7 +4562,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4580,10 +4580,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 8 17 10}
 {Losers 8 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4603,7 +4603,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4624,7 +4624,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4645,7 +4645,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4666,7 +4666,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4687,7 +4687,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4708,7 +4708,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4729,7 +4729,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4750,7 +4750,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4771,7 +4771,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4792,7 +4792,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4813,7 +4813,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4834,7 +4834,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4855,7 +4855,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4876,7 +4876,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4897,7 +4897,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4918,7 +4918,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4939,7 +4939,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4960,7 +4960,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -4981,7 +4981,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -4999,10 +4999,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 8 17 10}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5019,10 +5019,10 @@ Pass    Pass
 {HCP 7 9 15 9}
 {TP 9 9 15 10}
 {Losers 8 9 8 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5042,7 +5042,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5060,10 +5060,10 @@ Pass    Pass
 {HCP 7 9 16 8}
 {TP 9 10 16 9}
 {Losers 8 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5083,7 +5083,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5104,7 +5104,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5125,7 +5125,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5146,7 +5146,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5167,7 +5167,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5188,7 +5188,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5209,7 +5209,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5230,7 +5230,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5248,10 +5248,10 @@ Pass    Pass
 {HCP 7 9 15 9}
 {TP 9 9 15 10}
 {Losers 8 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5271,7 +5271,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5292,7 +5292,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5310,10 +5310,10 @@ Pass    Pass
 {HCP 7 8 16 9}
 {TP 9 8 16 9}
 {Losers 8 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5333,7 +5333,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5354,7 +5354,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5372,12 +5372,12 @@ Pass    Pass
 {HCP 7 6 17 10}
 {TP 9 8 17 10}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5397,7 +5397,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5418,7 +5418,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5436,10 +5436,10 @@ Pass    Pass
 {HCP 7 8 16 9}
 {TP 9 9 17 10}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5456,10 +5456,10 @@ Pass    Pass
 {HCP 7 8 15 10}
 {TP 9 9 15 10}
 {Losers 8 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5476,10 +5476,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 7 16 10}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5499,7 +5499,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5520,7 +5520,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5538,10 +5538,10 @@ Pass    Pass
 {HCP 7 8 17 8}
 {TP 9 8 18 8}
 {Losers 8 10 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5561,7 +5561,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5582,7 +5582,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5603,7 +5603,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5621,10 +5621,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 8 17 10}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5644,7 +5644,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5662,10 +5662,10 @@ Pass    Pass
 {HCP 7 9 17 7}
 {TP 9 9 17 8}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5682,10 +5682,10 @@ Pass    Pass
 {HCP 7 10 16 7}
 {TP 9 10 16 8}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5705,7 +5705,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5726,7 +5726,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5747,7 +5747,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5768,7 +5768,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5789,7 +5789,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5810,7 +5810,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5831,7 +5831,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5852,7 +5852,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5873,7 +5873,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5894,7 +5894,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5912,10 +5912,10 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 10 15 8}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -5935,7 +5935,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5956,7 +5956,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -5977,7 +5977,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -5998,7 +5998,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6019,7 +6019,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6040,7 +6040,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6061,7 +6061,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6082,7 +6082,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6103,7 +6103,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6124,7 +6124,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6145,7 +6145,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6166,7 +6166,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6187,7 +6187,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6208,7 +6208,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6229,7 +6229,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6250,7 +6250,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6271,7 +6271,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6289,10 +6289,10 @@ Pass    Pass
 {HCP 7 6 17 10}
 {TP 9 6 17 10}
 {Losers 8 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6309,10 +6309,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 7 17 10}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6332,7 +6332,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6353,7 +6353,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6374,7 +6374,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6395,7 +6395,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6416,7 +6416,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6437,7 +6437,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6458,7 +6458,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6479,7 +6479,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6497,10 +6497,10 @@ Pass    Pass
 {HCP 7 6 17 10}
 {TP 9 6 17 10}
 {Losers 8 10 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6520,7 +6520,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6541,7 +6541,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6562,7 +6562,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6583,7 +6583,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6601,10 +6601,10 @@ Pass    Pass
 {HCP 7 9 15 9}
 {TP 9 10 15 10}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6624,7 +6624,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6645,7 +6645,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6663,10 +6663,10 @@ Pass    Pass
 {HCP 7 10 17 6}
 {TP 9 10 17 7}
 {Losers 8 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6686,7 +6686,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6707,7 +6707,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6728,7 +6728,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6749,7 +6749,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6770,7 +6770,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6788,10 +6788,10 @@ Pass    Pass
 {HCP 7 8 15 10}
 {TP 9 8 15 10}
 {Losers 8 9 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6811,7 +6811,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6832,7 +6832,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6853,7 +6853,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6874,7 +6874,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6895,7 +6895,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -6913,10 +6913,10 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 11 16 8}
 {Losers 8 7 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6936,7 +6936,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6954,10 +6954,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 8 16 10}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6977,7 +6977,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -6998,7 +6998,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7019,7 +7019,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7040,7 +7040,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7061,7 +7061,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7082,7 +7082,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7103,7 +7103,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7124,7 +7124,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7145,7 +7145,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7166,7 +7166,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7187,7 +7187,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7208,7 +7208,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7229,7 +7229,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7250,7 +7250,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7271,7 +7271,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7292,7 +7292,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7310,10 +7310,10 @@ Pass    Pass
 {HCP 7 8 17 8}
 {TP 9 8 17 8}
 {Losers 8 10 5 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7333,7 +7333,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7354,7 +7354,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7372,10 +7372,10 @@ Pass    Pass
 {HCP 7 8 15 10}
 {TP 9 8 16 10}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7395,7 +7395,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7416,7 +7416,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7437,7 +7437,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7458,7 +7458,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7476,10 +7476,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 7 16 11}
 {Losers 8 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7499,7 +7499,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7520,7 +7520,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7541,7 +7541,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7562,7 +7562,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7583,7 +7583,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7604,7 +7604,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7625,7 +7625,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7646,7 +7646,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7667,7 +7667,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7688,7 +7688,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7709,7 +7709,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7730,7 +7730,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7751,7 +7751,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7772,7 +7772,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7793,7 +7793,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7811,10 +7811,10 @@ Pass    Pass
 {HCP 7 8 17 8}
 {TP 9 9 17 9}
 {Losers 8 9 5 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7831,10 +7831,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 8 17 9}
 {Losers 8 9 5 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7851,10 +7851,10 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 11 15 9}
 {Losers 8 8 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7874,7 +7874,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7895,7 +7895,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7913,10 +7913,10 @@ Pass    Pass
 {HCP 7 8 15 10}
 {TP 9 8 15 10}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -7936,7 +7936,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7957,7 +7957,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -7978,7 +7978,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -7999,7 +7999,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8020,7 +8020,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8041,7 +8041,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8062,7 +8062,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8083,7 +8083,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8104,7 +8104,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8125,7 +8125,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8146,7 +8146,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8167,7 +8167,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8188,7 +8188,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8209,7 +8209,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8230,7 +8230,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8251,7 +8251,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8272,7 +8272,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8293,7 +8293,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8314,7 +8314,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8332,10 +8332,10 @@ Pass    Pass
 {HCP 7 8 15 10}
 {TP 9 9 15 10}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8352,10 +8352,10 @@ Pass    Pass
 {HCP 7 8 16 9}
 {TP 9 9 16 9}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8375,7 +8375,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8396,7 +8396,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8417,7 +8417,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8438,7 +8438,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8459,7 +8459,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8480,7 +8480,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8501,7 +8501,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8522,7 +8522,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8543,7 +8543,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8564,7 +8564,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8582,10 +8582,10 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 10 16 9}
 {Losers 8 8 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8605,7 +8605,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8626,7 +8626,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8647,7 +8647,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8665,10 +8665,10 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 10 15 9}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8685,10 +8685,10 @@ Pass    Pass
 {HCP 7 8 16 9}
 {TP 9 9 16 9}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8708,7 +8708,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8729,7 +8729,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8747,11 +8747,11 @@ Pass    Pass
 {HCP 7 10 15 8}
 {TP 9 10 15 8}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
-3D      Pass    3NT     Pass
+1N     Pass    3C      Pass
+3D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8768,10 +8768,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 7 16 10}
 {Losers 8 9 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8791,7 +8791,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8812,7 +8812,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8833,7 +8833,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8854,7 +8854,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8875,7 +8875,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -8896,7 +8896,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8917,7 +8917,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8938,7 +8938,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8959,7 +8959,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -8977,10 +8977,10 @@ Pass    Pass
 {HCP 7 8 15 10}
 {TP 9 9 15 10}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9000,7 +9000,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9021,7 +9021,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9042,7 +9042,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9063,7 +9063,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9084,7 +9084,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9105,7 +9105,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9123,10 +9123,10 @@ Pass    Pass
 {HCP 7 10 16 7}
 {TP 9 11 17 7}
 {Losers 8 7 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9146,7 +9146,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9167,7 +9167,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9188,7 +9188,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9209,7 +9209,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9230,7 +9230,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9251,7 +9251,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9272,7 +9272,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9293,7 +9293,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9314,7 +9314,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9335,7 +9335,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9356,7 +9356,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9377,7 +9377,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9395,10 +9395,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 8 17 9}
 {Losers 8 8 7 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9418,7 +9418,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9439,7 +9439,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9457,10 +9457,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 8 16 10}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9480,7 +9480,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9498,10 +9498,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 9 17 10}
 {Losers 8 8 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9521,7 +9521,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9542,7 +9542,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9563,7 +9563,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9584,7 +9584,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9602,10 +9602,10 @@ Pass    Pass
 {HCP 7 7 17 9}
 {TP 9 7 18 9}
 {Losers 8 9 6 9}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9625,7 +9625,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9646,7 +9646,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9667,7 +9667,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9685,10 +9685,10 @@ Pass    Pass
 {HCP 7 8 17 8}
 {TP 9 9 17 9}
 {Losers 8 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9708,7 +9708,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9729,7 +9729,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9750,7 +9750,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9771,7 +9771,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9792,7 +9792,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9813,7 +9813,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9834,7 +9834,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9855,7 +9855,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9873,10 +9873,10 @@ Pass    Pass
 {HCP 7 7 16 10}
 {TP 9 7 16 11}
 {Losers 8 10 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9896,7 +9896,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9917,7 +9917,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -9938,7 +9938,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9959,7 +9959,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -9980,7 +9980,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10001,7 +10001,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10022,7 +10022,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -10043,7 +10043,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10064,7 +10064,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -10085,7 +10085,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10106,7 +10106,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10127,7 +10127,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -10148,7 +10148,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10166,10 +10166,10 @@ Pass    Pass
 {HCP 7 10 17 6}
 {TP 9 10 17 7}
 {Losers 8 8 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -10189,7 +10189,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10210,7 +10210,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -10231,7 +10231,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -10252,7 +10252,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10273,7 +10273,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10291,10 +10291,10 @@ Pass    Pass
 {HCP 7 10 17 6}
 {TP 9 10 17 8}
 {Losers 8 9 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -10314,7 +10314,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10335,7 +10335,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10356,7 +10356,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2NT     Pass
+1N     Pass    2N     Pass
 3C      Pass    Pass    Pass
 
 
@@ -10377,7 +10377,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -10398,7 +10398,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3C      Pass
+1N     Pass    3C      Pass
 3D      Pass    Pass    Pass
 
 
@@ -10416,9 +10416,9 @@ Pass    Pass
 {HCP 7 6 17 10}
 {TP 9 7 17 10}
 {Losers 8 9 6 10}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 

--- a/GIB/Opps_Bal_Unusual_2N
+++ b/GIB/Opps_Bal_Unusual_2N
@@ -4606,11 +4606,11 @@ Pass
 {HCP 7 9 13 11}
 {TP 7 11 15 13}
 {Losers 9 8 5 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
 1S      2C      2S      3D
-Pass    3S      Pass    3NT
+Pass    3S      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -9393,10 +9393,10 @@ Pass
 {HCP 6 11 12 11}
 {TP 7 11 13 13}
 {Losers 9 9 7 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "S"]
-1H      2C      2H      2NT
+1H      2C      2H      2N
 Pass    Pass    Pass    
 
 

--- a/GIB/Opps_Michaels_Cuebid
+++ b/GIB/Opps_Michaels_Cuebid
@@ -56,7 +56,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1H      1S      1NT     Pass
+1H      1S      1N     Pass
 2D      Pass    2H      Pass
 Pass    Pass    
 
@@ -161,8 +161,8 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      2S      Pass    2NT
-3S      Pass    3NT     Pass
+1S      2S      Pass    2N
+3S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -247,7 +247,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    4C      Pass    Pass
 Pass    
 
@@ -391,11 +391,11 @@ Pass    Pass    Pass
 {HCP 10 0 18 12}
 {TP 10 1 20 15}
 {Losers 8 11 4 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1S      2S      Pass    3H
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -436,7 +436,7 @@ Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    4D      Pass    Pass
 Pass    
 
@@ -602,7 +602,7 @@ Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "S"]
-1C      2C      Pass    2NT
+1C      2C      Pass    2N
 Pass    3H      Pass    Pass
 Pass    
 
@@ -726,7 +726,7 @@ Pass
 [Contract "5C"]
 [Declarer "W"]
 [Auction "S"]
-1S      2S      4S      4NT
+1S      2S      4S      4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -810,7 +810,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    2H      Pass    4H
 Pass    Pass    Pass    
 
@@ -916,7 +916,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -934,11 +934,11 @@ Pass
 {HCP 11 2 16 11}
 {TP 12 5 17 14}
 {Losers 8 8 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2C      2H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -958,7 +958,7 @@ Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    4D      Pass    Pass
 Pass    
 
@@ -1059,12 +1059,12 @@ Pass
 {HCP 9 3 16 12}
 {TP 11 3 18 15}
 {Losers 7 11 4 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2C      2S      Pass
 3C      Pass    3D      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1146,7 +1146,7 @@ Pass
 [Contract "3DX"]
 [Declarer "W"]
 [Auction "S"]
-1S      2S      X       2NT
+1S      2S      X       2N
 Pass    3D      X       Pass
 Pass    Pass    
 
@@ -1420,7 +1420,7 @@ Pass    Pass    Pass
 [Contract "4DX"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      X       2NT
+1H      2H      X       2N
 X       4D      Pass    Pass
 X       Pass    Pass    Pass
 
@@ -1463,7 +1463,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3H      3S      Pass    4S
 Pass    Pass    Pass    
 
@@ -1610,7 +1610,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3C      Pass    3D
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
@@ -1633,7 +1633,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 1C      X       1H      Pass
-1NT     2S      3C      3S
+1N     2S      3C      3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -2013,7 +2013,7 @@ Pass
 [Contract "4C"]
 [Declarer "E"]
 [Auction "S"]
-1H      2NT     3H      4C
+1H      2N     3H      4C
 Pass    Pass    Pass    
 
 
@@ -2030,12 +2030,12 @@ Pass    Pass    Pass
 {HCP 12 5 13 10}
 {TP 15 8 13 13}
 {Losers 4 7 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1C      2C      2S      Pass
 3D      3H      3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2178,7 +2178,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1C      2NT     Pass    3H
+1C      2N     Pass    3H
 Pass    3S      Pass    4H
 Pass    Pass    Pass    
 
@@ -2241,7 +2241,7 @@ Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3D      X       3S
 Pass    Pass    Pass    
 
@@ -2262,7 +2262,7 @@ Pass    Pass    Pass
 [Contract "4C"]
 [Declarer "W"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    4C      Pass    Pass
 Pass    
 
@@ -2496,7 +2496,7 @@ X       Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -2583,7 +2583,7 @@ Pass    Pass    4D      Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    4D      Pass    Pass
 Pass    
 
@@ -2921,8 +2921,8 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      2S      3H      Pass
-4S      Pass    4NT     Pass
-5NT     Pass    6S      Pass
+4S      Pass    4N     Pass
+5N     Pass    6S      Pass
 Pass    Pass    
 
 
@@ -3026,7 +3026,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1H      2NT     3C      Pass
+1H      2N     3C      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3047,7 +3047,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    4D      Pass    4H
 Pass    Pass    Pass    
 
@@ -3176,7 +3176,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1S      2S      3S      4H
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    5H      X       Pass
 Pass    Pass    
 
@@ -3282,7 +3282,7 @@ Pass    Pass
 [Contract "3SX"]
 [Declarer "S"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 3S      X       Pass    Pass
 Pass    
 
@@ -3323,7 +3323,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -3345,7 +3345,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1H      2H      3S      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -3551,10 +3551,10 @@ Pass    Pass
 {HCP 12 5 13 10}
 {TP 12 5 15 12}
 {Losers 8 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1S      2S      3NT     Pass
+1S      2S      3N     Pass
 Pass    Pass    
 
 
@@ -3634,11 +3634,11 @@ Pass    Pass    4C      Pass
 {HCP 13 2 11 14}
 {TP 13 5 13 19}
 {Losers 7 8 7 3}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      X       2S
-3S      X       3NT     Pass
+3S      X       3N     Pass
 Pass    Pass    
 
 
@@ -3659,7 +3659,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1H      2H      Pass    3S
-Pass    4H      Pass    4NT
+Pass    4H      Pass    4N
 Pass    6C      Pass    6S
 Pass    Pass    Pass    
 
@@ -3784,7 +3784,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    4D      Pass    Pass
 Pass    
 
@@ -3888,11 +3888,11 @@ Pass    Pass    Pass
 {HCP 9 2 14 15}
 {TP 9 3 16 18}
 {Losers 8 11 5 4}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      Pass    2H
-X       Pass    3NT     Pass
+X       Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3912,7 +3912,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -3933,7 +3933,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4081,7 +4081,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    3C      X       3H
 4S      Pass    Pass    Pass
 
@@ -4100,11 +4100,11 @@ Pass    3C      X       3H
 {HCP 12 4 12 12}
 {TP 12 5 13 15}
 {Losers 9 9 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "N"]
 [Auction "S"]
 1D      2D      Pass    2S
-Pass    Pass    2NT     Pass
+Pass    Pass    2N     Pass
 Pass    Pass    
 
 
@@ -4145,7 +4145,7 @@ Pass    Pass    Pass
 [Contract "6D"]
 [Declarer "S"]
 [Auction "S"]
-1S      2S      X       2NT
+1S      2S      X       2N
 Pass    3C      Pass    Pass
 3D      Pass    3H      Pass
 3S      Pass    5D      Pass
@@ -4254,7 +4254,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    4D      Pass    4S
 Pass    Pass    Pass    
 
@@ -4442,7 +4442,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    3D      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -4525,7 +4525,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    3D      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -4629,7 +4629,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    4C      Pass    4S
 Pass    Pass    Pass    
 
@@ -4734,7 +4734,7 @@ Pass
 [Contract "4C"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    4C      Pass    Pass
 Pass    
 
@@ -4799,7 +4799,7 @@ Pass
 [Declarer "W"]
 [Auction "S"]
 1D      2D      Pass    2H
-Pass    3S      Pass    3NT
+Pass    3S      Pass    3N
 Pass    4S      Pass    Pass
 Pass    
 
@@ -5071,7 +5071,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      4H      4NT
+1H      2H      4H      4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -5136,7 +5136,7 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1S      2S      3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -5303,7 +5303,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3D      X       Pass    3S
 Pass    Pass    4H      X
 Pass    4S      Pass    Pass
@@ -5326,7 +5326,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3H      3S      4H      Pass
 Pass    Pass    
 
@@ -5389,7 +5389,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1D      2D      Pass    2NT
+1D      2D      Pass    2N
 Pass    3D      Pass    Pass
 Pass    
 
@@ -5664,7 +5664,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 3S      Pass    Pass    Pass
 
 
@@ -5750,7 +5750,7 @@ Pass    Pass
 [Auction "S"]
 1C      2C      2H      Pass
 3C      3S      4C      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 6C      Pass    Pass    Pass
 
 
@@ -5979,7 +5979,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -6061,7 +6061,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    4D      Pass    4H
 Pass    Pass    Pass    
 
@@ -6166,7 +6166,7 @@ Pass    Pass    Pass
 [Contract "3HX"]
 [Declarer "W"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    3D      X       Pass
 Pass    3H      Pass    Pass
 X       Pass    Pass    Pass
@@ -6610,8 +6610,8 @@ Pass    Pass
 [Declarer "S"]
 [Auction "S"]
 1H      2H      2S      Pass
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -6716,7 +6716,7 @@ Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    4D      Pass    Pass
 Pass    
 
@@ -6821,11 +6821,11 @@ Pass
 {HCP 3 13 12 12}
 {TP 4 14 13 15}
 {Losers 9 8 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-1H      2H      Pass    2NT
-Pass    3D      Pass    3NT
+1H      2H      Pass    2N
+Pass    3D      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -6845,7 +6845,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3H      Pass    Pass    Pass
 
 
@@ -6930,7 +6930,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    4D      Pass    5D
 Pass    Pass    Pass    
 
@@ -6971,7 +6971,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3H      Pass    Pass    3S
 Pass    Pass    Pass    
 
@@ -7056,7 +7056,7 @@ Pass    Pass    Pass
 [Contract "3SX"]
 [Declarer "S"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 3S      X       Pass    Pass
 Pass    
 
@@ -7078,7 +7078,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1D      2D      X       2S
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 Pass    Pass    
 
 
@@ -7120,7 +7120,7 @@ Pass
 [Declarer "E"]
 [Auction "S"]
 1S      2S      Pass    4H
-Pass    4NT     Pass    5D
+Pass    4N     Pass    5D
 Pass    6H      Pass    Pass
 Pass    
 
@@ -7308,7 +7308,7 @@ Pass
 [Contract "3SX"]
 [Declarer "S"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 3S      X       Pass    Pass
 Pass    
 
@@ -7350,7 +7350,7 @@ Pass
 [Contract "5C"]
 [Declarer "E"]
 [Auction "S"]
-1S      2NT     Pass    3C
+1S      2N     Pass    3C
 Pass    4D      Pass    5C
 Pass    Pass    Pass    
 
@@ -7473,12 +7473,12 @@ X       Pass    Pass    Pass
 {HCP 13 4 11 12}
 {TP 14 4 14 15}
 {Losers 6 10 5 4}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1S      2S      X       2NT
+1S      2S      X       2N
 Pass    3C      3D      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7619,11 +7619,11 @@ Pass
 {HCP 11 5 11 13}
 {TP 12 6 13 16}
 {Losers 7 10 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 1H      2H      X       2S
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7794,7 +7794,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 1S      2S      Pass    4H
-Pass    4NT     Pass    5D
+Pass    4N     Pass    5D
 Pass    5H      Pass    Pass
 Pass    
 
@@ -7917,13 +7917,13 @@ Pass    Pass    Pass
 {HCP 12 3 12 13}
 {TP 12 5 12 16}
 {Losers 9 9 7 4}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
 1D      2D      2H      Pass
 3D      3H      Pass    Pass
 3S      X       XX      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7945,7 +7945,7 @@ Pass    Pass    Pass
 [Auction "S"]
 1D      2D      2S      Pass
 3C      Pass    3S      Pass
-4C      Pass    4NT     Pass
+4C      Pass    4N     Pass
 5D      Pass    6C      Pass
 Pass    Pass    
 
@@ -8072,7 +8072,7 @@ Pass
 [Auction "S"]
 1D      2D      X       2S
 X       Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 5C      Pass    Pass    Pass
 
 
@@ -8426,7 +8426,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    4C      Pass    4H
 Pass    Pass    Pass    
 
@@ -8821,11 +8821,11 @@ Pass
 {HCP 8 5 17 10}
 {TP 10 7 17 14}
 {Losers 8 8 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-1S      Pass    1NT     Pass
-2NT     Pass    3NT     Pass
+1S      Pass    1N     Pass
+2N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8866,7 +8866,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1H      2H      X       2NT
+1H      2H      X       2N
 Pass    4C      X       Pass
 4H      Pass    Pass    Pass
 
@@ -9017,7 +9017,7 @@ X       Pass    3D      Pass
 [Contract "4C"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3C      Pass    Pass
 X       3S      Pass    4C
 Pass    Pass    Pass    
@@ -9104,7 +9104,7 @@ Pass    Pass    Pass
 [Contract "4C"]
 [Declarer "E"]
 [Auction "S"]
-1D      2NT     3D      4C
+1D      2N     3D      4C
 Pass    Pass    Pass    
 
 
@@ -9146,7 +9146,7 @@ Pass
 [Declarer "S"]
 [Auction "S"]
 1H      2H      3S      4S
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6H      Pass    Pass    Pass
 
 
@@ -9187,7 +9187,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "E"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3H      3S      4H      5D
 Pass    Pass    Pass    
 
@@ -9271,7 +9271,7 @@ Pass    Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3D      X       3S
 Pass    Pass    Pass    
 
@@ -9313,7 +9313,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-Pass    1S      Pass    1NT
+Pass    1S      Pass    1N
 Pass    2H      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -9419,7 +9419,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1H      2H      X       2NT
+1H      2H      X       2N
 3H      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9998,7 +9998,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "W"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -10058,11 +10058,11 @@ Pass
 {HCP 17 2 11 10}
 {TP 17 2 12 13}
 {Losers 7 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
-Pass    1S      1NT     Pass
-3NT     Pass    Pass    Pass
+Pass    1S      1N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10083,7 +10083,7 @@ Pass    1S      1NT     Pass
 [Declarer "E"]
 [Auction "S"]
 1D      2D      Pass    2H
-Pass    3S      Pass    3NT
+Pass    3S      Pass    3N
 Pass    4H      Pass    Pass
 Pass    
 
@@ -10228,7 +10228,7 @@ Pass
 [Contract "4C"]
 [Declarer "W"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    4C      Pass    Pass
 Pass    
 
@@ -10289,7 +10289,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3C      Pass    3S
 Pass    4S      Pass    Pass
 Pass    
@@ -10353,7 +10353,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "W"]
 [Auction "S"]
-1S      2S      Pass    2NT
+1S      2S      Pass    2N
 Pass    4C      Pass    5C
 Pass    Pass    Pass    
 
@@ -10374,7 +10374,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "W"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 Pass    3C      Pass    Pass
 Pass    
 
@@ -10438,7 +10438,7 @@ Pass    Pass    X       Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1S      2NT     3C      3D
+1S      2N     3C      3D
 4S      Pass    Pass    Pass
 
 
@@ -10481,7 +10481,7 @@ Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1H      2H      Pass    2NT
+1H      2H      Pass    2N
 3H      X       Pass    3S
 Pass    Pass    Pass    
 

--- a/GIB/Opps_Preempt_4M
+++ b/GIB/Opps_Preempt_4M
@@ -380,7 +380,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      Pass    1NT     2H
+1S      Pass    1N     2H
 2S      4H      4S      Pass
 Pass    Pass    
 
@@ -421,7 +421,7 @@ Pass    Pass    Pass
 [Contract "5CX"]
 [Declarer "N"]
 [Auction "E"]
-1H      2NT     3D      4C
+1H      2N     3D      4C
 4H      Pass    Pass    5C
 X       Pass    Pass    Pass
 
@@ -1070,7 +1070,7 @@ Pass
 [Declarer "E"]
 [Auction "E"]
 1S      Pass    2H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -1112,7 +1112,7 @@ Pass    Pass
 [Declarer "N"]
 [Auction "E"]
 4H      Pass    Pass    X
-Pass    4NT     Pass    5C
+Pass    4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -1152,7 +1152,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -1252,7 +1252,7 @@ Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -1273,7 +1273,7 @@ Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -1515,7 +1515,7 @@ Pass    Pass    Pass
 [Contract "5S"]
 [Declarer "E"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      5S      Pass
 Pass    Pass    
 
@@ -1698,7 +1698,7 @@ Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -1718,7 +1718,7 @@ Pass    Pass    Pass
 [Contract "5H"]
 [Declarer "E"]
 [Auction "E"]
-1H      Pass    1NT     4S
+1H      Pass    1N     4S
 Pass    Pass    5H      Pass
 Pass    Pass    
 
@@ -1801,7 +1801,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -1843,7 +1843,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -2369,7 +2369,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -2533,7 +2533,7 @@ Pass
 [Auction "E"]
 1S      Pass    2D      Pass
 2S      Pass    3C      Pass
-3S      Pass    3NT     Pass
+3S      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -2594,7 +2594,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -3058,7 +3058,7 @@ Pass
 [Auction "E"]
 1H      Pass    1S      Pass
 2H      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -3140,7 +3140,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4H      4NT     Pass    5C
+4H      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -3279,10 +3279,10 @@ Pass
 {HCP 16 7 10 7}
 {TP 18 11 13 9}
 {Losers 5 6 6 8}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "N"]
 [Auction "E"]
-4S      5H      Pass    6NT
+4S      5H      Pass    6N
 Pass    Pass    Pass    
 
 
@@ -3385,7 +3385,7 @@ Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -3406,7 +3406,7 @@ Pass
 [Contract "6D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    6D
+4S      4N     Pass    6D
 Pass    Pass    Pass    
 
 
@@ -3450,7 +3450,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "E"]
 4H      Pass    Pass    X
-Pass    4NT     Pass    5C
+Pass    4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -3470,7 +3470,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4H      X       Pass    4NT
+4H      X       Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -3532,7 +3532,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2H      Pass    Pass    2S
 Pass    4S      Pass    Pass
 Pass    
@@ -3835,7 +3835,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -3855,7 +3855,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -3954,11 +3954,11 @@ Pass
 {HCP 12 10 11 7}
 {TP 14 13 12 8}
 {Losers 5 5 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "E"]
 1H      1S      Pass    3D
-Pass    3H      Pass    3NT
+Pass    3H      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -4220,7 +4220,7 @@ Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -4441,7 +4441,7 @@ Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -4541,7 +4541,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -4704,7 +4704,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -4928,7 +4928,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      X       2NT     Pass
+1H      X       2N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -5049,7 +5049,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -5273,7 +5273,7 @@ Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -5334,7 +5334,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -5355,7 +5355,7 @@ Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -5376,7 +5376,7 @@ Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "E"]
-1H      2NT     3C      3D
+1H      2N     3C      3D
 4H      Pass    Pass    Pass
 
 
@@ -5478,8 +5478,8 @@ Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "E"]
-1S      Pass    1NT     2S
-Pass    2NT     Pass    3D
+1S      Pass    1N     2S
+Pass    2N     Pass    3D
 Pass    3H      Pass    Pass
 Pass    
 
@@ -5707,7 +5707,7 @@ Pass
 [Declarer "N"]
 [Auction "E"]
 4H      Pass    Pass    X
-Pass    4NT     Pass    5C
+Pass    4N     Pass    5C
 Pass    5D      Pass    6C
 Pass    Pass    Pass    
 
@@ -5728,7 +5728,7 @@ Pass    Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "E"]
-4H      4S      Pass    4NT
+4H      4S      Pass    4N
 Pass    5S      Pass    6S
 Pass    Pass    Pass    
 
@@ -5769,7 +5769,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "E"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2S      Pass    Pass    Pass
 
 
@@ -5811,7 +5811,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1H      Pass    2C      2S
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -5952,7 +5952,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4H      X       Pass    4NT
+4H      X       Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -5993,7 +5993,7 @@ Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4H      Pass    Pass    4NT
+4H      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -6158,7 +6158,7 @@ Pass    Pass    Pass
 [Declarer "S"]
 [Auction "E"]
 1S      2H      2S      3H
-3S      4H      4S      4NT
+3S      4H      4S      4N
 Pass    6H      Pass    Pass
 Pass    
 
@@ -6219,7 +6219,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -6321,8 +6321,8 @@ Pass    Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "E"]
-4H      4S      Pass    4NT
-Pass    5NT     Pass    6S
+4H      4S      Pass    4N
+Pass    5N     Pass    6S
 Pass    Pass    Pass    
 
 
@@ -6402,7 +6402,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -6627,8 +6627,8 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-1S      2NT     Pass    3S
-Pass    4NT     Pass    5C
+1S      2N     Pass    3S
+Pass    4N     Pass    5C
 Pass    5D      Pass    Pass
 Pass    
 
@@ -6689,7 +6689,7 @@ Pass    Pass    Pass
 [Contract "6C"]
 [Declarer "N"]
 [Auction "E"]
-4H      X       Pass    4NT
+4H      X       Pass    4N
 Pass    5D      Pass    6C
 Pass    Pass    Pass    
 
@@ -6730,7 +6730,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      Pass    1NT     X
+1S      Pass    1N     X
 2S      3D      4S      Pass
 Pass    Pass    
 
@@ -6751,7 +6751,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1H      Pass    1NT     X
+1H      Pass    1N     X
 2H      3H      Pass    4C
 Pass    4S      Pass    Pass
 Pass    
@@ -6996,7 +6996,7 @@ Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4H      X       Pass    4NT
+4H      X       Pass    4N
 Pass    5C      Pass    5D
 Pass    Pass    Pass    
 
@@ -7222,7 +7222,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -7428,7 +7428,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -7468,7 +7468,7 @@ Pass    Pass    Pass
 [Contract "5S"]
 [Declarer "S"]
 [Auction "E"]
-4H      4S      Pass    4NT
+4H      4S      Pass    4N
 Pass    5S      Pass    Pass
 Pass    
 
@@ -7610,7 +7610,7 @@ Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "E"]
-1S      2S      X       2NT
+1S      2S      X       2N
 4S      Pass    Pass    Pass
 
 
@@ -7735,7 +7735,7 @@ Pass
 [Declarer "N"]
 [Auction "E"]
 4H      Pass    Pass    X
-Pass    4NT     Pass    5D
+Pass    4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -8120,7 +8120,7 @@ Pass
 [Contract "6S"]
 [Declarer "E"]
 [Auction "E"]
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -8161,7 +8161,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -8204,7 +8204,7 @@ Pass    Pass    Pass
 [Auction "E"]
 1H      Pass    1S      Pass
 2H      Pass    3C      Pass
-3H      Pass    3NT     Pass
+3H      Pass    3N     Pass
 4H      Pass    Pass    Pass
 
 
@@ -8245,7 +8245,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4H      X       Pass    4NT
+4H      X       Pass    4N
 Pass    5C      Pass    5D
 Pass    Pass    Pass    
 
@@ -8527,7 +8527,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4S      Pass    Pass    4NT
+4S      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -8629,7 +8629,7 @@ Pass
 [Contract "5C"]
 [Declarer "S"]
 [Auction "E"]
-4H      Pass    Pass    4NT
+4H      Pass    Pass    4N
 Pass    5C      Pass    Pass
 Pass    
 
@@ -8732,7 +8732,7 @@ Pass    Pass    Pass
 [Declarer "N"]
 [Auction "E"]
 4H      Pass    Pass    4S
-Pass    4NT     Pass    5C
+Pass    4N     Pass    5C
 Pass    5D      Pass    5S
 Pass    Pass    Pass    
 
@@ -8833,7 +8833,7 @@ Pass    Pass    Pass
 [Contract "5D"]
 [Declarer "S"]
 [Auction "E"]
-4H      Pass    Pass    4NT
+4H      Pass    Pass    4N
 Pass    5D      Pass    Pass
 Pass    
 
@@ -9337,7 +9337,7 @@ Pass    Pass    Pass
 [Contract "5H"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5H
+4S      4N     Pass    5H
 Pass    Pass    Pass    
 
 
@@ -9543,7 +9543,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1S      2C      Pass    Pass
-2S      Pass    4NT     Pass
+2S      Pass    4N     Pass
 6C      Pass    6S      Pass
 Pass    Pass    
 
@@ -9727,7 +9727,7 @@ Pass
 [Declarer "S"]
 [Auction "E"]
 4H      Pass    Pass    X
-Pass    4NT     Pass    5C
+Pass    4N     Pass    5C
 Pass    5D      Pass    Pass
 Pass    
 
@@ -9748,7 +9748,7 @@ Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5D
+4S      4N     Pass    5D
 Pass    Pass    Pass    
 
 
@@ -9809,7 +9809,7 @@ Pass    Pass    Pass
 [Contract "5H"]
 [Declarer "E"]
 [Auction "E"]
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    5H      Pass
 Pass    Pass    
 
@@ -9974,7 +9974,7 @@ Pass    Pass    Pass
 [Declarer "E"]
 [Auction "E"]
 1S      2C      2D      Pass
-2S      3C      3NT     Pass
+2S      3C      3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -9995,7 +9995,7 @@ Pass    Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "E"]
-4S      4NT     Pass    5C
+4S      4N     Pass    5C
 Pass    Pass    Pass    
 
 
@@ -10035,7 +10035,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2H      Pass    Pass    2S
 Pass    3S      Pass    4S
 Pass    Pass    Pass    
@@ -10078,7 +10078,7 @@ Pass
 [Contract "6H"]
 [Declarer "E"]
 [Auction "E"]
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    6H      Pass
 Pass    Pass    
 

--- a/GIB/Responsive_Double_TEST.pbn
+++ b/GIB/Responsive_Double_TEST.pbn
@@ -114,10 +114,10 @@ Pass    Pass    Pass
 {HCP 15 6 8 11}
 {TP 15 6 9 12}
 {Losers 7 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "W"]
-1S      1NT     2S      3NT
+1S      1N     2S      3N
 Pass    Pass    Pass    
 
 
@@ -344,7 +344,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "W"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2S      Pass    Pass    Pass
 
 
@@ -781,12 +781,12 @@ Pass    Pass    Pass
 {HCP 12 6 10 12}
 {TP 12 6 12 15}
 {Losers 7 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "W"]
-1S      Pass    1NT     Pass
+1S      Pass    1N     Pass
 2S      Pass    Pass    X
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1138,7 +1138,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "W"]
-1H      Pass    1NT     Pass
+1H      Pass    1N     Pass
 2H      X       Pass    2S
 Pass    Pass    3H      Pass
 Pass    Pass    
@@ -1429,7 +1429,7 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "W"]
 Pass    1D      Pass    1S
-Pass    1NT     Pass    Pass
+Pass    1N     Pass    Pass
 2H      Pass    Pass    Pass
 
 
@@ -1991,7 +1991,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "W"]
-1H      1NT     2H      Pass
+1H      1N     2H      Pass
 Pass    2S      Pass    4S
 Pass    Pass    Pass    
 

--- a/GIB/Smolen.pbn
+++ b/GIB/Smolen.pbn
@@ -12,12 +12,12 @@
 {HCP 11 5 16 8}
 {TP 12 5 16 9}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -37,9 +37,9 @@
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5H      Pass    6H      Pass
 Pass    Pass    
 
@@ -57,12 +57,12 @@ Pass    Pass
 {HCP 11 11 15 3}
 {TP 13 12 15 4}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -82,7 +82,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -101,12 +101,12 @@ Pass    Pass
 {HCP 14 7 16 3}
 {TP 16 7 16 4}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -123,12 +123,12 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 12 9 16 7}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -148,7 +148,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -170,7 +170,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -192,7 +192,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -214,7 +214,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -236,7 +236,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -258,7 +258,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -280,7 +280,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -299,12 +299,12 @@ Pass    Pass
 {HCP 15 3 15 7}
 {TP 16 4 16 7}
 {Losers 6 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -321,12 +321,12 @@ Pass    Pass
 {HCP 14 8 15 3}
 {TP 14 9 15 4}
 {Losers 6 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -346,7 +346,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -368,7 +368,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -390,7 +390,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -412,7 +412,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -434,7 +434,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -456,7 +456,7 @@ Pass    Pass
 [Contract "2SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2C      2S
+1N     Pass    2C      2S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -477,7 +477,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -499,7 +499,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -521,7 +521,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -543,7 +543,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -562,12 +562,12 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 13 9 15 7}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -587,7 +587,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -609,7 +609,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -628,12 +628,12 @@ Pass    Pass
 {HCP 11 7 16 6}
 {TP 11 7 16 7}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -653,10 +653,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5C      Pass    5N     Pass
 6C      Pass    6H      Pass
 Pass    Pass    
 
@@ -677,7 +677,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -699,7 +699,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -718,12 +718,12 @@ Pass    Pass
 {HCP 15 6 16 3}
 {TP 16 6 16 3}
 {Losers 5 10 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -740,12 +740,12 @@ Pass    Pass
 {HCP 11 9 17 3}
 {TP 11 10 17 5}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -762,12 +762,12 @@ Pass    Pass
 {HCP 15 7 15 3}
 {TP 17 9 15 3}
 {Losers 5 8 8 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -787,7 +787,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -809,7 +809,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -831,7 +831,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -853,9 +853,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -876,7 +876,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -898,7 +898,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -920,9 +920,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -944,9 +944,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -964,12 +964,12 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 13 9 15 7}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -989,7 +989,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1011,7 +1011,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1030,12 +1030,12 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 10 6 15 10}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1055,7 +1055,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4D      Pass
 5C      Pass    5H      Pass
@@ -1079,9 +1079,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -1099,12 +1099,12 @@ Pass    Pass
 {HCP 12 8 15 5}
 {TP 14 10 16 6}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1124,7 +1124,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1143,12 +1143,12 @@ Pass    Pass
 {HCP 14 10 15 1}
 {TP 15 10 16 2}
 {Losers 6 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1165,12 +1165,12 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 12 9 16 7}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1187,12 +1187,12 @@ Pass    Pass
 {HCP 10 7 16 7}
 {TP 11 7 17 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1212,7 +1212,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -1234,7 +1234,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1253,12 +1253,12 @@ Pass    Pass
 {HCP 13 3 16 8}
 {TP 15 4 16 8}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1278,7 +1278,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1300,10 +1300,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+4H      Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    6H      Pass
 Pass    Pass    
 
@@ -1324,7 +1324,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1343,12 +1343,12 @@ Pass    Pass
 {HCP 16 6 16 2}
 {TP 19 7 16 3}
 {Losers 5 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1368,7 +1368,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1387,12 +1387,12 @@ Pass    Pass
 {HCP 10 5 17 8}
 {TP 12 5 17 8}
 {Losers 6 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1412,7 +1412,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1431,12 +1431,12 @@ Pass    Pass
 {HCP 14 2 16 8}
 {TP 15 3 17 8}
 {Losers 6 11 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1456,7 +1456,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1475,12 +1475,12 @@ Pass    Pass
 {HCP 11 5 15 9}
 {TP 12 6 15 9}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1500,9 +1500,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -1524,7 +1524,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1546,7 +1546,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1565,12 +1565,12 @@ Pass    Pass
 {HCP 15 6 15 4}
 {TP 16 7 15 4}
 {Losers 6 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1590,7 +1590,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1612,7 +1612,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1634,7 +1634,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1656,7 +1656,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1678,9 +1678,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -1701,7 +1701,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1723,7 +1723,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1745,9 +1745,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -1768,7 +1768,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -1790,7 +1790,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1812,7 +1812,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1831,12 +1831,12 @@ Pass    Pass
 {HCP 14 7 16 3}
 {TP 14 8 17 4}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1853,12 +1853,12 @@ Pass    Pass
 {HCP 13 6 15 6}
 {TP 13 7 15 7}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1878,7 +1878,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -1897,12 +1897,12 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 12 8 15 6}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1919,12 +1919,12 @@ Pass    Pass
 {HCP 10 13 15 2}
 {TP 10 15 15 3}
 {Losers 7 6 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1941,12 +1941,12 @@ Pass    Pass
 {HCP 15 8 15 2}
 {TP 16 9 15 3}
 {Losers 6 9 7 10}
-[Contract "4NT"]
+[Contract "4N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3S      Pass
-3NT     Pass    4NT     Pass
+3N     Pass    4N     Pass
 Pass    Pass    
 
 
@@ -1966,7 +1966,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -1988,7 +1988,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2010,7 +2010,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2032,7 +2032,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2051,12 +2051,12 @@ Pass    Pass
 {HCP 13 4 16 7}
 {TP 16 5 16 10}
 {Losers 5 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2076,9 +2076,9 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3H      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    5H      Pass
 Pass    Pass    
 
@@ -2099,7 +2099,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2118,12 +2118,12 @@ Pass    Pass
 {HCP 11 14 15 0}
 {TP 11 14 16 1}
 {Losers 8 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2143,7 +2143,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2165,7 +2165,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2187,7 +2187,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2209,7 +2209,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2231,7 +2231,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
 Pass    Pass    
 
@@ -2252,7 +2252,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2274,9 +2274,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -2297,7 +2297,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    5C      Pass
 6H      Pass    Pass    Pass
@@ -2320,7 +2320,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    5C      Pass
 5D      Pass    6S      Pass
@@ -2340,12 +2340,12 @@ Pass    Pass
 {HCP 12 7 15 6}
 {TP 12 9 16 7}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2365,7 +2365,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4D      Pass
 4S      Pass    Pass    Pass
@@ -2388,7 +2388,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2410,7 +2410,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2429,12 +2429,12 @@ Pass    Pass
 {HCP 14 6 15 5}
 {TP 14 7 15 6}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2451,12 +2451,12 @@ Pass    Pass
 {HCP 17 3 16 4}
 {TP 18 5 16 6}
 {Losers 5 9 7 9}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -2473,12 +2473,12 @@ Pass    Pass
 {HCP 13 8 15 4}
 {TP 14 8 16 4}
 {Losers 6 10 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2498,7 +2498,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2520,7 +2520,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2539,12 +2539,12 @@ Pass    Pass
 {HCP 12 5 16 7}
 {TP 13 7 16 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2564,7 +2564,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -2586,7 +2586,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -2608,7 +2608,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -2630,7 +2630,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2652,7 +2652,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2674,7 +2674,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2693,12 +2693,12 @@ Pass    Pass
 {HCP 12 7 16 5}
 {TP 13 8 16 5}
 {Losers 8 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2718,7 +2718,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2740,7 +2740,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2759,12 +2759,12 @@ Pass    Pass
 {HCP 10 11 15 4}
 {TP 10 11 16 6}
 {Losers 8 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2784,7 +2784,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2803,12 +2803,12 @@ Pass    Pass
 {HCP 10 7 15 8}
 {TP 12 8 15 8}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2828,7 +2828,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2850,7 +2850,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2872,7 +2872,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2894,7 +2894,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2916,7 +2916,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2938,7 +2938,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -2960,7 +2960,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -2979,12 +2979,12 @@ Pass    Pass
 {HCP 13 5 15 7}
 {TP 15 5 16 7}
 {Losers 6 11 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3004,7 +3004,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3026,7 +3026,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    5C      Pass
 5D      Pass    6H      Pass
@@ -3046,12 +3046,12 @@ Pass    Pass
 {HCP 12 11 15 2}
 {TP 13 12 15 3}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3068,12 +3068,12 @@ Pass    Pass
 {HCP 11 6 16 7}
 {TP 12 6 16 7}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3093,7 +3093,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3112,12 +3112,12 @@ Pass    Pass
 {HCP 12 5 16 7}
 {TP 14 5 16 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3134,12 +3134,12 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 12 9 15 7}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3159,7 +3159,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3178,12 +3178,12 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 13 8 15 7}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3203,7 +3203,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3222,12 +3222,12 @@ Pass    Pass
 {HCP 13 5 15 7}
 {TP 14 6 16 8}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3244,12 +3244,12 @@ Pass    Pass
 {HCP 14 4 17 5}
 {TP 15 6 17 8}
 {Losers 6 8 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3269,7 +3269,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3291,10 +3291,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    5H      Pass
 6H      Pass    Pass    Pass
 
@@ -3316,9 +3316,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    6S      Pass
 Pass    Pass    
 
@@ -3336,12 +3336,12 @@ Pass    Pass
 {HCP 11 3 16 10}
 {TP 11 3 16 11}
 {Losers 8 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3361,7 +3361,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3383,7 +3383,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3402,12 +3402,12 @@ Pass    Pass
 {HCP 12 5 16 7}
 {TP 13 6 16 8}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3427,7 +3427,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3446,11 +3446,11 @@ Pass    Pass
 {HCP 12 8 15 5}
 {TP 13 11 15 7}
 {Losers 6 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
-Pass    3D      3NT     Pass
+1N     Pass    2C      2D
+Pass    3D      3N     Pass
 Pass    Pass    
 
 
@@ -3467,12 +3467,12 @@ Pass    Pass
 {HCP 10 12 15 3}
 {TP 11 12 16 4}
 {Losers 8 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3492,7 +3492,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3511,12 +3511,12 @@ Pass    Pass
 {HCP 14 9 15 2}
 {TP 16 10 16 4}
 {Losers 6 7 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3536,7 +3536,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3558,7 +3558,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3580,9 +3580,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4S      Pass
-4NT     Pass    6D      Pass
+4N     Pass    6D      Pass
 6S      Pass    Pass    Pass
 
 
@@ -3603,7 +3603,7 @@ Pass    Pass    4S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3622,12 +3622,12 @@ Pass    Pass    4S      Pass
 {HCP 15 6 15 4}
 {TP 15 8 15 5}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3647,7 +3647,7 @@ Pass    Pass    4S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -3669,7 +3669,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -3691,7 +3691,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3713,7 +3713,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3735,7 +3735,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3757,7 +3757,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3776,12 +3776,12 @@ Pass    Pass    3H      Pass
 {HCP 10 11 15 4}
 {TP 12 13 15 5}
 {Losers 7 5 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    2S      Pass
-3C      Pass    3NT     Pass
+3C      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3798,12 +3798,12 @@ Pass    Pass
 {HCP 15 4 17 4}
 {TP 17 5 18 5}
 {Losers 6 10 5 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3820,12 +3820,12 @@ Pass    Pass
 {HCP 12 6 15 7}
 {TP 13 6 16 7}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3845,7 +3845,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3867,7 +3867,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3889,7 +3889,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3911,10 +3911,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5H      Pass    5N     Pass
 6S      Pass    Pass    Pass
 
 
@@ -3935,7 +3935,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -3957,7 +3957,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -3976,12 +3976,12 @@ Pass    Pass
 {HCP 14 4 16 6}
 {TP 15 6 17 6}
 {Losers 6 9 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4001,7 +4001,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4023,9 +4023,9 @@ Pass    Pass
 [Contract "5S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
 5S      Pass    Pass    Pass
 
@@ -4044,12 +4044,12 @@ Pass    Pass
 {HCP 10 7 15 8}
 {TP 10 7 15 8}
 {Losers 7 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4069,7 +4069,7 @@ Pass    Pass
 [Contract "7H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    5C      Pass
 5D      Pass    5S      Pass
@@ -4090,12 +4090,12 @@ Pass    Pass
 {HCP 13 5 16 6}
 {TP 14 6 16 6}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4115,7 +4115,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4134,12 +4134,12 @@ Pass    Pass
 {HCP 13 3 15 9}
 {TP 14 4 15 9}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4159,7 +4159,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4181,10 +4181,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
 6C      Pass    6S      Pass
 Pass    Pass    
@@ -4206,7 +4206,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4228,7 +4228,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4250,7 +4250,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4269,12 +4269,12 @@ Pass    Pass
 {HCP 13 4 17 6}
 {TP 14 4 17 6}
 {Losers 7 11 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4294,7 +4294,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4313,12 +4313,12 @@ Pass    Pass
 {HCP 11 10 16 3}
 {TP 12 10 16 4}
 {Losers 7 8 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4335,12 +4335,12 @@ Pass    Pass
 {HCP 11 10 17 2}
 {TP 13 11 17 3}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3S      X
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4357,12 +4357,12 @@ Pass    Pass    3S      X
 {HCP 12 9 15 4}
 {TP 13 9 15 5}
 {Losers 7 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4379,12 +4379,12 @@ Pass    Pass    3S      X
 {HCP 12 6 15 7}
 {TP 13 6 15 7}
 {Losers 7 10 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4401,12 +4401,12 @@ Pass    Pass    3S      X
 {HCP 15 6 15 4}
 {TP 18 6 15 5}
 {Losers 4 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4426,9 +4426,9 @@ Pass    Pass    3S      X
 [Contract "5S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5D      Pass    5H      Pass
 5S      Pass    Pass    Pass
 
@@ -4450,7 +4450,7 @@ Pass    Pass    3S      X
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -4469,12 +4469,12 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 12 8 15 6}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4494,7 +4494,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4516,7 +4516,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4535,12 +4535,12 @@ Pass    Pass
 {HCP 12 6 16 6}
 {TP 14 6 16 7}
 {Losers 6 10 8 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4560,7 +4560,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -4582,7 +4582,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4604,7 +4604,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4626,7 +4626,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4645,12 +4645,12 @@ Pass    Pass    3H      Pass
 {HCP 10 11 16 3}
 {TP 10 11 16 5}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4670,7 +4670,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4692,7 +4692,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4714,7 +4714,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4736,7 +4736,7 @@ Pass    Pass    3H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4755,12 +4755,12 @@ Pass    Pass    3H      Pass
 {HCP 15 1 15 9}
 {TP 17 2 15 10}
 {Losers 5 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4780,7 +4780,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4802,7 +4802,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4821,12 +4821,12 @@ Pass    Pass    3H      Pass
 {HCP 10 8 15 7}
 {TP 12 9 15 7}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4846,7 +4846,7 @@ Pass    Pass    3H      Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 XX      Pass    3S      Pass
 4S      Pass    5D      Pass
 5H      Pass    5S      Pass
@@ -4870,7 +4870,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4892,7 +4892,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -4914,7 +4914,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4H      Pass
 5C      Pass    6S      Pass
@@ -4937,9 +4937,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -4960,7 +4960,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -4982,7 +4982,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5001,12 +5001,12 @@ Pass    Pass
 {HCP 11 9 17 3}
 {TP 12 10 17 5}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5023,12 +5023,12 @@ Pass    Pass
 {HCP 10 5 17 8}
 {TP 12 5 17 8}
 {Losers 7 10 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5045,12 +5045,12 @@ Pass    Pass
 {HCP 12 7 16 5}
 {TP 12 8 17 6}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5070,7 +5070,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5089,12 +5089,12 @@ Pass    Pass
 {HCP 16 5 15 4}
 {TP 19 6 15 4}
 {Losers 4 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5111,12 +5111,12 @@ Pass    Pass
 {HCP 12 8 15 5}
 {TP 12 8 16 5}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5136,7 +5136,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -5155,12 +5155,12 @@ Pass    Pass
 {HCP 11 10 15 4}
 {TP 12 10 15 5}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5177,12 +5177,12 @@ Pass    Pass
 {HCP 10 8 15 7}
 {TP 12 8 16 8}
 {Losers 8 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5202,7 +5202,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5221,12 +5221,12 @@ Pass    Pass
 {HCP 12 9 16 3}
 {TP 14 10 16 3}
 {Losers 6 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5246,7 +5246,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5268,7 +5268,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 XX      Pass    3H      Pass
 4H      Pass    6H      Pass
 Pass    Pass    
@@ -5290,7 +5290,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    5C      Pass
 5D      Pass    6H      Pass
@@ -5313,7 +5313,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5335,7 +5335,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5357,7 +5357,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5379,7 +5379,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -5401,7 +5401,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5420,12 +5420,12 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 12 8 16 6}
 {Losers 8 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5442,12 +5442,12 @@ Pass    Pass
 {HCP 13 4 15 8}
 {TP 14 5 15 8}
 {Losers 6 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5464,12 +5464,12 @@ Pass    Pass
 {HCP 12 4 17 7}
 {TP 13 5 17 8}
 {Losers 6 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5489,7 +5489,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5508,12 +5508,12 @@ Pass    Pass
 {HCP 11 9 15 5}
 {TP 12 11 15 6}
 {Losers 6 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5530,12 +5530,12 @@ Pass    Pass
 {HCP 11 10 15 4}
 {TP 12 12 16 5}
 {Losers 7 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5555,7 +5555,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5577,7 +5577,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -5599,7 +5599,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -5621,10 +5621,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    6C      Pass
+4N     Pass    6C      Pass
 6H      Pass    Pass    Pass
 
 
@@ -5645,7 +5645,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -5664,12 +5664,12 @@ Pass    Pass
 {HCP 11 10 16 3}
 {TP 11 11 16 3}
 {Losers 7 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5686,11 +5686,11 @@ Pass    Pass
 {HCP 13 9 15 3}
 {TP 13 12 16 4}
 {Losers 6 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3C
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3C
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5707,12 +5707,12 @@ Pass    Pass
 {HCP 14 7 15 4}
 {TP 15 8 15 5}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5732,7 +5732,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4C      Pass
 4D      Pass    4H      Pass
@@ -5754,11 +5754,11 @@ Pass    Pass
 {HCP 12 12 16 0}
 {TP 13 14 16 2}
 {Losers 7 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2D
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2D
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5775,12 +5775,12 @@ Pass    Pass
 {HCP 11 7 16 6}
 {TP 12 7 16 7}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5800,7 +5800,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -5822,7 +5822,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -5844,7 +5844,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5863,12 +5863,12 @@ Pass    Pass
 {HCP 11 8 17 4}
 {TP 11 10 17 6}
 {Losers 8 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5888,7 +5888,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5910,7 +5910,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
 5C      Pass    6H      Pass
@@ -5933,7 +5933,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -5955,10 +5955,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5S      Pass    5N     Pass
 6H      Pass    6S      Pass
 Pass    Pass    
 
@@ -5979,7 +5979,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6001,7 +6001,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6020,12 +6020,12 @@ Pass    Pass
 {HCP 11 11 15 3}
 {TP 12 11 15 4}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6042,12 +6042,12 @@ Pass    Pass
 {HCP 12 3 16 9}
 {TP 15 4 17 9}
 {Losers 6 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6067,7 +6067,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6086,12 +6086,12 @@ Pass    Pass
 {HCP 13 4 16 7}
 {TP 14 5 16 7}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6111,7 +6111,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6133,7 +6133,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6152,12 +6152,12 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 12 6 15 9}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6177,7 +6177,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6196,12 +6196,12 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 12 6 15 11}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6218,12 +6218,12 @@ Pass    Pass
 {HCP 11 7 16 6}
 {TP 13 7 16 6}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6240,12 +6240,12 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 11 9 16 8}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6265,7 +6265,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6287,7 +6287,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6309,7 +6309,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      2H
+1N     Pass    2C      2H
 Pass    Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -6331,7 +6331,7 @@ Pass    Pass    3S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6353,7 +6353,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6375,7 +6375,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6397,7 +6397,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6416,12 +6416,12 @@ Pass    Pass    3S      Pass
 {HCP 10 7 15 8}
 {TP 10 8 15 8}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6441,7 +6441,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6463,7 +6463,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6485,7 +6485,7 @@ Pass    Pass    3S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6507,7 +6507,7 @@ Pass    Pass    3S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6529,7 +6529,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6548,12 +6548,12 @@ Pass    Pass    3S      Pass
 {HCP 10 9 16 5}
 {TP 11 9 16 5}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6573,7 +6573,7 @@ Pass    Pass    3S      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6592,12 +6592,12 @@ Pass    Pass    3S      Pass
 {HCP 12 1 17 10}
 {TP 14 1 17 10}
 {Losers 6 12 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6617,7 +6617,7 @@ Pass    Pass    3S      Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    5H      Pass
 5S      Pass    6S      Pass
@@ -6640,7 +6640,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -6662,7 +6662,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6681,12 +6681,12 @@ Pass    Pass
 {HCP 10 11 17 2}
 {TP 12 12 17 3}
 {Losers 7 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6706,9 +6706,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5H      Pass    6H      Pass
 Pass    Pass    
 
@@ -6726,12 +6726,12 @@ Pass    Pass
 {HCP 10 9 16 5}
 {TP 10 10 17 5}
 {Losers 7 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6748,12 +6748,12 @@ Pass    Pass
 {HCP 13 3 16 8}
 {TP 15 3 17 8}
 {Losers 6 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6770,12 +6770,12 @@ Pass    Pass
 {HCP 16 2 16 6}
 {TP 16 3 16 6}
 {Losers 5 10 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6792,12 +6792,12 @@ Pass    Pass
 {HCP 11 4 15 10}
 {TP 13 5 16 10}
 {Losers 6 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6817,7 +6817,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6836,12 +6836,12 @@ Pass    Pass
 {HCP 11 9 15 5}
 {TP 11 9 15 6}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6861,7 +6861,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6883,7 +6883,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6902,12 +6902,12 @@ Pass    Pass
 {HCP 10 9 17 4}
 {TP 11 10 17 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6927,7 +6927,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
 5C      Pass    5H      Pass
@@ -6951,7 +6951,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6973,7 +6973,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -6995,7 +6995,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7017,7 +7017,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7039,9 +7039,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -7062,7 +7062,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7081,12 +7081,12 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 12 8 16 5}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7106,7 +7106,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
 5H      Pass    6H      Pass
@@ -7126,12 +7126,12 @@ Pass    Pass
 {HCP 13 10 15 2}
 {TP 14 10 15 3}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7148,12 +7148,12 @@ Pass    Pass
 {HCP 11 8 15 6}
 {TP 13 9 15 6}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7170,12 +7170,12 @@ Pass    Pass
 {HCP 14 8 16 2}
 {TP 14 9 16 3}
 {Losers 6 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7192,12 +7192,12 @@ Pass    Pass
 {HCP 11 11 15 3}
 {TP 14 11 15 3}
 {Losers 5 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7217,9 +7217,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    6H      Pass
 Pass    Pass    
 
@@ -7237,12 +7237,12 @@ Pass    Pass
 {HCP 14 5 16 5}
 {TP 16 5 16 6}
 {Losers 6 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7262,7 +7262,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7284,7 +7284,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7303,12 +7303,12 @@ Pass    Pass
 {HCP 12 6 16 6}
 {TP 14 7 16 6}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7325,12 +7325,12 @@ Pass    Pass
 {HCP 12 12 15 1}
 {TP 15 12 15 2}
 {Losers 6 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7347,12 +7347,12 @@ Pass    Pass
 {HCP 14 4 17 5}
 {TP 14 5 17 5}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7372,7 +7372,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7391,12 +7391,12 @@ Pass    Pass
 {HCP 13 4 17 6}
 {TP 13 5 17 7}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7416,10 +7416,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    5H      Pass
 6H      Pass    Pass    Pass
 
@@ -7441,7 +7441,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7463,7 +7463,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7485,9 +7485,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -7505,12 +7505,12 @@ Pass    Pass
 {HCP 10 7 17 6}
 {TP 13 7 17 7}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7530,7 +7530,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7549,12 +7549,12 @@ Pass    Pass
 {HCP 10 12 17 1}
 {TP 12 13 18 3}
 {Losers 7 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7574,7 +7574,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7593,12 +7593,12 @@ Pass    Pass
 {HCP 10 6 17 7}
 {TP 11 6 17 8}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7615,12 +7615,12 @@ Pass    Pass
 {HCP 13 8 16 3}
 {TP 14 8 17 4}
 {Losers 7 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7637,12 +7637,12 @@ Pass    Pass
 {HCP 13 5 16 6}
 {TP 15 5 16 6}
 {Losers 7 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7659,12 +7659,12 @@ Pass    Pass
 {HCP 11 3 17 9}
 {TP 12 4 17 9}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7684,7 +7684,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7706,7 +7706,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7728,7 +7728,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7750,7 +7750,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -7769,12 +7769,12 @@ Pass    Pass
 {HCP 16 5 15 4}
 {TP 16 6 16 5}
 {Losers 5 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7791,12 +7791,12 @@ Pass    Pass
 {HCP 10 7 16 7}
 {TP 12 8 17 8}
 {Losers 7 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7816,7 +7816,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 XX      Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -7835,12 +7835,12 @@ XX      Pass    3H      Pass
 {HCP 10 4 16 10}
 {TP 11 5 16 11}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7857,12 +7857,12 @@ XX      Pass    3H      Pass
 {HCP 10 3 17 10}
 {TP 12 4 17 10}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7882,7 +7882,7 @@ XX      Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7904,7 +7904,7 @@ XX      Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7923,12 +7923,12 @@ XX      Pass    3H      Pass
 {HCP 10 10 17 3}
 {TP 11 11 18 3}
 {Losers 7 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7945,12 +7945,12 @@ XX      Pass    3H      Pass
 {HCP 11 10 17 2}
 {TP 14 11 18 2}
 {Losers 5 7 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7970,7 +7970,7 @@ XX      Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -7992,7 +7992,7 @@ XX      Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8011,12 +8011,12 @@ XX      Pass    3H      Pass
 {HCP 10 9 16 5}
 {TP 11 10 16 6}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8036,10 +8036,10 @@ Pass    Pass    3S      Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
-5C      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5C      Pass    5N     Pass
 6H      Pass    6S      Pass
 Pass    Pass    
 
@@ -8060,7 +8060,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8082,9 +8082,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    6H      Pass
 Pass    Pass    
 
@@ -8105,9 +8105,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5S      Pass    6H      Pass
 Pass    Pass    
 
@@ -8128,7 +8128,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8150,7 +8150,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8172,7 +8172,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -8191,12 +8191,12 @@ Pass    Pass
 {HCP 11 7 15 7}
 {TP 13 7 16 7}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8216,7 +8216,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8238,7 +8238,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8260,7 +8260,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8279,12 +8279,12 @@ Pass    Pass
 {HCP 10 9 16 5}
 {TP 12 10 16 5}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8301,12 +8301,12 @@ Pass    Pass
 {HCP 11 10 15 4}
 {TP 11 11 15 6}
 {Losers 8 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8323,12 +8323,12 @@ Pass    Pass
 {HCP 11 4 16 9}
 {TP 13 4 16 10}
 {Losers 7 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8348,7 +8348,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    6S      Pass
 Pass    Pass    
@@ -8370,7 +8370,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8392,9 +8392,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -8416,7 +8416,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8438,7 +8438,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8460,9 +8460,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -8480,12 +8480,12 @@ Pass    Pass
 {HCP 11 8 16 5}
 {TP 13 8 16 5}
 {Losers 7 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8505,7 +8505,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8524,12 +8524,12 @@ Pass    Pass
 {HCP 15 5 17 3}
 {TP 17 5 17 4}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8549,7 +8549,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8571,7 +8571,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8593,7 +8593,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4H      Pass
 5C      Pass    6S      Pass
@@ -8616,7 +8616,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8638,7 +8638,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8660,7 +8660,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8682,7 +8682,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8704,7 +8704,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -8723,12 +8723,12 @@ Pass    Pass
 {HCP 15 7 16 2}
 {TP 16 9 16 3}
 {Losers 6 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8748,7 +8748,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8770,7 +8770,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8792,7 +8792,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -8814,7 +8814,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8836,7 +8836,7 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3H      Pass
 4H      Pass    5C      Pass
 5D      Pass    6H      Pass
@@ -8856,12 +8856,12 @@ Pass    Pass
 {HCP 17 8 15 0}
 {TP 19 8 16 1}
 {Losers 5 9 7 11}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -8881,7 +8881,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8900,12 +8900,12 @@ Pass    Pass
 {HCP 10 6 16 8}
 {TP 11 7 17 8}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8922,12 +8922,12 @@ Pass    Pass
 {HCP 12 7 16 5}
 {TP 12 7 16 5}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8947,7 +8947,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -8966,12 +8966,12 @@ Pass    Pass
 {HCP 10 4 16 10}
 {TP 12 5 17 11}
 {Losers 7 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8991,7 +8991,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -9013,7 +9013,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -9035,7 +9035,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      2D
+1N     Pass    2C      2D
 Pass    Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -9057,10 +9057,10 @@ Pass    Pass    3H      Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5H      Pass
+4N     Pass    5H      Pass
 6H      Pass    Pass    Pass
 
 
@@ -9081,7 +9081,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9100,12 +9100,12 @@ Pass    Pass    3H      Pass
 {HCP 13 5 15 7}
 {TP 14 7 15 8}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9125,7 +9125,7 @@ Pass    Pass    3H      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9144,12 +9144,12 @@ Pass    Pass    3H      Pass
 {HCP 18 0 16 6}
 {TP 18 0 16 6}
 {Losers 5 12 6 10}
-[Contract "6NT"]
+[Contract "6N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    6NT     Pass
+3N     Pass    6N     Pass
 Pass    Pass    
 
 
@@ -9169,7 +9169,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9188,12 +9188,12 @@ Pass    Pass
 {HCP 13 4 16 7}
 {TP 14 6 16 8}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9210,11 +9210,11 @@ Pass    Pass
 {HCP 12 13 15 0}
 {TP 14 16 15 2}
 {Losers 6 5 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      2S
-Pass    Pass    3NT     Pass
+1N     Pass    2C      2S
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9234,7 +9234,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9256,9 +9256,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -9276,12 +9276,12 @@ Pass    Pass
 {HCP 10 7 16 7}
 {TP 12 7 16 8}
 {Losers 7 8 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9298,12 +9298,12 @@ Pass    Pass
 {HCP 15 6 16 3}
 {TP 16 7 16 3}
 {Losers 7 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9323,7 +9323,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -9345,7 +9345,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -9367,7 +9367,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -9386,12 +9386,12 @@ Pass    Pass
 {HCP 14 9 15 2}
 {TP 14 9 15 2}
 {Losers 7 9 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9408,12 +9408,12 @@ Pass    Pass
 {HCP 15 8 15 2}
 {TP 16 8 15 2}
 {Losers 6 10 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9430,12 +9430,12 @@ Pass    Pass
 {HCP 10 8 17 5}
 {TP 12 9 18 6}
 {Losers 6 9 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9455,7 +9455,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9477,7 +9477,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -9499,7 +9499,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9518,12 +9518,12 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 12 9 15 10}
 {Losers 7 7 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9543,7 +9543,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9565,7 +9565,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -9587,9 +9587,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 Pass    Pass    3S      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 6D      Pass    6S      Pass
 Pass    Pass    
@@ -9611,9 +9611,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -9634,7 +9634,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9656,7 +9656,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 XX      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -9675,12 +9675,12 @@ XX      Pass    3S      Pass
 {HCP 12 6 16 6}
 {TP 13 6 16 7}
 {Losers 8 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9697,12 +9697,12 @@ XX      Pass    3S      Pass
 {HCP 11 6 15 8}
 {TP 12 6 15 9}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9722,7 +9722,7 @@ XX      Pass    3S      Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    5D      Pass
 6H      Pass    Pass    Pass
@@ -9745,7 +9745,7 @@ XX      Pass    3S      Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9767,9 +9767,9 @@ XX      Pass    3S      Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5S      Pass    6S      Pass
 Pass    Pass    
 
@@ -9787,12 +9787,12 @@ Pass    Pass
 {HCP 10 4 17 9}
 {TP 10 5 17 10}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9809,12 +9809,12 @@ Pass    Pass
 {HCP 13 5 15 7}
 {TP 15 6 16 8}
 {Losers 6 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9834,7 +9834,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9856,10 +9856,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5S      Pass
+4N     Pass    5S      Pass
 6H      Pass    Pass    Pass
 
 
@@ -9877,12 +9877,12 @@ Pass    Pass
 {HCP 12 4 15 9}
 {TP 13 5 15 9}
 {Losers 7 10 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9902,7 +9902,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    5C      Pass
 5H      Pass    6S      Pass
@@ -9925,10 +9925,10 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5C      Pass
+4N     Pass    5C      Pass
 5D      Pass    5H      Pass
 6H      Pass    Pass    Pass
 
@@ -9950,7 +9950,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -9969,12 +9969,12 @@ Pass    Pass
 {HCP 10 8 16 6}
 {TP 11 8 16 6}
 {Losers 8 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9991,12 +9991,12 @@ Pass    Pass
 {HCP 12 12 15 1}
 {TP 12 12 15 2}
 {Losers 7 8 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10013,12 +10013,12 @@ Pass    Pass
 {HCP 13 9 17 1}
 {TP 15 9 17 3}
 {Losers 6 8 5 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10035,12 +10035,12 @@ Pass    Pass
 {HCP 13 2 15 10}
 {TP 15 3 16 11}
 {Losers 5 10 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10060,7 +10060,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10082,7 +10082,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10101,12 +10101,12 @@ Pass    Pass
 {HCP 13 10 16 1}
 {TP 13 11 16 2}
 {Losers 7 9 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10123,12 +10123,12 @@ Pass    Pass
 {HCP 10 11 16 3}
 {TP 12 12 16 5}
 {Losers 7 7 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10148,7 +10148,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10170,9 +10170,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5D      Pass    6H      Pass
 Pass    Pass    
 
@@ -10193,7 +10193,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10212,12 +10212,12 @@ Pass    Pass
 {HCP 13 7 16 4}
 {TP 15 7 16 5}
 {Losers 6 10 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10237,7 +10237,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10259,7 +10259,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10281,10 +10281,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    6S      Pass
 Pass    Pass    
 
@@ -10305,10 +10305,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 XX      Pass    3S      Pass
-4S      Pass    4NT     Pass
-5S      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5S      Pass    5N     Pass
 6C      Pass    6S      Pass
 Pass    Pass    
 
@@ -10326,12 +10326,12 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 11 9 15 6}
 {Losers 7 9 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10351,7 +10351,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10370,12 +10370,12 @@ Pass    Pass
 {HCP 13 8 17 2}
 {TP 14 9 17 4}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10392,12 +10392,12 @@ Pass    Pass
 {HCP 10 11 15 4}
 {TP 11 12 15 4}
 {Losers 7 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10417,7 +10417,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10439,7 +10439,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10461,7 +10461,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10483,7 +10483,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10505,7 +10505,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10527,9 +10527,9 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2C      3D
+1N     Pass    2C      3D
 Pass    Pass    4H      Pass
-4NT     Pass    5D      Pass
+4N     Pass    5D      Pass
 5H      Pass    Pass    Pass
 
 
@@ -10547,12 +10547,12 @@ Pass    Pass    4H      Pass
 {HCP 10 4 16 10}
 {TP 10 6 17 10}
 {Losers 7 9 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10572,7 +10572,7 @@ Pass    Pass    4H      Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -10594,7 +10594,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10613,12 +10613,12 @@ Pass    Pass
 {HCP 13 8 15 4}
 {TP 15 8 15 4}
 {Losers 6 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10638,7 +10638,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10660,7 +10660,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10682,7 +10682,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10704,7 +10704,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      X
+1N     Pass    2C      X
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10726,7 +10726,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4H      Pass
 4S      Pass    Pass    Pass
@@ -10746,12 +10746,12 @@ Pass    Pass
 {HCP 10 11 15 4}
 {TP 11 11 15 4}
 {Losers 7 9 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10771,9 +10771,9 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-4H      Pass    4NT     Pass
+4H      Pass    4N     Pass
 5C      Pass    5D      Pass
 5H      Pass    6H      Pass
 Pass    Pass    
@@ -10795,7 +10795,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10817,7 +10817,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10839,7 +10839,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -10861,7 +10861,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4C      Pass
 4H      Pass    6S      Pass
@@ -10884,10 +10884,10 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 3S      Pass    4C      Pass
-4D      Pass    4NT     Pass
+4D      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -10906,12 +10906,12 @@ Pass    Pass
 {HCP 10 6 17 7}
 {TP 11 6 17 8}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10931,7 +10931,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10953,9 +10953,9 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
+4S      Pass    4N     Pass
 5C      Pass    5D      Pass
 5S      Pass    6S      Pass
 Pass    Pass    
@@ -10977,7 +10977,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -10999,7 +10999,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
 4H      Pass    Pass    Pass
 
@@ -11021,10 +11021,10 @@ Pass    Pass
 [Contract "7S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
-4S      Pass    4NT     Pass
-5D      Pass    5NT     Pass
+4S      Pass    4N     Pass
+5D      Pass    5N     Pass
 6C      Pass    7S      Pass
 Pass    Pass    
 
@@ -11042,11 +11042,11 @@ Pass    Pass
 {HCP 10 9 15 6}
 {TP 10 12 15 8}
 {Losers 7 7 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      3D
-Pass    Pass    3NT     Pass
+1N     Pass    2C      3D
+Pass    Pass    3N     Pass
 Pass    Pass    
 
 
@@ -11066,7 +11066,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3H      Pass
 4S      Pass    Pass    Pass
 
@@ -11085,11 +11085,11 @@ Pass    Pass
 {HCP 10 4 17 9}
 {TP 12 5 17 9}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2D      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 

--- a/GIB/We_Overcall_NT_then_Smolen.pbn
+++ b/GIB/We_Overcall_NT_then_Smolen.pbn
@@ -15,7 +15,7 @@
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -37,7 +37,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -56,12 +56,12 @@ Pass
 {HCP 12 12 15 1}
 {TP 13 13 15 3}
 {Losers 7 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -78,11 +78,11 @@ Pass
 {HCP 11 12 15 2}
 {TP 11 14 15 4}
 {Losers 7 6 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1H      1NT     Pass    2H
-Pass    2S      Pass    3NT
+1H      1N     Pass    2H
+Pass    2S      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -99,11 +99,11 @@ Pass    Pass    Pass
 {HCP 12 12 15 1}
 {TP 12 15 15 4}
 {Losers 6 5 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1H      1NT     Pass    2H
-Pass    2S      Pass    3NT
+1H      1N     Pass    2H
+Pass    2S      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -123,7 +123,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 2D      X       3C      3H
 Pass    Pass    Pass    
 
@@ -144,7 +144,7 @@ Pass    Pass    Pass
 [Contract "2HX"]
 [Declarer "E"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 2H      Pass    Pass    X
 Pass    Pass    Pass    
 
@@ -162,12 +162,12 @@ Pass    Pass    Pass
 {HCP 11 12 16 1}
 {TP 13 12 17 2}
 {Losers 7 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -184,12 +184,12 @@ Pass
 {HCP 11 12 17 0}
 {TP 13 13 17 1}
 {Losers 7 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-Pass    1NT     Pass    2C
+Pass    1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -206,12 +206,12 @@ Pass
 {HCP 13 12 15 0}
 {TP 16 14 15 2}
 {Losers 5 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -231,7 +231,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -250,12 +250,12 @@ Pass
 {HCP 10 12 16 2}
 {TP 10 12 16 3}
 {Losers 8 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -275,8 +275,8 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1H      1NT     Pass    2H
-Pass    2S      Pass    3NT
+1H      1N     Pass    2H
+Pass    2S      Pass    3N
 Pass    4H      Pass    4S
 Pass    Pass    Pass    
 
@@ -294,12 +294,12 @@ Pass    Pass    Pass
 {HCP 10 14 15 1}
 {TP 12 14 15 1}
 {Losers 6 8 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -316,12 +316,12 @@ Pass
 {HCP 12 13 15 0}
 {TP 13 13 16 0}
 {Losers 7 8 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -341,7 +341,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -360,12 +360,12 @@ Pass
 {HCP 10 12 16 2}
 {TP 11 12 16 3}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -382,12 +382,12 @@ Pass
 {HCP 11 13 16 0}
 {TP 12 14 16 1}
 {Losers 8 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -404,12 +404,12 @@ Pass
 {HCP 10 12 16 2}
 {TP 10 13 16 3}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -429,7 +429,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -451,7 +451,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -473,7 +473,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -492,11 +492,11 @@ Pass
 {HCP 10 12 15 3}
 {TP 12 13 16 4}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
 1C      1D      3C      3D
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -516,7 +516,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -538,7 +538,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -557,12 +557,12 @@ Pass
 {HCP 13 12 15 0}
 {TP 16 13 15 1}
 {Losers 5 8 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -579,12 +579,12 @@ Pass
 {HCP 10 14 15 1}
 {TP 12 15 15 2}
 {Losers 7 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -604,7 +604,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -626,7 +626,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -645,12 +645,12 @@ Pass
 {HCP 10 12 18 0}
 {TP 12 13 18 0}
 {Losers 6 7 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
 1D      X       Pass    2H
 Pass    3D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -670,7 +670,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -713,7 +713,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -735,7 +735,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -754,12 +754,12 @@ Pass
 {HCP 11 12 16 1}
 {TP 13 13 16 2}
 {Losers 7 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -776,12 +776,12 @@ Pass
 {HCP 10 12 15 3}
 {TP 10 12 16 4}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -798,12 +798,12 @@ Pass
 {HCP 11 13 16 0}
 {TP 12 13 17 0}
 {Losers 7 7 6 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -823,7 +823,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -845,7 +845,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -867,7 +867,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -889,7 +889,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -951,12 +951,12 @@ Pass    Pass    Pass
 {HCP 10 13 17 0}
 {TP 11 14 18 1}
 {Losers 7 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -973,12 +973,12 @@ Pass
 {HCP 11 12 15 2}
 {TP 12 13 15 3}
 {Losers 8 7 8 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -995,12 +995,12 @@ Pass
 {HCP 10 13 15 2}
 {TP 12 13 15 3}
 {Losers 7 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1041,8 +1041,8 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1H      1NT     Pass    2H
-Pass    2S      Pass    3NT
+1H      1N     Pass    2H
+Pass    2S      Pass    3N
 Pass    4S      Pass    Pass
 Pass    
 
@@ -1063,7 +1063,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1085,7 +1085,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -1107,7 +1107,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1169,11 +1169,11 @@ Pass
 {HCP 10 12 15 3}
 {TP 10 15 16 5}
 {Losers 7 6 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
 1C      1D      Pass    1S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1193,7 +1193,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 X       Pass    Pass    4S
 Pass    Pass    Pass    
 
@@ -1211,12 +1211,12 @@ Pass    Pass    Pass
 {HCP 11 12 16 1}
 {TP 12 14 16 4}
 {Losers 7 6 7 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1S      1NT     Pass    2D
+1S      1N     Pass    2D
 Pass    2H      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1236,7 +1236,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1258,7 +1258,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1280,7 +1280,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 X       2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -1302,7 +1302,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1324,7 +1324,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1343,11 +1343,11 @@ Pass
 {HCP 11 14 15 0}
 {TP 12 15 15 2}
 {Losers 7 6 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
-3C      Pass    Pass    3NT
+1C      1N     Pass    2C
+3C      Pass    Pass    3N
 Pass    Pass    Pass    
 
 
@@ -1367,7 +1367,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -1386,12 +1386,12 @@ Pass
 {HCP 11 13 15 1}
 {TP 14 15 15 1}
 {Losers 5 6 7 12}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1412,7 +1412,7 @@ Pass
 [Declarer "N"]
 [Auction "E"]
 1C      X       Pass    2C
-X       3NT     Pass    4S
+X       3N     Pass    4S
 Pass    Pass    Pass    
 
 
@@ -1429,12 +1429,12 @@ Pass    Pass    Pass
 {HCP 13 12 15 0}
 {TP 14 12 15 2}
 {Losers 6 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1454,7 +1454,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -1473,12 +1473,12 @@ Pass
 {HCP 13 12 15 0}
 {TP 15 13 15 1}
 {Losers 7 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1498,7 +1498,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -1520,7 +1520,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1539,12 +1539,12 @@ Pass
 {HCP 10 12 15 3}
 {TP 10 12 15 4}
 {Losers 8 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1564,7 +1564,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -1586,7 +1586,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1608,7 +1608,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1S      1NT     Pass    2C
+1S      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -1627,12 +1627,12 @@ Pass
 {HCP 11 13 15 1}
 {TP 12 14 16 2}
 {Losers 8 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1649,12 +1649,12 @@ Pass
 {HCP 12 12 15 1}
 {TP 13 13 16 2}
 {Losers 7 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1671,11 +1671,11 @@ Pass
 {HCP 11 13 15 1}
 {TP 13 15 16 3}
 {Losers 7 6 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1H      1NT     Pass    2H
-Pass    2S      Pass    3NT
+1H      1N     Pass    2H
+Pass    2S      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -1695,7 +1695,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1717,7 +1717,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1736,12 +1736,12 @@ Pass
 {HCP 10 13 16 1}
 {TP 11 15 17 1}
 {Losers 7 6 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1758,12 +1758,12 @@ Pass
 {HCP 10 12 16 2}
 {TP 11 12 17 3}
 {Losers 7 8 6 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -1783,7 +1783,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1S      1NT     Pass    2D
+1S      1N     Pass    2D
 Pass    2H      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -1805,7 +1805,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -1827,7 +1827,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1849,7 +1849,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -1871,7 +1871,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1893,9 +1893,9 @@ Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 X       2D      Pass    3H
-Pass    4S      Pass    4NT
+Pass    4S      Pass    4N
 Pass    5C      Pass    5D
 Pass    5S      Pass    6S
 Pass    Pass    Pass    
@@ -1917,7 +1917,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1939,7 +1939,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -1961,7 +1961,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "E"]
-1S      1NT     Pass    2D
+1S      1N     Pass    2D
 Pass    2H      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
@@ -1983,7 +1983,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -2005,7 +2005,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -2027,7 +2027,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -2046,12 +2046,12 @@ Pass
 {HCP 11 13 15 1}
 {TP 12 15 16 4}
 {Losers 7 6 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 X       XX      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -2068,12 +2068,12 @@ Pass
 {HCP 11 14 15 0}
 {TP 13 15 15 1}
 {Losers 6 7 7 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -2090,12 +2090,12 @@ Pass
 {HCP 10 13 15 2}
 {TP 12 13 15 3}
 {Losers 8 7 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -2115,7 +2115,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -2137,7 +2137,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "E"]
-1C      1NT     Pass    2C
+1C      1N     Pass    2C
 Pass    2D      Pass    3H
 Pass    4S      Pass    Pass
 Pass    
@@ -2178,11 +2178,11 @@ Pass
 {HCP 12 13 15 0}
 {TP 14 13 16 1}
 {Losers 7 7 6 11}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "E"]
-1D      1NT     Pass    2C
+1D      1N     Pass    2C
 Pass    2D      Pass    3S
-Pass    3NT     Pass    Pass
+Pass    3N     Pass    Pass
 Pass    
 

--- a/GIB/Weak_2_Bids_Leveled.pbn
+++ b/GIB/Weak_2_Bids_Leveled.pbn
@@ -14,7 +14,7 @@
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-2H      Pass    2NT     Pass
+2H      Pass    2N     Pass
 3H      Pass    Pass    Pass
 
 [Event "autoCapture"]
@@ -33,7 +33,7 @@
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-2H      X       Pass    2NT
+2H      X       Pass    2N
 Pass    3C      Pass    3D
 Pass    Pass    Pass
 
@@ -50,11 +50,11 @@ Pass    Pass    Pass
 {HCP 18 6 9 7}
 {TP 20 8 10 10}
 {Losers 4 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 2H      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass
 
 [Event "autoCapture"]
@@ -70,10 +70,10 @@ Pass    Pass
 {HCP 6 17 7 10}
 {TP 7 17 8 12}
 {Losers 9 7 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-2H      2S      Pass    3NT
+2H      2S      Pass    3N
 Pass    Pass    Pass
 
 [Event "autoCapture"]
@@ -171,8 +171,8 @@ Pass    Pass    Pass
 [Declarer "W"]
 [Auction "S"]
 2S      X       3S      X
-Pass    4H      Pass    4NT
-Pass    5NT     Pass    6H
+Pass    4H      Pass    4N
+Pass    5N     Pass    6H
 Pass    Pass    Pass
 
 [Event "autoCapture"]
@@ -246,10 +246,10 @@ Pass
 {HCP 3 22 6 9}
 {TP 3 22 7 10}
 {Losers 11 5 9 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-2S      Pass    Pass    3NT
+2S      Pass    Pass    3N
 Pass    Pass    Pass
 
 [Event "autoCapture"]
@@ -362,11 +362,11 @@ Pass    Pass
 {HCP 21 6 9 4}
 {TP 22 8 10 4}
 {Losers 4 8 7 10}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "N"]
 [Auction "S"]
 2D      Pass    3C      Pass
-3D      Pass    3NT     Pass
+3D      Pass    3N     Pass
 Pass    Pass
 
 [Event "autoCapture"]
@@ -444,7 +444,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    2NT     Pass
+2S      Pass    2N     Pass
 3S      Pass    4S      Pass
 Pass    Pass
 
@@ -464,7 +464,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-2S      Pass    2NT     Pass
+2S      Pass    2N     Pass
 3C      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -561,7 +561,7 @@ Pass    Pass
 [Declarer "E"]
 [Auction "S"]
 2H      Pass    Pass    X
-Pass    2NT     Pass    3C
+Pass    2N     Pass    3C
 Pass    Pass    Pass
 
 [Event "autoCapture"]

--- a/GIB/lebensohl.pbn
+++ b/GIB/lebensohl.pbn
@@ -14,7 +14,7 @@
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4S      Pass
+1N     2D      4S      Pass
 Pass    Pass    
 
 
@@ -31,10 +31,10 @@ Pass    Pass
 {HCP 12 0 15 13}
 {TP 12 2 15 14}
 {Losers 8 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -54,7 +54,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -71,11 +71,11 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 12 3 15 15}
 {Losers 8 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -92,11 +92,11 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 12 4 17 15}
 {Losers 7 10 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -113,10 +113,10 @@ Pass    Pass
 {HCP 11 0 16 13}
 {TP 12 1 17 14}
 {Losers 7 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -133,11 +133,11 @@ Pass    Pass
 {HCP 9 2 17 12}
 {TP 9 3 17 13}
 {Losers 9 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      X       Pass
-3NT     Pass    Pass    Pass
+1N     2D      X       Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -154,11 +154,11 @@ Pass    Pass
 {HCP 11 0 17 12}
 {TP 11 2 17 14}
 {Losers 8 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -178,7 +178,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -195,10 +195,10 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 11 3 15 12}
 {Losers 8 10 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -215,11 +215,11 @@ Pass    Pass
 {HCP 9 3 16 12}
 {TP 11 5 16 12}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -239,7 +239,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -259,7 +259,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -279,7 +279,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      3H      4S      X
 Pass    Pass    Pass    
 
@@ -300,7 +300,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -318,11 +318,11 @@ Pass    Pass    Pass
 {HCP 9 3 15 13}
 {TP 12 4 15 13}
 {Losers 6 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -342,7 +342,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -360,10 +360,10 @@ Pass    Pass    Pass
 {HCP 10 1 15 14}
 {TP 11 1 15 15}
 {Losers 8 12 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 Pass    Pass    
 
 
@@ -383,7 +383,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3NT     4S
+1N     2S      3N     4S
 X       Pass    Pass    Pass
 
 
@@ -401,10 +401,10 @@ X       Pass    Pass    Pass
 {HCP 10 0 15 15}
 {TP 10 1 15 17}
 {Losers 9 11 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -424,7 +424,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -444,7 +444,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 X       Pass    Pass    Pass
 
 
@@ -465,8 +465,8 @@ X       Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    4H      Pass
+1N     2S      3S      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -483,10 +483,10 @@ Pass    Pass
 {HCP 10 4 15 11}
 {TP 10 5 16 13}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -506,7 +506,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -523,10 +523,10 @@ Pass
 {HCP 10 3 15 12}
 {TP 11 3 15 14}
 {Losers 8 11 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -546,7 +546,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -567,7 +567,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      X       Pass
+1N     2D      X       Pass
 2H      Pass    2S      4D
 4S      Pass    Pass    Pass
 
@@ -589,7 +589,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    X       Pass    3D
 Pass    Pass    Pass    
 
@@ -610,7 +610,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -631,7 +631,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    Pass    
 
 
@@ -651,7 +651,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      4S      Pass
+1N     2C      4S      Pass
 Pass    Pass    
 
 
@@ -668,10 +668,10 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 11 3 16 13}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -688,10 +688,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 10 3 16 15}
 {Losers 9 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -708,10 +708,10 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 12 4 15 13}
 {Losers 8 9 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -731,7 +731,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -748,10 +748,10 @@ Pass    Pass
 {HCP 10 1 17 12}
 {TP 10 2 17 12}
 {Losers 9 11 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -768,11 +768,11 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 12 5 15 15}
 {Losers 7 9 7 4}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -792,7 +792,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -810,10 +810,10 @@ Pass    Pass
 {HCP 9 4 15 12}
 {TP 11 5 15 13}
 {Losers 7 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -833,7 +833,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -854,7 +854,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -874,7 +874,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -895,7 +895,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -915,7 +915,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      2NT     4S
+1N     2S      2N     4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -933,10 +933,10 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 10 3 15 16}
 {Losers 8 10 8 5}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 Pass    Pass    
 
 
@@ -953,11 +953,11 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 12 2 15 14}
 {Losers 9 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2S      Pass    3NT     Pass
+1N     2C      X       Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -977,8 +977,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      4H
-4S      Pass    4NT     Pass
+1N     2H      3S      4H
+4S      Pass    4N     Pass
 5C      Pass    6S      Pass
 Pass    Pass    
 
@@ -996,10 +996,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 5 16 13}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -1019,7 +1019,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 X       Pass    Pass    Pass
 
 
@@ -1040,7 +1040,7 @@ X       Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -1061,7 +1061,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -1082,7 +1082,7 @@ X       Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -1102,7 +1102,7 @@ Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    Pass    
 
 
@@ -1122,7 +1122,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      4H
+1N     2H      3S      4H
 4S      Pass    Pass    Pass
 
 
@@ -1143,7 +1143,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -1160,10 +1160,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 5 15 14}
 {Losers 9 9 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -1180,11 +1180,11 @@ Pass    Pass
 {HCP 11 0 17 12}
 {TP 12 0 17 14}
 {Losers 7 12 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1204,7 +1204,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2D      2S      Pass    Pass
 Pass    
 
@@ -1222,10 +1222,10 @@ Pass
 {HCP 9 2 15 14}
 {TP 9 5 15 16}
 {Losers 9 8 6 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 Pass    Pass    
 
 
@@ -1245,7 +1245,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      2NT     4S
+1N     2S      2N     4S
 X       Pass    Pass    Pass
 
 
@@ -1266,7 +1266,7 @@ X       Pass    Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3D      4H
+1N     2H      3D      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -1284,11 +1284,11 @@ Pass    Pass
 {HCP 10 4 15 11}
 {TP 11 5 15 14}
 {Losers 8 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1305,11 +1305,11 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 10 3 16 13}
 {Losers 8 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1326,10 +1326,10 @@ Pass    Pass
 {HCP 9 2 16 13}
 {TP 10 4 16 13}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -1346,10 +1346,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 4 15 13}
 {Losers 8 10 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -1369,7 +1369,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    3H      4C      Pass
 Pass    Pass    
 
@@ -1387,10 +1387,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 11 3 15 14}
 {Losers 9 10 6 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -1410,7 +1410,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      4H
+1N     2H      3S      4H
 4S      Pass    5C      Pass
 5D      Pass    6S      Pass
 Pass    Pass    
@@ -1432,7 +1432,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      4H
+1N     2H      3S      4H
 4S      Pass    Pass    Pass
 
 
@@ -1453,7 +1453,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3NT     4H
+1N     2H      3N     4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -1471,10 +1471,10 @@ Pass    Pass
 {HCP 12 0 16 12}
 {TP 14 2 16 15}
 {Losers 6 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -1494,7 +1494,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1511,10 +1511,10 @@ Pass
 {HCP 11 2 15 12}
 {TP 11 3 15 14}
 {Losers 8 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -1531,12 +1531,12 @@ Pass    Pass
 {HCP 9 2 16 13}
 {TP 11 2 16 14}
 {Losers 7 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    2S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1553,10 +1553,10 @@ Pass    Pass
 {HCP 9 4 15 12}
 {TP 10 7 15 14}
 {Losers 8 8 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -1576,7 +1576,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -1593,10 +1593,10 @@ Pass    Pass
 {HCP 11 1 15 13}
 {TP 11 3 15 14}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -1616,7 +1616,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    4S
 Pass    Pass    X       Pass
 Pass    Pass    
@@ -1638,7 +1638,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3C      4H
+1N     2H      3C      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -1659,8 +1659,8 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      4D
-4S      Pass    4NT     Pass
+1N     2D      3S      4D
+4S      Pass    4N     Pass
 5H      Pass    6S      Pass
 Pass    Pass    
 
@@ -1678,10 +1678,10 @@ Pass    Pass
 {HCP 10 0 16 14}
 {TP 10 2 16 17}
 {Losers 9 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -1698,10 +1698,10 @@ Pass    Pass
 {HCP 11 0 17 12}
 {TP 11 2 18 15}
 {Losers 9 10 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -1721,7 +1721,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -1742,7 +1742,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -1762,7 +1762,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -1779,11 +1779,11 @@ Pass
 {HCP 10 0 16 14}
 {TP 13 4 17 17}
 {Losers 6 8 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1800,10 +1800,10 @@ Pass
 {HCP 12 0 16 12}
 {TP 13 2 16 13}
 {Losers 8 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1823,7 +1823,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4S      Pass
+1N     2D      4S      Pass
 Pass    Pass    
 
 
@@ -1840,10 +1840,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 12 5 16 13}
 {Losers 7 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -1860,11 +1860,11 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 12 3 15 14}
 {Losers 7 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1884,7 +1884,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -1905,7 +1905,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      X       4H      Pass
 Pass    Pass    
 
@@ -1923,10 +1923,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 5 15 13}
 {Losers 9 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -1946,7 +1946,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -1967,7 +1967,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      3C      4D
+1N     2D      3C      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -1985,11 +1985,11 @@ Pass    Pass
 {HCP 9 4 15 12}
 {TP 11 6 15 13}
 {Losers 7 9 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2009,7 +2009,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -2029,7 +2029,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2050,7 +2050,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -2068,10 +2068,10 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 10 2 15 16}
 {Losers 8 11 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -2088,11 +2088,11 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 11 1 15 17}
 {Losers 8 12 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2112,7 +2112,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      4D
+1N     2D      3S      4D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -2130,11 +2130,11 @@ Pass    Pass
 {HCP 11 0 16 13}
 {TP 11 2 16 16}
 {Losers 9 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2151,10 +2151,10 @@ Pass    Pass
 {HCP 12 0 16 12}
 {TP 12 2 16 15}
 {Losers 8 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -2171,10 +2171,10 @@ Pass    Pass
 {HCP 12 0 15 13}
 {TP 12 4 15 15}
 {Losers 8 8 8 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -2194,7 +2194,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -2214,7 +2214,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      X       4S      Pass
 Pass    Pass    
 
@@ -2235,7 +2235,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      4D
+1N     2D      3S      4D
 4S      Pass    Pass    Pass
 
 
@@ -2253,10 +2253,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 12 4 15 15}
 {Losers 7 10 6 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -2273,10 +2273,10 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 11 5 16 13}
 {Losers 7 8 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -2296,7 +2296,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    3D      Pass    Pass
 Pass    
 
@@ -2314,10 +2314,10 @@ Pass
 {HCP 10 1 16 13}
 {TP 10 3 16 15}
 {Losers 9 10 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2337,8 +2337,8 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    4H      Pass
+1N     2S      3S      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -2355,10 +2355,10 @@ Pass    Pass
 {HCP 10 0 17 13}
 {TP 10 2 18 16}
 {Losers 8 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -2378,7 +2378,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -2396,10 +2396,10 @@ Pass    Pass
 {HCP 10 1 17 12}
 {TP 10 2 17 14}
 {Losers 9 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -2419,7 +2419,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    3S      4H      Pass
 Pass    Pass    
 
@@ -2440,7 +2440,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      4D
+1N     2D      3S      4D
 4S      Pass    Pass    Pass
 
 
@@ -2461,7 +2461,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -2481,7 +2481,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2502,7 +2502,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2523,7 +2523,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2544,7 +2544,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3H      4S
+1N     2S      3H      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -2565,7 +2565,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -2585,7 +2585,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      4H
+1N     2H      3C      4H
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -2606,7 +2606,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2627,7 +2627,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -2648,7 +2648,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 Pass    Pass    
 
 
@@ -2668,7 +2668,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      4H
+1N     2H      3S      4H
 4S      Pass    Pass    Pass
 
 
@@ -2686,11 +2686,11 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 10 3 16 14}
 {Losers 9 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2710,7 +2710,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -2730,7 +2730,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -2750,7 +2750,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    X       Pass    4C
 Pass    Pass    4H      Pass
 Pass    X       Pass    Pass
@@ -2773,7 +2773,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -2791,10 +2791,10 @@ Pass
 {HCP 9 3 16 12}
 {TP 12 5 16 15}
 {Losers 6 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2814,7 +2814,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -2831,11 +2831,11 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 10 4 16 14}
 {Losers 8 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2855,7 +2855,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2876,7 +2876,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      2NT     4H
+1N     2H      2N     4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -2894,10 +2894,10 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 10 4 16 15}
 {Losers 8 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -2914,11 +2914,11 @@ Pass    Pass
 {HCP 10 1 17 12}
 {TP 12 1 17 13}
 {Losers 7 12 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2935,11 +2935,11 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 12 3 15 14}
 {Losers 8 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2959,7 +2959,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      4H      Pass
+1N     2C      4H      Pass
 Pass    Pass    
 
 
@@ -2976,10 +2976,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 4 15 13}
 {Losers 9 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -2999,7 +2999,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -3016,10 +3016,10 @@ Pass    Pass
 {HCP 10 0 17 13}
 {TP 10 3 17 15}
 {Losers 8 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -3039,7 +3039,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    X       Pass    3S
 Pass    Pass    4C      Pass
 Pass    Pass    
@@ -3061,7 +3061,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 Pass    Pass    
 
 
@@ -3081,7 +3081,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -3101,7 +3101,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4S      Pass
+1N     2D      4S      Pass
 Pass    Pass    
 
 
@@ -3121,7 +3121,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3139,11 +3139,11 @@ Pass    Pass
 {HCP 10 0 16 14}
 {TP 11 0 16 14}
 {Losers 7 12 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3160,11 +3160,11 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 10 3 16 12}
 {Losers 9 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2D      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3184,7 +3184,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      4H
+1N     2H      3H      4H
 Pass    Pass    X       Pass
 4S      Pass    Pass    Pass
 
@@ -3203,11 +3203,11 @@ Pass    Pass    X       Pass
 {HCP 10 1 17 12}
 {TP 11 4 17 14}
 {Losers 8 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3227,7 +3227,7 @@ Pass    Pass    X       Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3245,11 +3245,11 @@ Pass    Pass    X       Pass
 {HCP 11 0 17 12}
 {TP 11 1 17 14}
 {Losers 8 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3269,7 +3269,7 @@ Pass    Pass    X       Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 X       Pass    Pass    Pass
 
 
@@ -3290,7 +3290,7 @@ X       Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -3310,7 +3310,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      3D      4H      Pass
 Pass    Pass    
 
@@ -3331,7 +3331,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -3348,11 +3348,11 @@ Pass    Pass
 {HCP 10 0 15 15}
 {TP 12 2 16 15}
 {Losers 7 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3372,7 +3372,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -3392,8 +3392,8 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    4H      Pass
+1N     2S      3S      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -3413,7 +3413,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3H      4S
+1N     2S      3H      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -3431,10 +3431,10 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 10 5 16 14}
 {Losers 8 8 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -3454,7 +3454,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3475,7 +3475,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -3495,7 +3495,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3516,7 +3516,7 @@ Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 X       Pass    Pass    Pass
 
 
@@ -3537,7 +3537,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3555,10 +3555,10 @@ X       Pass    Pass    Pass
 {HCP 9 3 15 13}
 {TP 9 4 15 14}
 {Losers 9 10 8 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -3578,7 +3578,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -3595,11 +3595,11 @@ Pass    Pass
 {HCP 10 4 15 11}
 {TP 13 5 15 14}
 {Losers 6 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3619,7 +3619,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3640,7 +3640,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3658,10 +3658,10 @@ Pass    Pass
 {HCP 10 1 17 12}
 {TP 11 3 17 14}
 {Losers 7 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -3681,8 +3681,8 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    4H      Pass
+1N     2S      3S      Pass
+3N     Pass    4H      Pass
 Pass    X       Pass    Pass
 Pass    
 
@@ -3700,11 +3700,11 @@ Pass
 {HCP 10 1 16 13}
 {TP 10 3 16 15}
 {Losers 9 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3721,10 +3721,10 @@ Pass
 {HCP 9 1 16 14}
 {TP 11 2 16 15}
 {Losers 7 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -3744,7 +3744,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    Pass    
 
 
@@ -3761,10 +3761,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 4 15 13}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -3784,7 +3784,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4S      Pass
+1N     2D      4S      Pass
 Pass    Pass    
 
 
@@ -3804,8 +3804,8 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
-3NT     Pass    4H      Pass
+1N     2D      3H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -3825,7 +3825,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      4D
+1N     2D      3H      4D
 4H      Pass    Pass    Pass
 
 
@@ -3843,10 +3843,10 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 10 3 15 15}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -3866,7 +3866,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      4D
+1N     2D      3H      4D
 4H      Pass    Pass    Pass
 
 
@@ -3884,10 +3884,10 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 10 3 15 16}
 {Losers 9 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -3904,11 +3904,11 @@ Pass    Pass
 {HCP 10 1 17 12}
 {TP 11 2 17 13}
 {Losers 8 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3928,7 +3928,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      4H
+1N     2H      3S      4H
 X       Pass    6S      Pass
 Pass    Pass    
 
@@ -3949,7 +3949,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3970,7 +3970,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 Pass    Pass    
 
 
@@ -3987,10 +3987,10 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 14 2 15 13}
 {Losers 6 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -4010,7 +4010,7 @@ Pass    Pass
 [Contract "2DX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 X       Pass    Pass    Pass
 
 
@@ -4028,10 +4028,10 @@ X       Pass    Pass    Pass
 {HCP 11 1 15 13}
 {TP 12 3 15 15}
 {Losers 6 10 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -4051,7 +4051,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    Pass    
 
 
@@ -4071,8 +4071,8 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      4D
-4H      Pass    4NT     Pass
+1N     2D      3H      4D
+4H      Pass    4N     Pass
 5D      Pass    5H      Pass
 Pass    Pass    
 
@@ -4093,7 +4093,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3H      4S
+1N     2S      3H      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -4111,11 +4111,11 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 12 2 15 13}
 {Losers 8 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2D      Pass    3NT     Pass
+1N     2C      X       Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4135,7 +4135,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -4155,7 +4155,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -4175,7 +4175,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -4192,10 +4192,10 @@ Pass    Pass
 {HCP 12 0 15 13}
 {TP 12 1 15 14}
 {Losers 7 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -4212,10 +4212,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 10 4 15 14}
 {Losers 9 9 8 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -4235,7 +4235,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -4252,10 +4252,10 @@ Pass    Pass
 {HCP 10 0 15 15}
 {TP 10 3 15 16}
 {Losers 9 9 8 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -4275,7 +4275,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -4295,7 +4295,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4316,7 +4316,7 @@ Pass
 [Contract "4HX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      X       4H      Pass
 Pass    X       Pass    Pass
 Pass    
@@ -4338,7 +4338,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4356,10 +4356,10 @@ Pass
 {HCP 11 2 15 12}
 {TP 11 3 15 14}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -4379,7 +4379,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      4H
+1N     2H      3H      4H
 4S      Pass    Pass    Pass
 
 
@@ -4397,10 +4397,10 @@ Pass    Pass
 {HCP 11 1 16 12}
 {TP 11 3 16 14}
 {Losers 8 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -4417,10 +4417,10 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 10 2 16 16}
 {Losers 9 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -4437,11 +4437,11 @@ Pass    Pass
 {HCP 9 4 15 12}
 {TP 11 4 15 14}
 {Losers 7 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4458,11 +4458,11 @@ Pass    Pass
 {HCP 11 1 16 12}
 {TP 12 2 16 13}
 {Losers 7 11 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4482,7 +4482,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4500,11 +4500,11 @@ Pass    Pass
 {HCP 11 0 15 14}
 {TP 11 2 15 15}
 {Losers 8 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4521,11 +4521,11 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 12 4 16 14}
 {Losers 7 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4542,10 +4542,10 @@ Pass    Pass
 {HCP 10 0 15 15}
 {TP 11 1 15 17}
 {Losers 8 11 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -4562,11 +4562,11 @@ Pass    Pass
 {HCP 9 4 15 12}
 {TP 10 5 15 15}
 {Losers 8 9 8 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4583,11 +4583,11 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 12 3 15 15}
 {Losers 8 10 8 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4604,11 +4604,11 @@ Pass    Pass
 {HCP 9 3 16 12}
 {TP 10 4 16 12}
 {Losers 8 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4628,7 +4628,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    Pass    
 
 
@@ -4648,7 +4648,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 Pass    3D      4C      Pass
 Pass    Pass    
 
@@ -4669,7 +4669,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4687,10 +4687,10 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 12 3 15 13}
 {Losers 8 10 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -4710,7 +4710,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4731,7 +4731,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2S      3C      4S      Pass
 Pass    Pass    
 
@@ -4752,7 +4752,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -4770,10 +4770,10 @@ Pass    Pass
 {HCP 9 2 16 13}
 {TP 11 4 16 14}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -4793,7 +4793,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4811,11 +4811,11 @@ Pass    Pass
 {HCP 10 0 17 13}
 {TP 10 1 18 16}
 {Losers 8 11 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4835,8 +4835,8 @@ Pass    Pass
 [Contract "6C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    4C      Pass
+1N     2H      3S      Pass
+3N     Pass    4C      Pass
 5C      Pass    6C      Pass
 Pass    Pass    
 
@@ -4854,10 +4854,10 @@ Pass    Pass
 {HCP 11 1 16 12}
 {TP 11 3 16 12}
 {Losers 7 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -4877,7 +4877,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4898,7 +4898,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4916,10 +4916,10 @@ Pass    Pass
 {HCP 11 0 16 13}
 {TP 11 1 17 14}
 {Losers 8 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -4936,10 +4936,10 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 10 5 16 15}
 {Losers 9 8 8 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -4956,10 +4956,10 @@ Pass    Pass
 {HCP 10 1 17 12}
 {TP 10 2 17 15}
 {Losers 8 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -4976,10 +4976,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 5 15 13}
 {Losers 7 9 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -4999,7 +4999,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    3H      4C      Pass
 Pass    Pass    
 
@@ -5017,10 +5017,10 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 11 3 15 12}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -5040,7 +5040,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -5060,8 +5060,8 @@ Pass    Pass
 [Contract "3SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2C      2D      Pass
-2H      Pass    2NT     Pass
+1N     2C      2D      Pass
+2H      Pass    2N     Pass
 3H      X       Pass    3S
 X       Pass    Pass    Pass
 
@@ -5083,7 +5083,7 @@ X       Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5103,7 +5103,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      4S      Pass
+1N     2C      4S      Pass
 Pass    Pass    
 
 
@@ -5123,7 +5123,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5144,7 +5144,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      3H      3S      Pass
 4S      Pass    Pass    Pass
 
@@ -5166,7 +5166,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -5187,7 +5187,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -5207,7 +5207,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 X       Pass    4S      Pass
 Pass    Pass    
 
@@ -5228,7 +5228,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5246,10 +5246,10 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 10 4 16 13}
 {Losers 9 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -5269,7 +5269,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -5290,7 +5290,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      2S      4H      Pass
 Pass    Pass    
 
@@ -5308,10 +5308,10 @@ Pass    Pass
 {HCP 9 3 15 13}
 {TP 11 6 16 14}
 {Losers 8 8 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -5331,7 +5331,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5349,10 +5349,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 11 2 15 15}
 {Losers 8 11 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -5369,10 +5369,10 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 12 3 15 14}
 {Losers 7 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -5392,7 +5392,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -5412,7 +5412,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5433,7 +5433,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    3S      4H      Pass
 Pass    Pass    
 
@@ -5451,11 +5451,11 @@ Pass    Pass
 {HCP 10 0 17 13}
 {TP 13 2 18 15}
 {Losers 6 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5472,11 +5472,11 @@ Pass    Pass
 {HCP 13 0 16 11}
 {TP 14 0 17 12}
 {Losers 7 12 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5496,7 +5496,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -5513,11 +5513,11 @@ Pass    Pass
 {HCP 9 2 16 13}
 {TP 11 3 16 15}
 {Losers 7 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5537,7 +5537,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4S      Pass
+1N     2D      4S      Pass
 Pass    Pass    
 
 
@@ -5557,7 +5557,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -5577,8 +5577,8 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
-2H      X       2NT     Pass
+1N     Pass    2D      Pass
+2H      X       2N     Pass
 4H      X       Pass    Pass
 Pass    
 
@@ -5599,7 +5599,7 @@ Pass
 [Contract "4SX"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2D      X       Pass
+1N     2D      X       Pass
 3C      Pass    3D      Pass
 3H      X       4H      Pass
 Pass    X       Pass    4S
@@ -5620,10 +5620,10 @@ X       Pass    Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 6 15 13}
 {Losers 9 8 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -5640,11 +5640,11 @@ Pass    Pass
 {HCP 9 1 15 15}
 {TP 12 3 15 17}
 {Losers 6 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5661,11 +5661,11 @@ Pass    Pass
 {HCP 10 3 16 11}
 {TP 12 4 16 12}
 {Losers 7 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5682,11 +5682,11 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 10 2 16 13}
 {Losers 8 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5703,11 +5703,11 @@ Pass    Pass
 {HCP 9 4 15 12}
 {TP 11 6 15 13}
 {Losers 7 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5727,7 +5727,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -5748,8 +5748,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -5770,7 +5770,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -5790,7 +5790,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2S      3H      Pass    4H
 Pass    Pass    4S      Pass
 Pass    Pass    
@@ -5812,7 +5812,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5830,11 +5830,11 @@ Pass    Pass
 {HCP 10 1 17 12}
 {TP 10 2 17 12}
 {Losers 9 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5854,7 +5854,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 3S      Pass    4H      Pass
 Pass    Pass    
 
@@ -5872,11 +5872,11 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 13 2 15 13}
 {Losers 6 11 8 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5893,10 +5893,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 4 16 15}
 {Losers 8 10 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -5913,11 +5913,11 @@ Pass    Pass
 {HCP 10 0 16 14}
 {TP 10 1 16 15}
 {Losers 9 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5934,10 +5934,10 @@ Pass    Pass
 {HCP 11 1 15 13}
 {TP 11 3 15 14}
 {Losers 9 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -5954,10 +5954,10 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 11 3 17 15}
 {Losers 8 10 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -5977,7 +5977,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5995,10 +5995,10 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 14 5 16 13}
 {Losers 6 8 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -6018,7 +6018,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      3D      4D
+1N     2D      3D      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -6039,7 +6039,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -6059,9 +6059,9 @@ Pass    Pass
 [Contract "6SX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      X       3H      Pass
-4S      X       4NT     Pass
+4S      X       4N     Pass
 5S      Pass    6S      X
 Pass    Pass    Pass    
 
@@ -6082,7 +6082,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -6102,7 +6102,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      2S      4H      Pass
 Pass    Pass    
 
@@ -6123,7 +6123,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      4H
+1N     2H      3S      4H
 4S      Pass    Pass    Pass
 
 
@@ -6144,7 +6144,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3NT     4S
+1N     2S      3N     4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -6162,11 +6162,11 @@ Pass    Pass
 {HCP 10 0 16 14}
 {TP 11 2 16 14}
 {Losers 8 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6183,10 +6183,10 @@ Pass    Pass
 {HCP 11 0 15 14}
 {TP 12 1 15 16}
 {Losers 8 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -6203,10 +6203,10 @@ Pass    Pass
 {HCP 9 4 15 12}
 {TP 10 4 15 14}
 {Losers 9 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -6223,11 +6223,11 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 12 1 16 17}
 {Losers 7 11 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6244,10 +6244,10 @@ Pass    Pass
 {HCP 10 2 17 11}
 {TP 10 3 18 11}
 {Losers 9 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -6264,10 +6264,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 4 15 14}
 {Losers 8 10 8 5}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 Pass    Pass    
 
 
@@ -6287,7 +6287,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -6304,11 +6304,11 @@ Pass    Pass
 {HCP 12 0 16 12}
 {TP 15 1 16 15}
 {Losers 6 11 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6328,7 +6328,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -6345,11 +6345,11 @@ Pass    Pass
 {HCP 11 3 15 11}
 {TP 13 3 15 12}
 {Losers 7 11 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6369,7 +6369,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -6389,7 +6389,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -6407,11 +6407,11 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 10 4 15 17}
 {Losers 8 9 8 4}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      Pass
-2S      3H      3NT     Pass
+1N     2C      2H      Pass
+2S      3H      3N     Pass
 Pass    Pass    
 
 
@@ -6431,7 +6431,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -6451,7 +6451,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      4D
+1N     2D      3S      4D
 4S      Pass    Pass    Pass
 
 
@@ -6472,7 +6472,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -6492,7 +6492,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3NT     4H
+1N     2H      3N     4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -6513,7 +6513,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    3S      4D      Pass
 Pass    Pass    
 
@@ -6531,10 +6531,10 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 12 3 15 14}
 {Losers 7 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -6551,11 +6551,11 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 11 4 16 16}
 {Losers 8 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6572,11 +6572,11 @@ Pass    Pass
 {HCP 10 0 15 15}
 {TP 10 1 15 16}
 {Losers 8 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2D      2H      3NT     Pass
+1N     2C      X       Pass
+2D      2H      3N     Pass
 Pass    Pass    
 
 
@@ -6596,7 +6596,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -6616,7 +6616,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3NT     4H
+1N     2H      3N     4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -6637,7 +6637,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -6655,11 +6655,11 @@ Pass    Pass
 {HCP 13 0 15 12}
 {TP 15 2 16 14}
 {Losers 7 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6676,10 +6676,10 @@ Pass    Pass
 {HCP 11 0 15 14}
 {TP 11 2 15 14}
 {Losers 9 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -6696,10 +6696,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 11 3 15 14}
 {Losers 8 11 6 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 Pass    Pass    
 
 
@@ -6719,7 +6719,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -6736,10 +6736,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 12 5 15 15}
 {Losers 6 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -6756,10 +6756,10 @@ Pass    Pass
 {HCP 11 0 16 13}
 {TP 11 3 16 16}
 {Losers 8 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -6776,10 +6776,10 @@ Pass    Pass
 {HCP 13 0 15 12}
 {TP 14 2 15 15}
 {Losers 7 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -6799,7 +6799,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -6819,7 +6819,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -6840,7 +6840,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3H      4H
+1N     2H      3H      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -6858,10 +6858,10 @@ Pass    Pass
 {HCP 13 0 15 12}
 {TP 15 2 15 15}
 {Losers 6 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -6878,10 +6878,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 4 15 15}
 {Losers 8 9 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -6898,11 +6898,11 @@ Pass    Pass
 {HCP 11 0 16 13}
 {TP 13 3 16 16}
 {Losers 7 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6922,7 +6922,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -6942,7 +6942,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -6960,10 +6960,10 @@ Pass    Pass
 {HCP 10 1 17 12}
 {TP 10 2 17 14}
 {Losers 8 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -6983,7 +6983,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -7000,11 +7000,11 @@ Pass
 {HCP 10 0 16 14}
 {TP 12 2 17 16}
 {Losers 7 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7021,10 +7021,10 @@ Pass
 {HCP 10 3 15 12}
 {TP 10 4 16 14}
 {Losers 9 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7041,10 +7041,10 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 11 2 15 16}
 {Losers 8 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7061,10 +7061,10 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 12 3 15 13}
 {Losers 8 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -7081,10 +7081,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 10 3 15 16}
 {Losers 9 10 7 5}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 Pass    Pass    
 
 
@@ -7101,10 +7101,10 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 11 3 16 14}
 {Losers 8 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7121,11 +7121,11 @@ Pass    Pass
 {HCP 9 3 16 12}
 {TP 10 4 16 15}
 {Losers 8 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7142,11 +7142,11 @@ Pass    Pass
 {HCP 9 3 16 12}
 {TP 10 4 16 15}
 {Losers 9 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7163,10 +7163,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 3 15 13}
 {Losers 8 11 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 Pass    Pass    
 
 
@@ -7183,10 +7183,10 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 11 3 17 13}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7203,10 +7203,10 @@ Pass    Pass
 {HCP 9 3 17 11}
 {TP 10 7 18 14}
 {Losers 7 7 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -7223,11 +7223,11 @@ Pass    Pass
 {HCP 9 4 15 12}
 {TP 10 4 16 15}
 {Losers 8 11 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7244,10 +7244,10 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 11 2 15 14}
 {Losers 8 11 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7267,7 +7267,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -7288,7 +7288,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -7309,7 +7309,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    3S      4H      Pass
 Pass    Pass    
 
@@ -7327,11 +7327,11 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 11 3 15 15}
 {Losers 8 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7351,7 +7351,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -7368,10 +7368,10 @@ Pass    Pass
 {HCP 10 0 16 14}
 {TP 10 1 16 16}
 {Losers 9 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -7388,10 +7388,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 3 15 13}
 {Losers 8 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -7411,7 +7411,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -7432,7 +7432,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -7452,7 +7452,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -7472,7 +7472,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    X       Pass    3S
 Pass    Pass    4H      Pass
 Pass    Pass    
@@ -7494,7 +7494,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 X       Pass    Pass    Pass
 
 
@@ -7515,7 +7515,7 @@ X       Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -7535,7 +7535,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -7556,7 +7556,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2D      2H      Pass    Pass
 Pass    
 
@@ -7574,10 +7574,10 @@ Pass
 {HCP 10 3 16 11}
 {TP 10 4 17 12}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7594,10 +7594,10 @@ Pass    Pass
 {HCP 11 2 15 12}
 {TP 12 3 15 14}
 {Losers 8 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7614,11 +7614,11 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 12 2 15 14}
 {Losers 8 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7635,11 +7635,11 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 5 16 14}
 {Losers 8 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2D      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7659,7 +7659,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    3H      4C      Pass
 4D      X       5D      Pass
 Pass    Pass    
@@ -7678,10 +7678,10 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 12 1 15 14}
 {Losers 8 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -7701,7 +7701,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -7722,7 +7722,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3D      4S
+1N     2S      3D      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -7743,7 +7743,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -7760,10 +7760,10 @@ Pass    Pass
 {HCP 10 0 15 15}
 {TP 11 2 15 17}
 {Losers 8 10 8 4}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -7783,8 +7783,8 @@ Pass    Pass
 [Contract "6H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
-4H      Pass    4NT     Pass
+1N     2D      3H      Pass
+4H      Pass    4N     Pass
 5C      Pass    6H      Pass
 Pass    Pass    
 
@@ -7805,7 +7805,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    X       Pass    3S
 Pass    Pass    4D      Pass
 Pass    Pass    
@@ -7824,11 +7824,11 @@ Pass    Pass
 {HCP 10 0 16 14}
 {TP 12 1 16 16}
 {Losers 7 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7845,10 +7845,10 @@ Pass    Pass
 {HCP 12 0 16 12}
 {TP 12 1 16 14}
 {Losers 7 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7865,10 +7865,10 @@ Pass    Pass
 {HCP 10 0 15 15}
 {TP 10 1 15 15}
 {Losers 9 11 9 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 Pass    Pass    
 
 
@@ -7888,7 +7888,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      3NT     4D
+1N     2D      3N     4D
 Pass    Pass    Pass    
 
 
@@ -7908,9 +7908,9 @@ Pass    Pass    Pass
 [Contract "6H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    4S      Pass
-4NT     Pass    5NT     Pass
+4N     Pass    5N     Pass
 6H      Pass    Pass    Pass
 
 
@@ -7928,11 +7928,11 @@ Pass    Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 6 15 14}
 {Losers 8 8 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7949,11 +7949,11 @@ Pass    Pass    Pass
 {HCP 10 2 16 12}
 {TP 10 4 17 14}
 {Losers 9 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7970,11 +7970,11 @@ Pass    Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 5 16 14}
 {Losers 9 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7994,7 +7994,7 @@ Pass    Pass    Pass
 [Contract "4HX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 Pass    X       Pass    Pass
 Pass    
 
@@ -8015,7 +8015,7 @@ Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      3C      4D
+1N     2D      3C      4D
 Pass    Pass    Pass    
 
 
@@ -8035,7 +8035,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -8056,7 +8056,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2S      3H      4S      Pass
 Pass    Pass    
 
@@ -8074,10 +8074,10 @@ Pass    Pass
 {HCP 9 3 16 12}
 {TP 9 6 17 14}
 {Losers 8 8 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -8097,7 +8097,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -8114,10 +8114,10 @@ Pass
 {HCP 11 0 16 13}
 {TP 13 2 16 14}
 {Losers 5 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -8134,10 +8134,10 @@ Pass    Pass
 {HCP 11 0 17 12}
 {TP 11 0 18 14}
 {Losers 8 12 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -8157,7 +8157,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    X       Pass    3S
 Pass    Pass    4H      Pass
 Pass    Pass    
@@ -8179,7 +8179,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -8199,7 +8199,7 @@ Pass
 [Contract "4D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    X       Pass    3S
 Pass    Pass    4D      Pass
 Pass    Pass    
@@ -8221,7 +8221,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -8242,7 +8242,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -8260,10 +8260,10 @@ Pass    Pass
 {HCP 10 0 16 14}
 {TP 11 2 16 16}
 {Losers 7 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -8283,7 +8283,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3H      4H
+1N     2H      3H      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -8301,10 +8301,10 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 11 4 16 15}
 {Losers 8 10 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -8324,7 +8324,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -8345,7 +8345,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -8363,10 +8363,10 @@ Pass    Pass
 {HCP 10 0 15 15}
 {TP 12 1 15 17}
 {Losers 7 11 7 5}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -8383,11 +8383,11 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 12 5 16 15}
 {Losers 7 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8404,10 +8404,10 @@ Pass    Pass
 {HCP 9 3 15 13}
 {TP 11 5 15 15}
 {Losers 7 9 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -8424,10 +8424,10 @@ Pass    Pass
 {HCP 9 3 15 13}
 {TP 9 5 15 16}
 {Losers 9 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -8444,11 +8444,11 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 11 3 16 17}
 {Losers 9 10 6 4}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8465,10 +8465,10 @@ Pass    Pass
 {HCP 10 0 15 15}
 {TP 11 0 15 18}
 {Losers 7 12 7 5}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -8485,11 +8485,11 @@ Pass    Pass
 {HCP 9 2 16 13}
 {TP 9 5 17 16}
 {Losers 9 8 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8509,7 +8509,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      X       Pass    Pass
 Pass    
 
@@ -8530,7 +8530,7 @@ Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -8551,7 +8551,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      2NT     4S
+1N     2S      2N     4S
 X       Pass    Pass    Pass
 
 
@@ -8572,7 +8572,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      4H
+1N     2H      3S      4H
 4S      Pass    Pass    Pass
 
 
@@ -8593,7 +8593,7 @@ X       Pass    Pass    Pass
 [Contract "4D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    X       Pass    3H
 Pass    Pass    4D      Pass
 Pass    Pass    
@@ -8612,11 +8612,11 @@ Pass    Pass
 {HCP 9 2 16 13}
 {TP 10 4 16 16}
 {Losers 8 10 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8636,7 +8636,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    X       Pass    3S
 Pass    Pass    Pass    
 
@@ -8657,7 +8657,7 @@ Pass    Pass    Pass
 [Contract "6D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      3NT     4C
+1N     2C      3N     4C
 Pass    Pass    6D      Pass
 Pass    Pass    
 
@@ -8675,10 +8675,10 @@ Pass    Pass
 {HCP 11 1 15 13}
 {TP 11 3 15 16}
 {Losers 7 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -8698,7 +8698,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -8716,11 +8716,11 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 12 4 16 13}
 {Losers 7 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8737,11 +8737,11 @@ Pass    Pass
 {HCP 10 1 16 13}
 {TP 10 3 17 14}
 {Losers 8 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2H      2S      3NT     Pass
+1N     2C      X       Pass
+2H      2S      3N     Pass
 Pass    Pass    
 
 
@@ -8761,7 +8761,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -8781,7 +8781,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      4H      Pass
+1N     2C      4H      Pass
 Pass    Pass    
 
 
@@ -8798,11 +8798,11 @@ Pass    Pass
 {HCP 10 2 17 11}
 {TP 11 3 17 13}
 {Losers 8 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8822,7 +8822,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -8843,7 +8843,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -8864,7 +8864,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -8881,10 +8881,10 @@ Pass    Pass
 {HCP 11 1 16 12}
 {TP 11 3 16 14}
 {Losers 7 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -8904,7 +8904,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -8921,11 +8921,11 @@ Pass    Pass
 {HCP 9 5 15 11}
 {TP 12 5 15 13}
 {Losers 7 10 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2D      Pass    2NT     Pass
+1N     2C      X       Pass
+2D      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -8945,7 +8945,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    Pass    
 
 
@@ -8962,11 +8962,11 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 5 16 14}
 {Losers 8 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8986,7 +8986,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      4D
+1N     2D      3H      4D
 4H      Pass    Pass    Pass
 
 
@@ -9007,7 +9007,7 @@ Pass    Pass
 [Contract "4DX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      3D      4D
+1N     2D      3D      4D
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -9025,11 +9025,11 @@ Pass    Pass
 {HCP 9 1 16 14}
 {TP 10 2 16 16}
 {Losers 8 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      X       Pass
-3NT     Pass    Pass    Pass
+1N     2D      X       Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9046,10 +9046,10 @@ Pass    Pass
 {HCP 12 0 16 12}
 {TP 13 1 17 12}
 {Losers 7 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -9069,7 +9069,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    3H      Pass    4H
 Pass    Pass    X       Pass
 Pass    Pass    
@@ -9091,7 +9091,7 @@ Pass    Pass
 [Contract "2DX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 X       Pass    Pass    Pass
 
 
@@ -9109,10 +9109,10 @@ X       Pass    Pass    Pass
 {HCP 11 1 16 12}
 {TP 11 3 17 14}
 {Losers 8 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -9129,10 +9129,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 10 4 15 16}
 {Losers 8 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -9152,7 +9152,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -9170,11 +9170,11 @@ Pass    Pass
 {HCP 10 3 16 11}
 {TP 10 4 16 12}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9194,7 +9194,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -9214,7 +9214,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3H      4H
+1N     2H      3H      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -9235,7 +9235,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -9253,10 +9253,10 @@ Pass    Pass
 {HCP 9 4 15 12}
 {TP 10 5 15 14}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -9273,11 +9273,11 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 4 15 14}
 {Losers 9 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9297,7 +9297,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -9314,10 +9314,10 @@ Pass    Pass
 {HCP 11 1 15 13}
 {TP 11 1 15 14}
 {Losers 9 12 6 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 Pass    Pass    
 
 
@@ -9337,7 +9337,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -9357,9 +9357,9 @@ Pass
 [Contract "6S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      4H
-4S      Pass    4NT     Pass
-5H      Pass    5NT     Pass
+1N     2H      3S      4H
+4S      Pass    4N     Pass
+5H      Pass    5N     Pass
 6C      Pass    6S      Pass
 Pass    Pass    
 
@@ -9377,11 +9377,11 @@ Pass    Pass
 {HCP 12 0 15 13}
 {TP 12 1 15 16}
 {Losers 7 11 8 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9401,7 +9401,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -9419,10 +9419,10 @@ Pass    Pass
 {HCP 9 2 16 13}
 {TP 10 4 16 13}
 {Losers 9 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -9439,11 +9439,11 @@ Pass    Pass
 {HCP 13 0 16 11}
 {TP 13 1 17 11}
 {Losers 7 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9463,7 +9463,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      4H      Pass
+1N     2C      4H      Pass
 Pass    Pass    
 
 
@@ -9483,7 +9483,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -9503,7 +9503,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -9523,7 +9523,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -9540,10 +9540,10 @@ Pass    Pass
 {HCP 9 1 16 14}
 {TP 11 3 16 15}
 {Losers 7 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -9563,7 +9563,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -9584,7 +9584,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -9604,7 +9604,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -9621,11 +9621,11 @@ Pass    Pass
 {HCP 11 0 16 13}
 {TP 12 2 16 16}
 {Losers 8 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9645,7 +9645,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -9666,7 +9666,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3D      4S
+1N     2S      3D      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -9687,7 +9687,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -9704,10 +9704,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 11 3 15 16}
 {Losers 7 10 7 5}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -9724,10 +9724,10 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 13 2 15 13}
 {Losers 7 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -9744,11 +9744,11 @@ Pass    Pass
 {HCP 12 1 15 12}
 {TP 14 3 15 14}
 {Losers 6 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9765,10 +9765,10 @@ Pass    Pass
 {HCP 9 4 15 12}
 {TP 10 6 15 14}
 {Losers 8 9 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -9788,7 +9788,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -9808,8 +9808,8 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3D      Pass
-3NT     Pass    5C      Pass
+1N     2D      3D      Pass
+3N     Pass    5C      Pass
 Pass    Pass    
 
 
@@ -9826,10 +9826,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 4 15 12}
 {Losers 8 10 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 Pass    Pass    
 
 
@@ -9849,7 +9849,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -9866,10 +9866,10 @@ Pass    Pass
 {HCP 10 0 15 15}
 {TP 11 1 15 16}
 {Losers 8 11 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 Pass    Pass    
 
 
@@ -9886,10 +9886,10 @@ Pass    Pass
 {HCP 10 0 15 15}
 {TP 11 1 16 17}
 {Losers 7 11 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -9909,7 +9909,7 @@ Pass    Pass
 [Contract "6S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4D      Pass
 4H      Pass    6S      Pass
 Pass    Pass    
@@ -9928,11 +9928,11 @@ Pass    Pass
 {HCP 9 1 17 13}
 {TP 9 2 17 13}
 {Losers 9 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9952,7 +9952,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -9972,8 +9972,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      X       Pass
-3NT     Pass    4S      Pass
+1N     2D      X       Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -9993,7 +9993,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10014,7 +10014,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3D      4D
+1N     2D      3D      4D
 Pass    Pass    4S      Pass
 Pass    Pass    
 
@@ -10035,7 +10035,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -10056,7 +10056,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      X       3H      Pass
 4H      Pass    Pass    Pass
 
@@ -10078,7 +10078,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4S      Pass
+1N     2D      4S      Pass
 Pass    Pass    
 
 
@@ -10098,7 +10098,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4S      Pass
+1N     2D      4S      Pass
 Pass    Pass    
 
 
@@ -10118,7 +10118,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -10135,11 +10135,11 @@ Pass    Pass
 {HCP 10 0 16 14}
 {TP 10 2 16 14}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -10159,7 +10159,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4S      Pass
+1N     2D      4S      Pass
 Pass    Pass    
 
 
@@ -10179,7 +10179,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    4H      Pass
+1N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -10199,7 +10199,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -10219,7 +10219,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10237,10 +10237,10 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 10 3 16 16}
 {Losers 9 10 7 4}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -10257,10 +10257,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 4 15 14}
 {Losers 8 9 7 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 Pass    Pass    
 
 
@@ -10280,7 +10280,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3H      4S
+1N     2S      3H      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -10301,7 +10301,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 

--- a/GIB/lebensohl2.pbn
+++ b/GIB/lebensohl2.pbn
@@ -15,7 +15,7 @@
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4C      Pass
 4S      Pass    Pass    Pass
 
@@ -37,7 +37,7 @@
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 X       Pass    Pass    Pass
 
 
@@ -58,7 +58,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -79,7 +79,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -99,7 +99,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      2H      4D
+1N     2D      2H      4D
 Pass    Pass    Pass    
 
 
@@ -116,10 +116,10 @@ Pass    Pass    Pass
 {HCP 11 3 17 9}
 {TP 11 5 17 11}
 {Losers 9 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -139,7 +139,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      Pass    Pass
+1N     2C      Pass    Pass
 X       2D      3D      Pass
 3S      X       4S      Pass
 Pass    Pass    
@@ -158,10 +158,10 @@ Pass    Pass
 {HCP 13 2 15 10}
 {TP 14 5 15 11}
 {Losers 7 8 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -178,11 +178,11 @@ Pass    Pass
 {HCP 9 0 15 16}
 {TP 9 1 15 16}
 {Losers 9 11 8 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
-2S      Pass    2NT     Pass
+1N     Pass    2H      Pass
+2S      Pass    2N     Pass
 Pass    Pass    
 
 
@@ -199,11 +199,11 @@ Pass    Pass
 {HCP 10 4 16 10}
 {TP 12 7 16 12}
 {Losers 6 8 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      X
-3NT     Pass    Pass    Pass
+1N     2S      3S      X
+3N     Pass    Pass    Pass
 
 
 
@@ -220,10 +220,10 @@ Pass    Pass
 {HCP 4 3 16 17}
 {TP 4 3 16 17}
 {Losers 9 10 7 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -240,10 +240,10 @@ Pass    Pass
 {HCP 10 0 17 13}
 {TP 10 2 17 15}
 {Losers 7 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -260,10 +260,10 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 11 7 15 10}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -283,7 +283,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3H      3S
+1N     2S      3H      3S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -304,7 +304,7 @@ Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 X       Pass    2S      3H
 Pass    Pass    3S      Pass
 Pass    Pass    
@@ -326,7 +326,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    3H      Pass    3S
 Pass    4H      Pass    Pass
 Pass    
@@ -345,11 +345,11 @@ Pass
 {HCP 12 3 15 10}
 {TP 12 5 15 12}
 {Losers 8 9 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2D      Pass    3NT     Pass
+1N     2C      X       Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -369,7 +369,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -386,11 +386,11 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 12 5 16 11}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -410,7 +410,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -428,11 +428,11 @@ Pass    Pass
 {HCP 11 3 17 9}
 {TP 11 4 17 10}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -452,7 +452,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -472,7 +472,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -492,7 +492,7 @@ Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -512,7 +512,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -532,7 +532,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -552,7 +552,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -570,11 +570,11 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 4 15 14}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2H      Pass    3NT     Pass
+1N     2C      X       Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -594,7 +594,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -614,7 +614,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -634,7 +634,7 @@ Pass
 [Contract "2C"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      Pass    Pass
+1N     2C      Pass    Pass
 Pass    
 
 
@@ -651,10 +651,10 @@ Pass
 {HCP 11 3 17 9}
 {TP 11 6 17 12}
 {Losers 8 8 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -671,10 +671,10 @@ Pass    Pass
 {HCP 13 3 15 9}
 {TP 14 4 15 11}
 {Losers 7 9 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -694,7 +694,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -711,10 +711,10 @@ Pass    Pass
 {HCP 10 4 15 11}
 {TP 11 6 16 13}
 {Losers 7 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -731,11 +731,11 @@ Pass    Pass
 {HCP 12 3 16 9}
 {TP 12 5 16 11}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2D      Pass    3NT     Pass
+1N     2C      X       Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -755,7 +755,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -775,7 +775,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -796,7 +796,7 @@ Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      X       Pass    3D
 Pass    Pass    Pass    
 
@@ -817,7 +817,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -838,7 +838,7 @@ Pass    Pass
 [Contract "2CX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      Pass    Pass
+1N     2C      Pass    Pass
 X       Pass    Pass    Pass
 
 
@@ -859,7 +859,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -880,7 +880,7 @@ X       Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      4D
+1N     2D      3H      4D
 4H      Pass    Pass    Pass
 
 
@@ -901,7 +901,7 @@ X       Pass    Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3NT     4S
+1N     2S      3N     4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -919,10 +919,10 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 12 6 15 12}
 {Losers 7 8 8 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -939,11 +939,11 @@ Pass    Pass
 {HCP 8 2 16 14}
 {TP 9 3 16 16}
 {Losers 8 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -960,10 +960,10 @@ Pass    Pass
 {HCP 10 4 16 10}
 {TP 11 5 16 12}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -983,7 +983,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -1003,7 +1003,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      3C
+1N     2C      2H      3C
 Pass    Pass    3D      Pass
 3S      Pass    Pass    Pass
 
@@ -1025,7 +1025,7 @@ Pass    Pass    3D      Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      X       Pass    3D
 Pass    Pass    Pass    
 
@@ -1046,7 +1046,7 @@ Pass    Pass    Pass
 [Contract "2HX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 X       Pass    2H      Pass
 Pass    X       Pass    Pass
 Pass    
@@ -1065,10 +1065,10 @@ Pass
 {HCP 10 2 16 12}
 {TP 10 3 16 13}
 {Losers 9 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -1088,7 +1088,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    3D      Pass    3S
 Pass    Pass    Pass    
 
@@ -1109,7 +1109,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -1129,7 +1129,7 @@ Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      X       Pass    3H
 Pass    Pass    Pass    
 
@@ -1150,7 +1150,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -1172,7 +1172,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -1192,7 +1192,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4S      Pass
+1N     2D      4S      Pass
 Pass    Pass    
 
 
@@ -1212,7 +1212,7 @@ Pass    Pass
 [Contract "2HX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2H      Pass
+1N     2D      2H      Pass
 Pass    X       Pass    Pass
 Pass    
 
@@ -1230,10 +1230,10 @@ Pass
 {HCP 10 1 15 14}
 {TP 11 3 15 17}
 {Losers 7 10 7 5}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -1250,10 +1250,10 @@ Pass    Pass
 {HCP 10 4 15 11}
 {TP 11 5 15 13}
 {Losers 8 9 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -1273,7 +1273,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1290,10 +1290,10 @@ Pass
 {HCP 10 1 16 13}
 {TP 10 2 17 15}
 {Losers 9 11 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -1313,7 +1313,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3D      4H
+1N     2H      3D      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -1334,7 +1334,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      X       Pass    3C
 Pass    Pass    Pass    
 
@@ -1352,11 +1352,11 @@ Pass    Pass    Pass
 {HCP 10 5 15 10}
 {TP 12 7 15 13}
 {Losers 7 8 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1376,7 +1376,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -1396,7 +1396,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    3C      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
@@ -1415,11 +1415,11 @@ Pass    Pass
 {HCP 14 1 16 9}
 {TP 14 2 16 12}
 {Losers 6 11 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1439,7 +1439,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    X       Pass    3H
 Pass    Pass    4C      Pass
 Pass    Pass    
@@ -1458,11 +1458,11 @@ Pass    Pass
 {HCP 11 1 16 12}
 {TP 11 2 16 13}
 {Losers 9 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2D      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1482,7 +1482,7 @@ Pass    Pass
 [Contract "5S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    5H      Pass
 5S      Pass    Pass    Pass
 
@@ -1504,7 +1504,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      4S
+1N     2S      3C      4S
 Pass    Pass    5C      Pass
 Pass    Pass    
 
@@ -1525,7 +1525,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1542,10 +1542,10 @@ Pass
 {HCP 10 3 16 11}
 {TP 11 5 16 13}
 {Losers 8 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -1565,7 +1565,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -1583,10 +1583,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 4 15 13}
 {Losers 9 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -1603,10 +1603,10 @@ Pass    Pass
 {HCP 1 5 15 19}
 {TP 2 7 16 19}
 {Losers 10 8 6 5}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -1626,7 +1626,7 @@ Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -1643,10 +1643,10 @@ Pass    Pass
 {HCP 12 1 16 11}
 {TP 12 2 16 13}
 {Losers 8 11 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -1666,7 +1666,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    4S      Pass    Pass
 Pass    
 
@@ -1684,11 +1684,11 @@ Pass
 {HCP 10 5 16 9}
 {TP 11 6 16 10}
 {Losers 7 9 8 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -1705,11 +1705,11 @@ Pass    Pass
 {HCP 11 3 17 9}
 {TP 12 3 17 11}
 {Losers 8 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1726,11 +1726,11 @@ Pass    Pass
 {HCP 7 5 15 13}
 {TP 9 8 15 16}
 {Losers 8 7 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      Pass    Pass
-X       2D      3NT     Pass
+1N     2C      Pass    Pass
+X       2D      3N     Pass
 Pass    Pass    
 
 
@@ -1747,11 +1747,11 @@ Pass    Pass
 {HCP 10 3 16 11}
 {TP 10 4 16 12}
 {Losers 8 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1768,10 +1768,10 @@ Pass    Pass
 {HCP 10 4 15 11}
 {TP 11 5 15 12}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -1788,10 +1788,10 @@ Pass    Pass
 {HCP 10 4 15 11}
 {TP 11 4 15 13}
 {Losers 8 11 7 7}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 Pass    Pass    
 
 
@@ -1811,7 +1811,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -1829,10 +1829,10 @@ Pass    Pass
 {HCP 10 0 15 15}
 {TP 10 0 15 16}
 {Losers 8 12 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -1852,7 +1852,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -1872,7 +1872,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      4S      Pass
+1N     2C      4S      Pass
 Pass    Pass    
 
 
@@ -1892,7 +1892,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -1912,7 +1912,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -1932,7 +1932,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2H      4D
+1N     2D      2H      4D
 X       Pass    4H      Pass
 Pass    Pass    
 
@@ -1953,7 +1953,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 X       Pass    Pass    Pass
 
 
@@ -1971,11 +1971,11 @@ X       Pass    Pass    Pass
 {HCP 13 2 15 10}
 {TP 14 3 15 12}
 {Losers 7 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -1995,8 +1995,8 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2H      Pass    3NT     Pass
+1N     2C      X       Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -2014,10 +2014,10 @@ X       Pass    Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 4 15 12}
 {Losers 8 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -2034,10 +2034,10 @@ Pass    Pass
 {HCP 10 0 16 14}
 {TP 11 1 17 16}
 {Losers 8 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -2054,10 +2054,10 @@ Pass    Pass
 {HCP 12 4 15 9}
 {TP 12 5 15 11}
 {Losers 7 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -2077,7 +2077,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -2097,7 +2097,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -2117,7 +2117,7 @@ Pass    Pass
 [Contract "4C"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      2D      4C
+1N     2C      2D      4C
 Pass    Pass    Pass    
 
 
@@ -2134,10 +2134,10 @@ Pass    Pass    Pass
 {HCP 12 2 17 9}
 {TP 12 3 17 10}
 {Losers 9 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2157,7 +2157,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -2175,11 +2175,11 @@ Pass    Pass
 {HCP 11 1 15 13}
 {TP 12 3 15 15}
 {Losers 8 9 8 4}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2196,12 +2196,12 @@ Pass    Pass
 {HCP 12 2 17 9}
 {TP 13 4 17 11}
 {Losers 8 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 3H      Pass    3S      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2221,7 +2221,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      4H
+1N     2H      3H      4H
 4S      Pass    Pass    Pass
 
 
@@ -2239,11 +2239,11 @@ Pass    Pass
 {HCP 12 1 17 10}
 {TP 12 1 17 11}
 {Losers 8 12 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3D      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2263,7 +2263,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 X       3S      Pass    Pass
 Pass    
 
@@ -2284,7 +2284,7 @@ Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3C      4H
+1N     2H      3C      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -2305,7 +2305,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 X       Pass    Pass    Pass
 
 
@@ -2323,10 +2323,10 @@ X       Pass    Pass    Pass
 {HCP 12 2 15 11}
 {TP 12 4 15 14}
 {Losers 8 9 8 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -2346,7 +2346,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      X       Pass    3H
 Pass    Pass    Pass    
 
@@ -2367,7 +2367,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4S      Pass
+1N     2D      4S      Pass
 Pass    Pass    
 
 
@@ -2384,10 +2384,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 11 2 15 14}
 {Losers 7 11 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -2407,8 +2407,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2H      Pass    3NT     Pass
+1N     2C      X       Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -2429,7 +2429,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -2446,11 +2446,11 @@ Pass
 {HCP 2 5 16 17}
 {TP 5 7 16 17}
 {Losers 8 8 8 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       2H      Pass
-2S      Pass    Pass    2NT
+1N     X       2H      Pass
+2S      Pass    Pass    2N
 Pass    Pass    Pass    
 
 
@@ -2470,7 +2470,7 @@ Pass    Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -2490,7 +2490,7 @@ Pass
 [Contract "3HX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      X
+1N     2S      3H      X
 Pass    Pass    Pass    
 
 
@@ -2507,10 +2507,10 @@ Pass    Pass    Pass
 {HCP 10 1 15 14}
 {TP 10 3 15 14}
 {Losers 8 10 6 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -2530,7 +2530,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 X       Pass    2H      Pass
 Pass    3D      3H      Pass
 Pass    Pass    
@@ -2552,7 +2552,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 X       Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -2574,7 +2574,7 @@ X       Pass    3S      Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      2S      Pass    Pass
 Pass    
 
@@ -2592,10 +2592,10 @@ Pass
 {HCP 13 1 15 11}
 {TP 14 3 15 13}
 {Losers 7 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -2615,7 +2615,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2636,7 +2636,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -2654,11 +2654,11 @@ Pass    Pass
 {HCP 10 1 16 13}
 {TP 11 3 16 14}
 {Losers 8 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2H      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -2675,10 +2675,10 @@ Pass    Pass
 {HCP 12 2 15 11}
 {TP 12 4 16 13}
 {Losers 7 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -2698,7 +2698,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -2719,7 +2719,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -2737,10 +2737,10 @@ Pass    Pass
 {HCP 12 4 15 9}
 {TP 13 5 15 12}
 {Losers 7 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -2757,10 +2757,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 3 16 14}
 {Losers 8 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -2780,7 +2780,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -2801,7 +2801,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 Pass    Pass    
 
 
@@ -2818,11 +2818,11 @@ Pass    Pass
 {HCP 2 7 15 16}
 {TP 4 10 15 18}
 {Losers 10 6 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
-1NT     Pass    Pass    2H
-Pass    3NT     Pass    Pass
+1N     Pass    Pass    2H
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -2839,10 +2839,10 @@ Pass
 {HCP 11 5 15 9}
 {TP 11 9 15 11}
 {Losers 8 7 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -2862,7 +2862,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      3C      4D
+1N     2D      3C      4D
 Pass    Pass    Pass    
 
 
@@ -2879,10 +2879,10 @@ Pass    Pass    Pass
 {HCP 10 6 15 9}
 {TP 10 8 15 11}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -2902,7 +2902,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -2920,11 +2920,11 @@ Pass    Pass
 {HCP 10 1 17 12}
 {TP 10 4 17 15}
 {Losers 9 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -2944,7 +2944,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    3H      Pass    Pass
 3S      X       Pass    4H
 Pass    Pass    Pass    
@@ -2966,7 +2966,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -2986,7 +2986,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -3007,7 +3007,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    Pass    
 
 
@@ -3027,7 +3027,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3047,7 +3047,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -3068,7 +3068,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3089,7 +3089,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3110,7 +3110,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      2S      4H      Pass
 Pass    Pass    
 
@@ -3131,7 +3131,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2S      Pass
+1N     2D      2S      Pass
 Pass    3C      3S      Pass
 Pass    Pass    
 
@@ -3152,7 +3152,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      X       Pass
+1N     2D      X       Pass
 2S      Pass    3H      Pass
 Pass    Pass    
 
@@ -3173,7 +3173,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      4S      Pass
+1N     2C      4S      Pass
 Pass    Pass    
 
 
@@ -3190,10 +3190,10 @@ Pass    Pass
 {HCP 10 4 15 11}
 {TP 11 6 15 13}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -3213,7 +3213,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    4S
+1N     2S      Pass    4S
 Pass    Pass    Pass    
 
 
@@ -3233,7 +3233,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3251,11 +3251,11 @@ Pass    Pass
 {HCP 10 2 16 12}
 {TP 11 3 16 13}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3272,11 +3272,11 @@ Pass    Pass
 {HCP 10 4 17 9}
 {TP 11 6 17 11}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3296,7 +3296,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 Pass    Pass    
 
 
@@ -3316,7 +3316,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -3334,10 +3334,10 @@ Pass    Pass
 {HCP 14 2 15 9}
 {TP 16 2 15 11}
 {Losers 6 12 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -3357,7 +3357,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -3374,10 +3374,10 @@ Pass    Pass
 {HCP 11 3 16 10}
 {TP 11 5 16 11}
 {Losers 7 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -3397,7 +3397,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      X       Pass    3H
 Pass    Pass    Pass    
 
@@ -3418,7 +3418,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -3438,7 +3438,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    3S      Pass
 4S      Pass    Pass    Pass
 
@@ -3460,7 +3460,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3478,10 +3478,10 @@ Pass    Pass
 {HCP 6 1 16 17}
 {TP 6 1 16 17}
 {Losers 9 12 7 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -3498,10 +3498,10 @@ Pass    Pass
 {HCP 11 3 16 10}
 {TP 11 3 16 12}
 {Losers 8 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -3521,7 +3521,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -3542,7 +3542,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -3559,11 +3559,11 @@ Pass
 {HCP 11 2 17 10}
 {TP 12 4 17 13}
 {Losers 8 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3583,7 +3583,7 @@ Pass
 [Contract "3H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    X       Pass    3H
 Pass    Pass    Pass    
 
@@ -3604,7 +3604,7 @@ Pass    Pass    Pass
 [Contract "4SX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       2H
+1N     2C      X       2H
 2S      3D      4S      Pass
 Pass    X       Pass    Pass
 Pass    
@@ -3626,7 +3626,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      4S      Pass
+1N     2C      4S      Pass
 Pass    Pass    
 
 
@@ -3643,10 +3643,10 @@ Pass    Pass
 {HCP 13 1 15 11}
 {TP 13 4 15 13}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -3663,12 +3663,12 @@ Pass    Pass
 {HCP 1 5 16 18}
 {TP 2 7 16 18}
 {Losers 10 8 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       2H      2S
-X       2NT     Pass    3D
-Pass    3H      Pass    3NT
+1N     X       2H      2S
+X       2N     Pass    3D
+Pass    3H      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -3688,7 +3688,7 @@ Pass    Pass    Pass
 [Contract "2HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2D      2H      X       Pass
 Pass    Pass    
 
@@ -3709,7 +3709,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3H      4S
+1N     2S      3H      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -3730,7 +3730,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3D      4S
+1N     2S      3D      4S
 Pass    Pass    Pass    
 
 
@@ -3747,11 +3747,11 @@ Pass    Pass    Pass
 {HCP 11 2 15 12}
 {TP 11 3 15 13}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -3768,10 +3768,10 @@ Pass    Pass
 {HCP 11 3 17 9}
 {TP 11 7 17 12}
 {Losers 8 7 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -3791,7 +3791,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -3811,7 +3811,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3D      X
+1N     2D      3D      X
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -3832,7 +3832,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3853,7 +3853,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -3871,10 +3871,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 5 15 15}
 {Losers 9 9 7 5}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 Pass    Pass    
 
 
@@ -3894,7 +3894,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -3914,7 +3914,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 X       3C      3S      Pass
 Pass    Pass    
 
@@ -3932,11 +3932,11 @@ Pass    Pass
 {HCP 13 2 15 10}
 {TP 14 4 15 13}
 {Losers 7 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -3953,10 +3953,10 @@ Pass    Pass
 {HCP 10 3 17 10}
 {TP 10 4 17 12}
 {Losers 9 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -3976,7 +3976,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -3996,7 +3996,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      2S      Pass
+1N     2D      2S      Pass
 Pass    X       Pass    3D
 Pass    Pass    Pass    
 
@@ -4017,7 +4017,7 @@ Pass    Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -4038,7 +4038,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4059,7 +4059,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3H      4S
+1N     2S      3H      4S
 Pass    Pass    Pass    
 
 
@@ -4076,10 +4076,10 @@ Pass    Pass    Pass
 {HCP 2 7 15 16}
 {TP 3 7 15 16}
 {Losers 11 9 6 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4099,7 +4099,7 @@ Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -4119,7 +4119,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -4136,10 +4136,10 @@ Pass    Pass
 {HCP 10 3 16 11}
 {TP 11 3 16 13}
 {Losers 8 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -4156,10 +4156,10 @@ Pass    Pass
 {HCP 9 0 16 15}
 {TP 10 0 17 16}
 {Losers 8 12 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -4176,10 +4176,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 11 3 15 13}
 {Losers 8 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -4199,7 +4199,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    4D
+1N     2D      Pass    4D
 Pass    5D      Pass    Pass
 Pass    
 
@@ -4217,10 +4217,10 @@ Pass
 {HCP 2 7 15 16}
 {TP 3 7 15 16}
 {Losers 10 10 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -4240,7 +4240,7 @@ Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -4257,10 +4257,10 @@ Pass    Pass
 {HCP 11 5 15 9}
 {TP 13 5 15 10}
 {Losers 7 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4280,7 +4280,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4301,7 +4301,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -4318,10 +4318,10 @@ Pass    Pass
 {HCP 3 3 16 18}
 {TP 5 5 16 18}
 {Losers 9 9 7 6}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -4341,7 +4341,7 @@ Pass
 [Contract "3H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2D      2S      Pass
+1N     2D      2S      Pass
 Pass    X       Pass    3H
 Pass    Pass    Pass    
 
@@ -4362,7 +4362,7 @@ Pass    Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3C      4H
+1N     2H      3C      4H
 X       Pass    Pass    Pass
 
 
@@ -4383,7 +4383,7 @@ X       Pass    Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -4403,7 +4403,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4421,10 +4421,10 @@ Pass    Pass
 {HCP 12 0 17 11}
 {TP 12 2 17 13}
 {Losers 8 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -4441,10 +4441,10 @@ Pass    Pass
 {HCP 11 1 16 12}
 {TP 11 4 16 13}
 {Losers 8 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -4464,7 +4464,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -4484,7 +4484,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -4504,7 +4504,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4522,12 +4522,12 @@ Pass    Pass
 {HCP 1 6 15 18}
 {TP 3 8 16 19}
 {Losers 10 8 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       2H      Pass
-2S      Pass    Pass    2NT
-Pass    3NT     Pass    Pass
+1N     X       2H      Pass
+2S      Pass    Pass    2N
+Pass    3N     Pass    Pass
 Pass    
 
 
@@ -4547,7 +4547,7 @@ Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -4567,7 +4567,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -4585,10 +4585,10 @@ Pass    Pass
 {HCP 12 0 15 13}
 {TP 12 2 16 14}
 {Losers 7 10 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -4608,7 +4608,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      Pass    Pass
+1N     2C      Pass    Pass
 Pass    
 
 
@@ -4625,10 +4625,10 @@ Pass
 {HCP 10 1 16 13}
 {TP 10 4 16 15}
 {Losers 8 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -4645,10 +4645,10 @@ Pass    Pass
 {HCP 11 3 16 10}
 {TP 11 3 17 12}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -4668,7 +4668,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3C      4H
+1N     2H      3C      4H
 X       Pass    Pass    Pass
 
 
@@ -4689,7 +4689,7 @@ X       Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2D      2S
+1N     2C      2D      2S
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -4707,11 +4707,11 @@ Pass    Pass
 {HCP 10 0 16 14}
 {TP 10 0 16 17}
 {Losers 9 12 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2D      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -4731,7 +4731,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2S      Pass
+1N     2D      2S      Pass
 Pass    Pass    
 
 
@@ -4751,7 +4751,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -4768,10 +4768,10 @@ Pass
 {HCP 11 4 16 9}
 {TP 11 6 17 10}
 {Losers 9 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -4791,7 +4791,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2S      Pass
+1N     2D      2S      Pass
 Pass    3D      Pass    Pass
 3S      Pass    Pass    Pass
 
@@ -4813,7 +4813,7 @@ Pass    3D      Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -4831,10 +4831,10 @@ Pass    Pass
 {HCP 12 3 15 10}
 {TP 12 6 16 13}
 {Losers 8 8 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -4854,7 +4854,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2H      4D
+1N     2D      2H      4D
 Pass    Pass    4H      Pass
 Pass    X       Pass    Pass
 Pass    
@@ -4876,7 +4876,7 @@ Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -4896,7 +4896,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -4913,10 +4913,10 @@ Pass    Pass
 {HCP 11 1 16 12}
 {TP 11 4 17 14}
 {Losers 8 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -4933,10 +4933,10 @@ Pass    Pass
 {HCP 13 1 15 11}
 {TP 13 4 15 14}
 {Losers 8 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -4956,7 +4956,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -4977,7 +4977,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
+1N     2H      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -4995,10 +4995,10 @@ Pass    Pass
 {HCP 12 2 16 10}
 {TP 12 3 16 12}
 {Losers 8 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -5018,7 +5018,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    3H      Pass    Pass
 3S      Pass    Pass    Pass
 
@@ -5040,7 +5040,7 @@ Pass    3H      Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5061,7 +5061,7 @@ Pass    3H      Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 X       Pass    3C      Pass
 Pass    Pass    
 
@@ -5082,7 +5082,7 @@ Pass    Pass
 [Contract "5C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2S      Pass    3C
+1N     2S      Pass    3C
 Pass    4C      Pass    5C
 Pass    Pass    Pass    
 
@@ -5103,7 +5103,7 @@ Pass    Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 3S      X       4H      Pass
 Pass    Pass    
 
@@ -5121,10 +5121,10 @@ Pass    Pass
 {HCP 11 3 15 11}
 {TP 12 6 15 13}
 {Losers 8 8 8 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 Pass    Pass    
 
 
@@ -5144,7 +5144,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      3S
+1N     2D      3H      3S
 4H      Pass    Pass    Pass
 
 
@@ -5162,10 +5162,10 @@ Pass    Pass
 {HCP 11 3 16 10}
 {TP 11 4 17 11}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -5182,11 +5182,11 @@ Pass    Pass
 {HCP 10 3 16 11}
 {TP 11 5 17 13}
 {Losers 8 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5206,7 +5206,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 X       Pass    Pass    Pass
 
 
@@ -5224,11 +5224,11 @@ X       Pass    Pass    Pass
 {HCP 13 0 16 11}
 {TP 14 1 16 12}
 {Losers 6 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3D      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5248,7 +5248,7 @@ X       Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5266,10 +5266,10 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 11 6 15 11}
 {Losers 8 9 7 8}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 Pass    Pass    
 
 
@@ -5286,10 +5286,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 10 3 15 14}
 {Losers 9 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -5306,11 +5306,11 @@ Pass    Pass
 {HCP 13 1 17 9}
 {TP 13 4 17 12}
 {Losers 7 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2D      Pass    3NT     Pass
+1N     2C      X       Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5330,7 +5330,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -5351,7 +5351,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -5372,7 +5372,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -5389,12 +5389,12 @@ Pass
 {HCP 1 6 15 18}
 {TP 2 6 15 18}
 {Losers 11 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "W"]
 [Auction "S"]
-1NT     X       2H      2S
-X       2NT     Pass    3C
-Pass    3D      Pass    3NT
+1N     X       2H      2S
+X       2N     Pass    3C
+Pass    3D      Pass    3N
 Pass    Pass    Pass    
 
 
@@ -5414,7 +5414,7 @@ Pass    Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -5435,7 +5435,7 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      2S      3H
+1N     2H      2S      3H
 Pass    4H      4S      Pass
 Pass    5H      Pass    Pass
 Pass    
@@ -5457,7 +5457,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5478,7 +5478,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      2H      Pass
+1N     2D      2H      Pass
 Pass    2S      Pass    Pass
 Pass    
 
@@ -5499,7 +5499,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    4S      Pass
+1N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -5519,7 +5519,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -5540,7 +5540,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -5560,7 +5560,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      Pass    Pass
+1N     2C      Pass    Pass
 Pass    
 
 
@@ -5580,7 +5580,7 @@ Pass
 [Contract "2H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2D      Pass
+1N     X       2D      Pass
 2H      Pass    Pass    Pass
 
 
@@ -5601,7 +5601,7 @@ Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5621,7 +5621,7 @@ Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      Pass    3H
+1N     2H      Pass    3H
 Pass    4H      Pass    Pass
 Pass    
 
@@ -5639,10 +5639,10 @@ Pass
 {HCP 10 1 15 14}
 {TP 11 2 15 15}
 {Losers 8 11 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 Pass    Pass    
 
 
@@ -5662,7 +5662,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -5679,10 +5679,10 @@ Pass    Pass
 {HCP 8 0 15 17}
 {TP 9 1 15 19}
 {Losers 8 11 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -5702,7 +5702,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -5723,7 +5723,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 3S      Pass    4H      Pass
 Pass    Pass    
 
@@ -5741,12 +5741,12 @@ Pass    Pass
 {HCP 13 3 15 9}
 {TP 15 3 15 10}
 {Losers 6 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    3C      Pass
-3NT     Pass    Pass    Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -5763,10 +5763,10 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 10 2 15 13}
 {Losers 8 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -5783,10 +5783,10 @@ Pass    Pass
 {HCP 10 4 15 11}
 {TP 11 4 15 12}
 {Losers 8 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -5806,7 +5806,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -5826,7 +5826,7 @@ Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -5844,10 +5844,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 10 4 15 13}
 {Losers 10 10 8 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -5867,7 +5867,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -5887,7 +5887,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5905,10 +5905,10 @@ Pass
 {HCP 10 6 15 9}
 {TP 11 10 15 10}
 {Losers 8 6 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -5925,10 +5925,10 @@ Pass    Pass
 {HCP 11 4 15 10}
 {TP 12 6 15 12}
 {Losers 7 8 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -5948,7 +5948,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -5966,10 +5966,10 @@ Pass    Pass
 {HCP 10 4 15 11}
 {TP 10 7 15 12}
 {Losers 9 7 8 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 Pass    Pass    
 
 
@@ -5989,7 +5989,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -6009,7 +6009,7 @@ Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3S      4S
+1N     2S      3S      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -6030,7 +6030,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 X       Pass    2H      Pass
 Pass    3D      Pass    Pass
 Pass    
@@ -6052,7 +6052,7 @@ Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -6072,7 +6072,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -6093,7 +6093,7 @@ Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -6113,7 +6113,7 @@ Pass    Pass
 [Contract "5H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 2S      3D      Pass    4H
 Pass    Pass    4S      X
 Pass    5H      Pass    Pass
@@ -6136,7 +6136,7 @@ Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -6156,7 +6156,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    3C
 Pass    Pass    Pass    
 
@@ -6174,10 +6174,10 @@ Pass    Pass    Pass
 {HCP 10 2 16 12}
 {TP 10 4 16 15}
 {Losers 9 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -6194,10 +6194,10 @@ Pass    Pass
 {HCP 3 3 16 18}
 {TP 5 4 17 18}
 {Losers 9 10 7 5}
-[Contract "1NTX"]
+[Contract "1NX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       Pass    Pass
+1N     X       Pass    Pass
 Pass    
 
 
@@ -6217,7 +6217,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      X       Pass    2S
 Pass    Pass    Pass    
 
@@ -6238,7 +6238,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    3D      Pass    Pass
 Pass    
 
@@ -6259,7 +6259,7 @@ Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      3C      4D
+1N     2D      3C      4D
 Pass    Pass    Pass    
 
 
@@ -6279,7 +6279,7 @@ Pass    Pass    Pass
 [Contract "3H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2D      Pass
+1N     2C      2D      Pass
 2H      Pass    Pass    2S
 Pass    Pass    3H      Pass
 Pass    Pass    
@@ -6301,7 +6301,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -6318,10 +6318,10 @@ Pass    Pass
 {HCP 10 2 17 11}
 {TP 10 2 18 14}
 {Losers 9 11 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -6341,7 +6341,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -6359,11 +6359,11 @@ Pass    Pass
 {HCP 10 4 16 10}
 {TP 11 5 16 11}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2H      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6380,11 +6380,11 @@ Pass    Pass
 {HCP 13 3 15 9}
 {TP 15 4 15 12}
 {Losers 6 10 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3D      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6404,7 +6404,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      2H      Pass
+1N     2D      2H      Pass
 Pass    3C      Pass    3D
 Pass    Pass    Pass    
 
@@ -6422,10 +6422,10 @@ Pass    Pass    Pass
 {HCP 10 3 16 11}
 {TP 10 4 17 14}
 {Losers 8 10 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -6445,7 +6445,7 @@ Pass    Pass
 [Contract "2SX"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      X       Pass    Pass
 Pass    
 
@@ -6466,7 +6466,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -6486,7 +6486,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -6506,7 +6506,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -6523,10 +6523,10 @@ Pass
 {HCP 10 2 17 11}
 {TP 10 4 17 13}
 {Losers 10 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -6546,7 +6546,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2S      Pass
+1N     2D      2S      Pass
 Pass    3C      3S      Pass
 Pass    Pass    
 
@@ -6567,7 +6567,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3C      4S
+1N     2S      3C      4S
 Pass    Pass    Pass    
 
 
@@ -6587,7 +6587,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -6605,11 +6605,11 @@ Pass    Pass    Pass
 {HCP 12 3 15 10}
 {TP 14 5 15 11}
 {Losers 7 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6626,10 +6626,10 @@ Pass    Pass
 {HCP 5 2 16 17}
 {TP 7 4 16 17}
 {Losers 8 10 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6646,11 +6646,11 @@ Pass    Pass
 {HCP 11 4 16 9}
 {TP 13 5 16 10}
 {Losers 7 10 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6667,11 +6667,11 @@ Pass    Pass
 {HCP 11 4 16 9}
 {TP 12 5 16 12}
 {Losers 8 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6688,11 +6688,11 @@ Pass    Pass
 {HCP 11 1 15 13}
 {TP 12 3 15 15}
 {Losers 8 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2S      Pass    3NT     Pass
+1N     2C      X       Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6712,7 +6712,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -6733,7 +6733,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -6754,7 +6754,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -6771,10 +6771,10 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 10 6 15 11}
 {Losers 9 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -6794,7 +6794,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -6811,10 +6811,10 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 10 3 15 16}
 {Losers 7 10 8 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
+1N     2S      2N     Pass
 Pass    Pass    
 
 
@@ -6831,11 +6831,11 @@ Pass    Pass
 {HCP 8 0 16 16}
 {TP 10 1 16 18}
 {Losers 8 11 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6852,11 +6852,11 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 5 15 15}
 {Losers 8 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6876,7 +6876,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      4H
+1N     2H      3S      4H
 4S      Pass    Pass    Pass
 
 
@@ -6894,10 +6894,10 @@ Pass    Pass
 {HCP 11 5 15 9}
 {TP 11 8 15 12}
 {Losers 8 8 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -6914,10 +6914,10 @@ Pass    Pass
 {HCP 3 4 16 17}
 {TP 4 5 17 18}
 {Losers 10 10 6 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -6934,10 +6934,10 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 10 8 15 10}
 {Losers 9 8 6 9}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6954,11 +6954,11 @@ Pass    Pass
 {HCP 10 0 16 14}
 {TP 10 1 16 16}
 {Losers 9 11 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      2NT     Pass
-3NT     Pass    Pass    Pass
+1N     2S      2N     Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -6975,11 +6975,11 @@ Pass    Pass
 {HCP 10 4 17 9}
 {TP 10 5 17 11}
 {Losers 9 9 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -6999,7 +6999,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -7020,7 +7020,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 X       Pass    3H      Pass
 4H      Pass    Pass    Pass
 
@@ -7039,10 +7039,10 @@ X       Pass    3H      Pass
 {HCP 10 2 15 13}
 {TP 11 2 15 15}
 {Losers 8 11 7 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      2NT     Pass
+1N     2H      2N     Pass
 Pass    Pass    
 
 
@@ -7062,7 +7062,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 Pass    Pass    
 
 
@@ -7082,7 +7082,7 @@ Pass    Pass
 [Contract "5HX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    X       Pass    4S
 Pass    Pass    5H      X
 Pass    Pass    Pass    
@@ -7104,7 +7104,7 @@ Pass    Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -7124,7 +7124,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -7145,7 +7145,7 @@ Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2H      Pass
+1N     2D      2H      Pass
 Pass    Pass    
 
 
@@ -7165,7 +7165,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3NT     4H
+1N     2H      3N     4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -7186,7 +7186,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -7204,10 +7204,10 @@ Pass    Pass
 {HCP 10 4 16 10}
 {TP 10 5 17 12}
 {Losers 9 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7227,7 +7227,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -7247,7 +7247,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      Pass    Pass
+1N     2C      Pass    Pass
 Pass    
 
 
@@ -7264,10 +7264,10 @@ Pass
 {HCP 10 5 15 10}
 {TP 10 5 16 12}
 {Losers 9 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7284,10 +7284,10 @@ Pass    Pass
 {HCP 11 1 17 11}
 {TP 11 3 17 13}
 {Losers 8 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7304,10 +7304,10 @@ Pass    Pass
 {HCP 8 4 15 13}
 {TP 10 5 16 15}
 {Losers 7 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -7324,11 +7324,11 @@ Pass    Pass
 {HCP 9 5 15 11}
 {TP 9 8 15 13}
 {Losers 7 8 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7345,10 +7345,10 @@ Pass    Pass
 {HCP 11 0 15 14}
 {TP 11 1 15 17}
 {Losers 8 11 8 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7368,7 +7368,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -7386,10 +7386,10 @@ Pass    Pass
 {HCP 10 3 16 11}
 {TP 10 3 16 13}
 {Losers 8 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7409,7 +7409,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3NT     4S
+1N     2S      3N     4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -7430,7 +7430,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      Pass    Pass
+1N     2C      Pass    Pass
 Pass    
 
 
@@ -7447,10 +7447,10 @@ Pass
 {HCP 12 3 15 10}
 {TP 12 5 15 12}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -7470,7 +7470,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      X       Pass    2S
 Pass    Pass    3H      Pass
 Pass    3S      Pass    Pass
@@ -7493,8 +7493,8 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    4S      Pass
+1N     2H      3H      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -7514,7 +7514,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -7532,10 +7532,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 3 16 13}
 {Losers 8 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -7552,11 +7552,11 @@ Pass    Pass
 {HCP 12 0 16 12}
 {TP 14 1 16 14}
 {Losers 6 11 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7573,11 +7573,11 @@ Pass    Pass
 {HCP 13 1 15 11}
 {TP 15 2 15 14}
 {Losers 6 11 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3D      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7597,7 +7597,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4S      Pass
+1N     2D      4S      Pass
 Pass    Pass    
 
 
@@ -7614,11 +7614,11 @@ Pass    Pass
 {HCP 14 2 15 9}
 {TP 15 3 15 10}
 {Losers 7 11 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7635,10 +7635,10 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 10 9 15 12}
 {Losers 9 7 8 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -7655,11 +7655,11 @@ Pass    Pass
 {HCP 10 0 17 13}
 {TP 11 0 17 15}
 {Losers 8 12 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3D      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -7679,7 +7679,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      2H      3H
+1N     2C      2H      3H
 Pass    Pass    3S      Pass
 Pass    4H      4S      Pass
 Pass    Pass    
@@ -7701,7 +7701,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3NT     4H
+1N     2H      3N     4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -7722,7 +7722,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -7742,7 +7742,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3C      Pass
+1N     2D      3C      Pass
 Pass    Pass    
 
 
@@ -7762,7 +7762,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -7782,7 +7782,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3D      4H
+1N     2H      3D      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -7803,7 +7803,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -7821,10 +7821,10 @@ Pass    Pass
 {HCP 14 2 15 9}
 {TP 15 6 15 10}
 {Losers 6 7 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7844,7 +7844,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -7861,11 +7861,11 @@ Pass    Pass
 {HCP 10 2 15 13}
 {TP 12 4 15 15}
 {Losers 7 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2S      Pass    3NT     Pass
+1N     2C      X       Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7882,10 +7882,10 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 12 8 15 10}
 {Losers 7 7 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -7902,10 +7902,10 @@ Pass    Pass
 {HCP 13 1 15 11}
 {TP 13 3 15 12}
 {Losers 8 10 5 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -7925,7 +7925,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -7945,7 +7945,7 @@ Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -7962,10 +7962,10 @@ Pass    Pass
 {HCP 12 0 16 12}
 {TP 12 2 17 13}
 {Losers 9 10 6 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -7982,10 +7982,10 @@ Pass    Pass
 {HCP 10 5 16 9}
 {TP 10 7 16 11}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -8002,10 +8002,10 @@ Pass    Pass
 {HCP 10 5 15 10}
 {TP 11 6 15 13}
 {Losers 8 10 7 5}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      2NT     Pass
+1N     2D      2N     Pass
 Pass    Pass    
 
 
@@ -8025,7 +8025,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -8045,7 +8045,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -8062,11 +8062,11 @@ Pass
 {HCP 13 2 16 9}
 {TP 13 2 16 10}
 {Losers 7 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2S      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2S      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8086,7 +8086,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2S      Pass
+1N     2D      2S      Pass
 Pass    X       Pass    3D
 Pass    Pass    3S      Pass
 Pass    Pass    
@@ -8108,7 +8108,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3H      4S
+1N     2S      3H      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -8129,7 +8129,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     X       2H      Pass
+1N     X       2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -8147,10 +8147,10 @@ Pass    Pass
 {HCP 3 6 15 16}
 {TP 6 6 15 16}
 {Losers 8 9 7 6}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -8170,7 +8170,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2H      Pass
+1N     2D      2H      Pass
 Pass    Pass    
 
 
@@ -8190,7 +8190,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -8208,11 +8208,11 @@ Pass    Pass
 {HCP 11 5 15 9}
 {TP 11 7 15 11}
 {Losers 8 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8232,7 +8232,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -8252,7 +8252,7 @@ Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8273,7 +8273,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      4H      Pass
+1N     2D      4H      Pass
 Pass    Pass    
 
 
@@ -8293,7 +8293,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    3H      3S      Pass
 Pass    Pass    
 
@@ -8311,10 +8311,10 @@ Pass    Pass
 {HCP 8 3 16 13}
 {TP 9 5 17 15}
 {Losers 8 9 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -8334,7 +8334,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3D      Pass
+1N     2D      3D      Pass
 3H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8355,7 +8355,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -8372,10 +8372,10 @@ Pass    Pass
 {HCP 11 0 17 12}
 {TP 12 2 17 15}
 {Losers 8 10 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -8395,7 +8395,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      2S      4H
+1N     2H      2S      4H
 Pass    Pass    Pass    
 
 
@@ -8415,7 +8415,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -8435,7 +8435,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2S      4D
+1N     2D      2S      4D
 X       Pass    4H      Pass
 Pass    Pass    
 
@@ -8453,10 +8453,10 @@ Pass    Pass
 {HCP 10 6 15 9}
 {TP 11 7 15 9}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8476,8 +8476,8 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    4H      Pass
+1N     2S      3S      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -8497,7 +8497,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -8517,7 +8517,7 @@ Pass
 [Contract "3D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      2S      3D
+1N     2D      2S      3D
 Pass    Pass    Pass    
 
 
@@ -8537,7 +8537,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
+1N     Pass    2C      Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -8558,7 +8558,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -8578,7 +8578,7 @@ Pass    Pass
 [Contract "2C"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      Pass    Pass
+1N     2C      Pass    Pass
 Pass    
 
 
@@ -8598,7 +8598,7 @@ Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2H      Pass
+1N     2D      2H      Pass
 Pass    X       Pass    3D
 Pass    Pass    3H      Pass
 Pass    Pass    
@@ -8620,7 +8620,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3D      4H
+1N     2H      3D      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -8638,10 +8638,10 @@ Pass    Pass
 {HCP 10 4 15 11}
 {TP 11 5 15 11}
 {Losers 7 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -8661,7 +8661,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2D      2H      Pass
+1N     2D      2H      Pass
 Pass    X       Pass    3C
 Pass    Pass    Pass    
 
@@ -8679,10 +8679,10 @@ Pass    Pass    Pass
 {HCP 10 1 17 12}
 {TP 11 2 18 15}
 {Losers 8 11 5 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -8702,7 +8702,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3C      Pass
+1N     2S      3C      Pass
 Pass    Pass    
 
 
@@ -8722,7 +8722,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -8739,11 +8739,11 @@ Pass    Pass
 {HCP 11 1 15 13}
 {TP 11 3 15 15}
 {Losers 9 10 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2H      Pass    3NT     Pass
+1N     2C      X       Pass
+2H      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -8763,7 +8763,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    4S      Pass
+1N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -8783,7 +8783,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    Pass    
 
 
@@ -8803,7 +8803,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      2NT     4H
+1N     2H      2N     4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -8824,7 +8824,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    Pass    
 
 
@@ -8844,8 +8844,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3S      Pass
-3NT     Pass    4S      Pass
+1N     2H      3S      Pass
+3N     Pass    4S      Pass
 Pass    Pass    
 
 
@@ -8865,7 +8865,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2H      Pass    4H      Pass
 Pass    Pass    
 
@@ -8886,7 +8886,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3H      4H
+1N     2H      3H      4H
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -8904,10 +8904,10 @@ Pass    Pass
 {HCP 10 1 15 14}
 {TP 10 4 15 15}
 {Losers 9 9 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -8927,9 +8927,9 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2D      2S      Pass
+1N     2D      2S      Pass
 Pass    3C      Pass    3H
-Pass    3NT     Pass    4H
+Pass    3N     Pass    4H
 Pass    Pass    Pass    
 
 
@@ -8946,11 +8946,11 @@ Pass    Pass    Pass
 {HCP 10 2 17 11}
 {TP 11 2 17 11}
 {Losers 8 11 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3D      Pass
-3NT     Pass    Pass    Pass
+1N     2D      3D      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -8970,7 +8970,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -8990,7 +8990,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -9011,7 +9011,7 @@ Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -9031,7 +9031,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 X       Pass    3C      Pass
 Pass    Pass    
 
@@ -9052,8 +9052,8 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
-3NT     Pass    4H      Pass
+1N     2D      3H      Pass
+3N     Pass    4H      Pass
 Pass    Pass    
 
 
@@ -9073,7 +9073,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      4S      Pass
+1N     2H      4S      Pass
 Pass    Pass    
 
 
@@ -9093,7 +9093,7 @@ Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -9110,11 +9110,11 @@ Pass
 {HCP 12 1 15 12}
 {TP 12 3 15 13}
 {Losers 7 10 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9134,7 +9134,7 @@ Pass
 [Contract "5CX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2C      X       2NT
+1N     2C      X       2N
 Pass    3C      3D      Pass
 3H      Pass    3S      Pass
 4S      X       Pass    5C
@@ -9155,10 +9155,10 @@ X       Pass    Pass    Pass
 {HCP 11 1 15 13}
 {TP 12 1 16 16}
 {Losers 7 12 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -9175,10 +9175,10 @@ Pass    Pass
 {HCP 14 0 15 11}
 {TP 14 2 15 12}
 {Losers 7 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -9198,7 +9198,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2C      2H      Pass
+1N     2C      2H      Pass
 2S      X       Pass    3D
 Pass    Pass    Pass    
 
@@ -9216,10 +9216,10 @@ Pass    Pass    Pass
 {HCP 11 4 15 10}
 {TP 12 4 15 10}
 {Losers 8 10 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9236,10 +9236,10 @@ Pass    Pass
 {HCP 11 4 16 9}
 {TP 11 7 16 11}
 {Losers 8 8 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -9259,7 +9259,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9280,8 +9280,8 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      X       Pass
-2H      Pass    3NT     Pass
+1N     2C      X       Pass
+2H      Pass    3N     Pass
 4S      Pass    Pass    Pass
 
 
@@ -9299,10 +9299,10 @@ Pass    Pass
 {HCP 12 4 15 9}
 {TP 15 5 15 12}
 {Losers 5 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -9322,7 +9322,7 @@ Pass    Pass
 [Contract "5D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      2H      4D
+1N     2D      2H      4D
 Pass    Pass    4H      Pass
 Pass    X       Pass    5D
 Pass    Pass    Pass    
@@ -9341,11 +9341,11 @@ Pass    Pass    Pass
 {HCP 12 1 16 11}
 {TP 14 4 16 13}
 {Losers 6 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
-3NT     Pass    Pass    Pass
+1N     2H      3H      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9362,10 +9362,10 @@ Pass    Pass    Pass
 {HCP 4 5 15 16}
 {TP 5 5 15 16}
 {Losers 10 10 8 5}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9382,10 +9382,10 @@ Pass    Pass    Pass
 {HCP 11 3 15 11}
 {TP 11 4 15 13}
 {Losers 7 9 8 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -9405,7 +9405,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      Pass    2S      Pass
 Pass    Pass    
 
@@ -9426,7 +9426,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    3H      Pass    4H
 Pass    Pass    Pass    
 
@@ -9447,7 +9447,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -9465,10 +9465,10 @@ Pass    Pass
 {HCP 12 2 15 11}
 {TP 13 5 15 13}
 {Losers 8 8 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -9485,11 +9485,11 @@ Pass    Pass
 {HCP 11 3 15 11}
 {TP 12 4 15 12}
 {Losers 8 10 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2C      Pass
-2D      Pass    3NT     Pass
+1N     Pass    2C      Pass
+2D      Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9509,7 +9509,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     Pass    2D      Pass
+1N     Pass    2D      Pass
 2H      X       Pass    2S
 Pass    Pass    Pass    
 
@@ -9527,10 +9527,10 @@ Pass    Pass    Pass
 {HCP 3 4 17 16}
 {TP 6 5 17 16}
 {Losers 8 9 7 7}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9547,10 +9547,10 @@ Pass    Pass    Pass
 {HCP 11 1 16 12}
 {TP 12 1 16 14}
 {Losers 7 12 6 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -9570,7 +9570,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3D      Pass
+1N     2S      3D      Pass
 Pass    Pass    
 
 
@@ -9590,7 +9590,7 @@ Pass    Pass
 [Contract "4SX"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      3C      4S
+1N     2S      3C      4S
 Pass    Pass    X       Pass
 Pass    Pass    
 
@@ -9608,10 +9608,10 @@ Pass    Pass
 {HCP 8 1 15 16}
 {TP 10 1 15 18}
 {Losers 7 12 7 5}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -9628,10 +9628,10 @@ Pass    Pass
 {HCP 10 3 15 12}
 {TP 11 4 16 14}
 {Losers 8 9 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3NT     Pass
+1N     2H      3N     Pass
 Pass    Pass    
 
 
@@ -9651,7 +9651,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -9671,7 +9671,7 @@ Pass
 [Contract "2S"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2D      Pass    2S
+1N     2D      Pass    2S
 Pass    Pass    Pass    
 
 
@@ -9691,7 +9691,7 @@ Pass    Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    Pass    
 
 
@@ -9708,11 +9708,11 @@ Pass    Pass
 {HCP 11 4 15 10}
 {TP 11 5 16 11}
 {Losers 8 9 7 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
-3NT     Pass    Pass    Pass
+1N     2S      3S      Pass
+3N     Pass    Pass    Pass
 
 
 
@@ -9732,7 +9732,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2S      3H      Pass
+1N     2S      3H      Pass
 Pass    Pass    
 
 
@@ -9749,10 +9749,10 @@ Pass    Pass
 {HCP 13 1 17 9}
 {TP 13 4 17 11}
 {Losers 7 9 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -9769,10 +9769,10 @@ Pass    Pass
 {HCP 11 3 15 11}
 {TP 11 4 16 13}
 {Losers 9 10 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2D      3NT     Pass
+1N     2D      3N     Pass
 Pass    Pass    
 
 
@@ -9792,7 +9792,7 @@ Pass    Pass
 [Contract "2S"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2S      Pass    Pass
+1N     2S      Pass    Pass
 Pass    
 
 
@@ -9812,7 +9812,7 @@ Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -9832,7 +9832,7 @@ Pass
 [Contract "2S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    2H      Pass
+1N     Pass    2H      Pass
 2S      Pass    Pass    Pass
 
 
@@ -9850,10 +9850,10 @@ Pass
 {HCP 12 2 16 10}
 {TP 12 3 17 10}
 {Losers 8 11 6 8}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    3NT     Pass
+1N     Pass    3N     Pass
 Pass    Pass    
 
 
@@ -9870,10 +9870,10 @@ Pass    Pass
 {HCP 14 0 15 11}
 {TP 14 3 16 12}
 {Losers 6 9 7 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -9890,10 +9890,10 @@ Pass    Pass
 {HCP 1 8 15 16}
 {TP 2 10 15 16}
 {Losers 10 7 7 8}
-[Contract "1NT"]
+[Contract "1N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     Pass    Pass    Pass
+1N     Pass    Pass    Pass
 
 
 
@@ -9913,7 +9913,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2C      X       Pass
+1N     2C      X       Pass
 2D      Pass    2H      Pass
 4H      Pass    Pass    Pass
 
@@ -9935,7 +9935,7 @@ Pass    Pass
 [Contract "4H"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3S      Pass
+1N     2S      3S      Pass
 4H      Pass    Pass    Pass
 
 
@@ -9956,7 +9956,7 @@ Pass    Pass
 [Contract "3H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      2H      Pass
+1N     2D      2H      Pass
 Pass    X       Pass    3C
 Pass    Pass    3H      Pass
 Pass    Pass    
@@ -9978,7 +9978,7 @@ Pass    Pass
 [Contract "3S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    3C      Pass    3H
 Pass    Pass    3S      Pass
 Pass    Pass    
@@ -10000,7 +10000,7 @@ Pass    Pass
 [Contract "4HX"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      X       Pass    Pass
 Pass    
 
@@ -10021,7 +10021,7 @@ Pass
 [Contract "4H"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3H      Pass
+1N     2D      3H      Pass
 4H      Pass    Pass    Pass
 
 
@@ -10042,7 +10042,7 @@ Pass
 [Contract "3D"]
 [Declarer "E"]
 [Auction "S"]
-1NT     2H      2S      Pass
+1N     2H      2S      Pass
 Pass    X       Pass    3D
 Pass    Pass    Pass    
 
@@ -10063,7 +10063,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2D      3S      Pass
+1N     2D      3S      Pass
 4S      Pass    Pass    Pass
 
 
@@ -10081,11 +10081,11 @@ Pass    Pass    Pass
 {HCP 2 7 15 16}
 {TP 5 10 15 17}
 {Losers 8 6 8 6}
-[Contract "2NT"]
+[Contract "2N"]
 [Declarer "E"]
 [Auction "S"]
-1NT     X       2D      Pass
-2H      Pass    Pass    2NT
+1N     X       2D      Pass
+2H      Pass    Pass    2N
 Pass    Pass    Pass    
 
 
@@ -10105,7 +10105,7 @@ Pass    Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10126,7 +10126,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2H      3H      Pass
+1N     2H      3H      Pass
 3S      Pass    4S      Pass
 Pass    Pass    
 
@@ -10147,7 +10147,7 @@ Pass    Pass
 [Contract "4D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      3C      4D
+1N     2D      3C      4D
 Pass    Pass    Pass    
 
 
@@ -10167,7 +10167,7 @@ Pass    Pass    Pass
 [Contract "2H"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2H      Pass    Pass
+1N     2H      Pass    Pass
 Pass    
 
 
@@ -10184,10 +10184,10 @@ Pass
 {HCP 10 1 17 12}
 {TP 10 2 18 13}
 {Losers 9 11 6 7}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2S      3NT     Pass
+1N     2S      3N     Pass
 Pass    Pass    
 
 
@@ -10207,7 +10207,7 @@ Pass    Pass
 [Contract "2D"]
 [Declarer "W"]
 [Auction "S"]
-1NT     2D      Pass    Pass
+1N     2D      Pass    Pass
 Pass    
 
 
@@ -10224,10 +10224,10 @@ Pass
 {HCP 12 4 15 9}
 {TP 12 6 15 12}
 {Losers 8 8 7 6}
-[Contract "3NT"]
+[Contract "3N"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      3NT     Pass
+1N     2C      3N     Pass
 Pass    Pass    
 
 
@@ -10247,7 +10247,7 @@ Pass    Pass
 [Contract "3D"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3D      Pass
+1N     2H      3D      Pass
 Pass    Pass    
 
 
@@ -10267,7 +10267,7 @@ Pass    Pass
 [Contract "3C"]
 [Declarer "N"]
 [Auction "S"]
-1NT     2H      3C      Pass
+1N     2H      3C      Pass
 Pass    Pass    
 
 
@@ -10287,7 +10287,7 @@ Pass    Pass
 [Contract "4S"]
 [Declarer "S"]
 [Auction "S"]
-1NT     2C      2H      4C
+1N     2C      2H      4C
 X       Pass    4D      Pass
 4S      Pass    Pass    Pass
 

--- a/js/gib-capture.mjs
+++ b/js/gib-capture.mjs
@@ -54,6 +54,11 @@ export default async function ({ page, ctx, say }) {
   const readLog = () => page.evaluate(() => localStorage.getItem('PBNcapture') || '');
   const records = log => log.split(/\n(?=\[Event )/).map(r => r.trim()).filter(r => r.startsWith('[Event '));
   const boardOf = rec => parseInt((rec.match(/^\[Board "(\d+)"\]/m) || [])[1], 10) || 0;
+  // PBNcapture writes notrump as "1NT"; BBA writes "1N", in the auction and
+  // the contract alike. Store captures the BBA way, so one auction-filter works
+  // on both. A record has no other digit-then-NT text (the contract "3NTX"
+  // becomes "3NX", as BBA writes it).
+  const bbaNotation = rec => rec.replace(/([1-7])NT/g, '$1N');
 
   const setCapture = (enable, redeals) => inPbs(a => {
     const sel = document.getElementById('bboalert-menu-config');
@@ -155,7 +160,7 @@ export default async function ({ page, ctx, say }) {
       if (recs.length > have) {
         have = recs.length;
         kicks = 0;
-        writeFileSync(job.partialPbn, recs.slice(0, job.boards).join('\n\n') + '\n');
+        writeFileSync(job.partialPbn, recs.slice(0, job.boards).map(bbaNotation).join('\n\n') + '\n');
         if (have % 10 === 0 || have >= job.boards) note(`${Math.min(have, job.boards)}/${job.boards} boards`);
         if (delayMs && have < job.boards) {
           await page.waitForTimeout(delayMs);


### PR DESCRIPTION
Part of #323. Follows #324.

## Why

The PBNcapture plugin writes notrump as `1NT`; BBA writes `1N`, both in the auction and in `[Contract]`. So a filter written for BBA auctions (86 of them mention a notrump bid) could not match a GIB capture: `1N Pass` never matches `1NT     Pass`. Storing GIB captures the BBA way means one `auction-filter` works on both, with no parallel GIB filters to maintain.

## What

- `js/gib-capture.mjs` rewrites `[1-7]NT` → `[1-7]N` as it saves each board. A record has no other digit-then-`NT` text; a doubled `3NTX` becomes `3NX`, which is how BBA writes it. Checked with a live 10-board Smolen capture: no `NT` left, contracts `3N`.
- All 65 existing files in `GIB/` converted the same way. The diff is large but mechanical: only `[Contract]` tags (5,239 lines) and auction lines (14,102) change. Deals, board numbers and everything else are untouched.
- The four `GIB-report/` outputs regenerated from the converted captures. Their match rates are unchanged, since none of those filters involves a notrump bid.
- `CLAUDE.md`: `GIB/` is stored in BBA notation.

## Next

Rewrite the 40 `auction-filter`s that anchor on BBA `Note` tags into auction-only form, accepting each only if it selects the same boards from `bba/<name>.pbn` as the Note version. BBA filter output, and everything built from it, then stays unchanged. The one remaining format difference is BBA's inline alert markers (`2C =1=`), which a filter allows for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
