### PR TITLE
Add the level operation: leveled scripts win downstream (#322)

### DIFF
--- a/.github/workflows/build-manifest.yml
+++ b/.github/workflows/build-manifest.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'btn/**'
       - 'dlr/**'
+      - 'dlr-leveled/**'
       - 'coaching-non-rotated/**'
       - 'py/build_manifest.py'
       - 'py/board_version_token.py'

--- a/.github/workflows/check-leveled.yml
+++ b/.github/workflows/check-leveled.yml
@@ -1,0 +1,35 @@
+name: Check leveled scripts
+
+# Issue #322: the level operation writes dlr-leveled/<name>.dlr from
+# dlr/<name>.dlr and stamps it with that file's hash. Fail when a leveled file
+# no longer matches its dlr, or a scenario that declares hand types has none.
+# The check is a hash comparison, so it needs no dealer3.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dlr/**'
+      - 'dlr-leveled/**'
+      - 'build-scripts-mac/utils/leveling.py'
+      - '.github/workflows/check-leveled.yml'
+  pull_request:
+    paths:
+      - 'dlr/**'
+      - 'dlr-leveled/**'
+      - 'build-scripts-mac/utils/leveling.py'
+      - '.github/workflows/check-leveled.yml'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check leveled scripts against their sources
+        run: python3 build-scripts-mac/utils/leveling.py --check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,14 +88,17 @@ python3 pbs-pipeline-mac.py "Weak_2_Bids" "pbn"
 
 Pipeline operations in order:
 1. `dlr` - Extract dealer code from the `.btn` master file
-2. `pbn` - Generate hands using dealer
-3. `rotate` - Create 4-player rotations (PBN and LIN formats)
-4. `bba` - Analyze bidding with Bridge Base Archive
-5. `filter` - Filter by auction patterns
-6. `filterStats` - Generate statistics
-7. `biddingSheet` - Generate PDF bidding sheets
+2. `level` - Write `dlr-leveled/<name>.dlr` for a scenario that declares hand types (`HandType_*`)
+3. `pbn` - Generate hands using dealer
+4. `rotate` - Create 4-player rotations (PBN and LIN formats)
+5. `bba` - Analyze bidding with Bridge Base Archive
+6. `filter` - Filter by auction patterns
+7. `filterStats` - Generate statistics
+8. `biddingSheet` - Generate PDF bidding sheets
 
-The default `*` order continues past `biddingSheet` with `quiz` (generate quiz PBN/PDF/JSON) and `package` (copy artifacts into the Bidding Scenarios hierarchy). The `release` and `release-layout` operations are NOT in the default order — invoke them explicitly. `release` publishes a scenario: it regenerates the `.dlr`, commits the `.btn` and `.dlr` (only those two files), and pushes `main`. It refuses to run on any other branch. `release-layout` copies `btn/-button-layout-beta.txt` over `-button-layout-release.txt` and pushes; the two layout files decide which buttons each channel shows. To try a script before releasing it, use `bbo-demo`, which loads the local `.dlr` into BBO without going through GitHub.
+**Leveling (issue #322).** `level` runs `dealer3 --write-leveled` on a `.dlr` that names `HandType_*` variables. It skips every other scenario, and removes leftover leveled files when a scenario stops declaring hand types. Where `dlr-leveled/<name>.dlr` exists, it wins downstream. `pbn` writes both `pbn/<name>.pbn` (the natural mix) and `pbn-leveled/<name>.pbn` (interleaved by hand type). `rotate`, `bba`, `gib`, `package` and the manifest read the leveled files. One resolver decides this: `leveled_or_original()` in `build-scripts-mac/utils/leveling.py`. The leveled file's first line stamps the sha256 of the `.dlr` it came from. `level` skips a file that is still current, `pbn` refuses a stale one, and the `check-leveled` workflow fails CI on either a stale file or a missing one. `# level-budget: N` in a `.btn` caps the leveling cost.
+
+The default `*` order continues past `biddingSheet` with `quiz` (generate quiz PBN/PDF/JSON) and `package` (copy artifacts into the Bidding Scenarios hierarchy). The `release` and `release-layout` operations are NOT in the default order — invoke them explicitly. `release` publishes a scenario: it regenerates and levels the `.dlr`, commits the `.btn`, the `.dlr` and `dlr-leveled/<name>.dlr` if there is one (only those files), and pushes `main`. It refuses to run on any other branch. `release-layout` copies `btn/-button-layout-beta.txt` over `-button-layout-release.txt` and pushes; the two layout files decide which buttons each channel shows. To try a script before releasing it, use `bbo-demo`, which loads the local `.dlr` into BBO without going through GitHub.
 
 `gib` and `gibReport` are also explicit-only. They are a **report on how well a scenario matches GIB**, not a second lesson pipeline; BBA stays the source everything downstream is built from. `gib` runs `py/gib_capture.py`, which has BBO's robots bid 30 deals from the scenario's `.dlr` on a live account (Mac, Playwright test profile), replaces `GIB/<name>.pbn`, then runs `gibReport`. `gibReport` filters that capture by the `auction-filter` into `GIB-filtered/` and `GIB-filtered-out/` (PBN + PDF) and writes `GIB-report/<name>.md` plus `GIB-report/-summary.md`. It touches only local files, so it also works on the hand-collected captures. `bbo-demo` (also explicit-only; `py/gib_capture.py --demo`) sets up the same four-robot table with the scenario's script loaded and captures nothing. It leaves the browser open so a person can test the script by hand: redealing, reading the robots' bid explanations. Closing the BBO tab ends it. The pipeline refuses `gib` or `bbo-demo` on more than one scenario at a time: we are guests on BBO, so keep live runs to about 30 boards. The 40 filters that anchor on BBA `Note` tags match nothing in a GIB capture; the report flags them.
 
@@ -122,8 +125,10 @@ The system follows a linear transformation pipeline:
 btn file (master scenario definition: dealer code + button metadata)
     ↓ [dlr] Extract dealer code
 dlr file (dealer language constraints; what BBO loads, published by [release] = git push)
+    ↓ [level] dealer3 --write-leveled, only for scripts that declare HandType_ variables
+dlr-leveled file (wins downstream wherever it exists)
     ↓ [pbn] Generate hands via dealer (500 per scenario)
-pbn file (Portable Bridge Notation)
+pbn file (Portable Bridge Notation; pbn-leveled/ too, when leveled)
     ↓ [rotate] Create 4-player rotations
 pbn-rotated & lin-rotated files
     ↓ [bba] Analyze bidding with BBA
@@ -175,6 +180,8 @@ Extension provides:
 
 **Generated (Intermediate):**
 - `dlr/` - Extracted dealer code
+- `dlr-leveled/` - Leveled copies of the `.dlr` files that declare hand types, from the `level` operation (issue #322). Committed, stamped with their source's hash; where one exists it wins downstream
+- `pbn-leveled/` - Hands dealt from `dlr-leveled/`, interleaved by hand type; `pbn/` keeps the natural mix beside them
 - `pbs-release/` - **Frozen.** The `.pbs` files older BBO extension sessions load. Nothing writes it any more (issue #321); delete it once those sessions have turned over. `pbs-test/` and the `pbs` operation are gone.
 - `pbn/` - Bridge Portable Notation files (~500 hands each)
 - `pbn-rotated-for-4-players/` - Rotated PBN for 4-player practice
@@ -189,7 +196,7 @@ Extension provides:
 **Generated (Final Output):**
 - `bidding-sheets/` - PDF bidding sheets for practice
 - `quiz/` - Bidding quizzes in three forms, all from the `quiz` operation: `{Scenario}.pbn` (print layout), `{Scenario}.pdf`, and `{Scenario}.json` — one `quiz-lesson/v1` file per scenario, plus an `index.json` manifest. The JSON is hierarchical (lesson → exercise, which owns the shared prompt → question, a hand + its answer) and is what lesson-studio embeds by value. Its shape is fixed by Contract 3 (`documentation/contracts/quiz-json-schema.md` in the lesson-studio repo), so change it there first. **Generated — never hand-edit.**
-- `manifest/` - Pre-built deal-source menu manifests (`manifest-{release,beta}.json`), generated by `py/build_manifest.py` via a GitHub Action so the BBO extension / Bridge Classroom build their menu from ONE fetch; on a click they fetch `dlr/<name>.dlr`. **Generated — never hand-edit** (see `manifest/README.md`).
+- `manifest/` - Pre-built deal-source menu manifests (`manifest-{release,beta}.json`), generated by `py/build_manifest.py` via a GitHub Action so the BBO extension / Bridge Classroom build their menu from ONE fetch; on a click they fetch the scenario's `dlr` path (`dlr-leveled/<name>.dlr` when leveled, else `dlr/<name>.dlr`). **Generated — never hand-edit** (see `manifest/README.md`).
 
 **Source Code:**
 - `build-scripts-mac/` - Python pipeline orchestration and operations

--- a/build-scripts-mac/config.py
+++ b/build-scripts-mac/config.py
@@ -83,7 +83,10 @@ FOLDERS = {
     "btn": os.path.join(PROJECT_ROOT, "btn"),
     "pbs": os.path.join(PROJECT_ROOT, "PBS"),
     "dlr": os.path.join(PROJECT_ROOT, "dlr"),
+    # Leveled copies (issue #322); where one exists it wins downstream
+    "dlr_leveled": os.path.join(PROJECT_ROOT, "dlr-leveled"),
     "pbn": os.path.join(PROJECT_ROOT, "pbn"),
+    "pbn_leveled": os.path.join(PROJECT_ROOT, "pbn-leveled"),
     "pbn_rotated": os.path.join(PROJECT_ROOT, "pbn-rotated-for-4-players"),
     "lin_rotated": os.path.join(PROJECT_ROOT, "lin-rotated-for-4-players"),
     "bba": os.path.join(PROJECT_ROOT, "bba"),
@@ -144,6 +147,12 @@ SEED_OFFSET = 1          # Increment to regenerate all scenarios with fresh deal
 DEALER_GENERATE = 300000000
 DEALER_PRODUCE = 500
 
+# Leveling parameters (the level operation, issue #322). The seed is fixed so a
+# rebuild is byte-identical. The timeout is set well past what measuring takes,
+# because a run the clock stops won't reproduce.
+LEVEL_SEED = 1
+LEVEL_TIMEOUT = 600      # seconds
+
 # Bidding sheet parameters
 BIDDING_SHEET_MAX_BOARDS = 50  # Max boards to include in bidding sheets PDF
 
@@ -157,6 +166,7 @@ def dealer_seed(scenario: str) -> int:
 # Pipeline operations in order
 OPERATIONS_ORDER = [
     "dlr",      # Generate DLR from BTN
+    "level",    # Leveled DLR, for a scenario that declares hand types (issue #322)
     "pbn",
     "rotate",
     "bba",

--- a/build-scripts-mac/operations/bba_from_pbn.py
+++ b/build-scripts-mac/operations/bba_from_pbn.py
@@ -17,6 +17,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from config import FOLDERS, MAC_TOOLS, PROJECT_ROOT
 from utils.properties import get_convention_card_ns, get_convention_card_ew
 from operations.title import get_title_from_pbs
+from utils.leveling import leveled_or_original
 
 # Timeout for BBA completion
 BBA_TIMEOUT = 300
@@ -107,8 +108,11 @@ def run_bba(scenario: str, verbose: bool = True, output_dir: str = None) -> bool
     Returns:
         True if successful, False otherwise
     """
+    # pbn-leveled/ when the scenario is leveled (issue #322)
+    pbn_path = leveled_or_original(scenario, "pbn")
     if verbose:
-        print(f"--------- bba-cli: Creating bba/{scenario}.pbn from pbn/{scenario}.pbn")
+        print(f"--------- bba-cli: Creating bba/{scenario}.pbn from "
+              f"{os.path.relpath(pbn_path, PROJECT_ROOT)}")
 
     bba_cli = MAC_TOOLS.get("bba_cli")
     if not bba_cli or not os.path.exists(bba_cli):
@@ -116,7 +120,6 @@ def run_bba(scenario: str, verbose: bool = True, output_dir: str = None) -> bool
         print(f"  Install from https://github.com/Rick-Wilson/BBA-Tools/releases (.dmg)")
         return False
 
-    pbn_path = os.path.join(FOLDERS["pbn"], f"{scenario}.pbn")
     if not os.path.exists(pbn_path):
         print(f"Error: PBN file not found: {pbn_path}")
         return False

--- a/build-scripts-mac/operations/level.py
+++ b/build-scripts-mac/operations/level.py
@@ -1,0 +1,198 @@
+"""
+Level operation (issue #322): generate the leveled copy of a scenario that
+declares hand types.
+
+    dlr/{scenario}.dlr -> dlr-leveled/{scenario}.dlr
+
+dealer3 measures how often each HandType_ comes up, and writes a copy whose
+condition keeps each type at the rate that evens out the mix (see
+docs/leveling-guide.md in the dealer3 repo). From then on the leveled file
+wins downstream; see utils/leveling.py.
+
+- A scenario with no HandType_ variables is skipped, and any leveled files it
+  left behind are removed, so they can't win over the script it has now.
+- A leveled file already made from this dlr is left alone.
+- No -p: dealer3 sizes the measurement itself, dealing until the rarest type
+  has been seen 2,000 times. The seed is fixed and the clock set well past
+  what that takes, so a rebuild is byte-identical.
+- `# level-budget: N` in the .btn caps the cost at N deals dealt per deal kept,
+  for scenarios too expensive to level exactly (e.g. Bergen_Raises).
+- dealer3 fills in the {{level-mix:...}} tokens in the chat.
+
+Then it checks the result: it deals 10,000 from the leveled file and compares
+each type's share with the mix dealer3 said the keeps would deliver.
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from config import FOLDERS, MAC_TOOLS, PROJECT_ROOT, DEALER_GENERATE, LEVEL_SEED, LEVEL_TIMEOUT
+from utils.leveling import (CURRENT, declares_hand_types, dlr_path, leveled_dlr_path,
+                            leveled_pbn_path, leveled_status, stamp_line)
+from utils.properties import get_btn_property
+
+VERIFY_DEALS = 10000
+# 10,000 deals land a share within about 1 point of its mix; allow 2 before
+# calling the leveling wrong
+VERIFY_TOLERANCE = 0.02
+
+# A row of the summary dealer3 prints to stderr:
+#   type     natural    target       mix     keep      seen
+#   12_14    0.58301   0.20000   0.20000   0.0217     92304
+MIX_ROW = re.compile(r"^\s+(\S+)\s+[\d.]+\s+[\d.]+\s+([\d.]+)\s+[\d.]+\s+\d+\s*$")
+
+
+def _rel(path: str) -> str:
+    return os.path.relpath(path, PROJECT_ROOT)
+
+
+def _remove(path: str, verbose: bool):
+    if os.path.exists(path):
+        os.remove(path)
+        if verbose:
+            print(f"  Removed: {_rel(path)}")
+
+
+def run_level(scenario: str, verbose: bool = True) -> bool:
+    """
+    Write dlr-leveled/{scenario}.dlr from dlr/{scenario}.dlr.
+
+    Args:
+        scenario: Scenario name (e.g., "NT_Ladder")
+        verbose: Whether to print progress
+
+    Returns:
+        True if successful (including when there is nothing to level)
+    """
+    if verbose:
+        print(f"--------- dealer3: Leveling dlr/{scenario}.dlr")
+
+    source = dlr_path(scenario)
+    if not os.path.exists(source):
+        print(f"Error: level: DLR file not found: {source}")
+        return False
+
+    leveled = leveled_dlr_path(scenario)
+    if not declares_hand_types(source):
+        if verbose:
+            print(f"  No HandType_ variables; {scenario} is not leveled")
+        _remove(leveled, verbose)
+        _remove(leveled_pbn_path(scenario), verbose)
+        return True
+
+    if leveled_status(scenario) == CURRENT:
+        # Touch it, so a regenerated but unchanged dlr doesn't make it look stale
+        os.utime(leveled)
+        if verbose:
+            print(f"  Up to date: {_rel(leveled)}")
+        return True
+
+    cmd = [MAC_TOOLS["dealer"], source, "-q",
+           "-s", str(LEVEL_SEED),
+           "--level-timeout", str(LEVEL_TIMEOUT)]
+    budget = get_btn_property(scenario, "level-budget")
+    if budget:
+        cmd += ["--level-budget", budget]
+    if verbose:
+        print(f"  [Local] {' '.join(cmd)} --write-leveled {_rel(leveled)}")
+
+    # Write beside the target and move it in, so a failed run leaves no half file
+    os.makedirs(FOLDERS["dlr_leveled"], exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".", suffix=".dlr", dir=FOLDERS["dlr_leveled"])
+    os.close(fd)
+    try:
+        result = subprocess.run(cmd + ["--write-leveled", tmp], capture_output=True,
+                                text=True, timeout=LEVEL_TIMEOUT + 60)
+        report = (result.stdout + result.stderr).strip()
+        if result.returncode != 0:
+            print(f"Error: level: dealer3 failed with exit code {result.returncode}")
+            if report:
+                print(report)
+            return False
+        with open(tmp, encoding="utf-8") as f:
+            body = f.read()
+        with open(leveled, "w", encoding="utf-8") as f:
+            f.write(stamp_line(scenario) + "\n" + body)
+    except subprocess.TimeoutExpired:
+        print(f"Error: level: dealer3 still running after {LEVEL_TIMEOUT + 60} seconds")
+        return False
+    finally:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+
+    if verbose:
+        for line in report.splitlines():
+            # dealer3's "wrote <file>" names the temporary file
+            if not line.startswith("wrote "):
+                print(f"  {line}")
+        print(f"  Created: {_rel(leveled)}")
+
+    # dealer3 names the switch when the clock, not the sightings, ended the
+    # measuring. The file is still usable, but a rebuild won't reproduce it.
+    if "--level-timeout" in report:
+        print(f"  Warning: measuring {scenario} stopped on the clock, so a rebuild won't be "
+              f"byte-identical. Raise LEVEL_TIMEOUT in config.py, or set # level-budget.")
+
+    return _verify(leveled, report, verbose)
+
+
+def _verify(leveled: str, report: str, verbose: bool) -> bool:
+    """Deal VERIFY_DEALS from the leveled file and compare each hand type's
+    share with the mix in dealer3's report."""
+    mix = {}
+    for line in report.splitlines():
+        m = MIX_ROW.match(line)
+        if m:
+            mix[m.group(1)] = float(m.group(2))
+    if not mix:
+        print("Error: level: found no mix table in dealer3's report")
+        return False
+
+    cmd = [MAC_TOOLS["dealer"], leveled, "-q",
+           "-s", str(LEVEL_SEED),
+           "-g", str(DEALER_GENERATE),
+           "-p", str(VERIFY_DEALS),
+           "--stats-json"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+        shares = {t["name"]: t["share"] for t in json.loads(result.stdout)["hand_types"]}
+    except subprocess.TimeoutExpired:
+        print(f"Error: level: checking {_rel(leveled)} took over 600 seconds")
+        return False
+    except (ValueError, KeyError, TypeError):
+        print(f"Error: level: couldn't read the check run's --stats-json (exit {result.returncode})")
+        if result.stderr:
+            print(result.stderr.strip())
+        return False
+
+    if verbose:
+        print(f"  Check: {VERIFY_DEALS} deals from {_rel(leveled)}")
+    worst = 0.0
+    for name, want in mix.items():
+        got = shares.get(name, 0.0)
+        worst = max(worst, abs(got - want))
+        if verbose:
+            print(f"    {name:16} mix {want:6.1%}   dealt {got:6.1%}")
+
+    if worst > VERIFY_TOLERANCE:
+        print(f"Error: level: a hand type was dealt {worst:.1%} away from its mix "
+              f"(allowed {VERIFY_TOLERANCE:.0%}); look at the keeps in {_rel(leveled)}")
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        scenario = sys.argv[1]
+    else:
+        scenario = "NT_Ladder"
+
+    print(f"Testing level operation with scenario: {scenario}\n")
+    success = run_level(scenario)
+    print(f"\nResult: {'Success' if success else 'Failed'}")

--- a/build-scripts-mac/operations/package.py
+++ b/build-scripts-mac/operations/package.py
@@ -24,6 +24,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from config import FOLDERS, PROJECT_ROOT
+from utils.leveling import leveled_or_original
 
 # Module-level cache for the parsed layout
 _layout_cache = None
@@ -163,9 +164,13 @@ def run_package(scenario: str, verbose: bool = True) -> bool:
             src_name = src_pattern.format(scenario=scenario)
             src_path = os.path.join(FOLDERS[folder_key], src_name)
 
-            # Fallback: if bba_filtered PBN doesn't exist, try pbn/
+            # A leveled scenario ships its leveled script (issue #322)
+            if folder_key == "dlr":
+                src_path = leveled_or_original(scenario, "dlr")
+
+            # Fallback: if bba_filtered PBN doesn't exist, try pbn/ (pbn-leveled/ when leveled)
             if not os.path.exists(src_path) and folder_key == "bba_filtered" and dest_suffix == ".pbn":
-                src_path = os.path.join(FOLDERS["pbn"], f"{scenario}.pbn")
+                src_path = leveled_or_original(scenario, "pbn")
 
             if not os.path.exists(src_path):
                 continue

--- a/build-scripts-mac/operations/pbn_from_dlr.py
+++ b/build-scripts-mac/operations/pbn_from_dlr.py
@@ -2,6 +2,10 @@
 PBN operation: Generate PBN file from DLR using dealer (Mac or Windows).
 Then run oneComment.py locally to add comments.
 Finally, set correct Event tags using title from PBS file.
+
+A leveled scenario (issue #322) gets two PBN files: pbn/{scenario}.pbn from
+the natural mix, which is how you see what leveling changed, and
+pbn-leveled/{scenario}.pbn from dlr-leveled/, which rotate and bba read.
 """
 import os
 import re
@@ -12,9 +16,10 @@ import threading
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from config import FOLDERS, MAC_TOOLS, WINDOWS_TOOLS, dealer_seed, DEALER_GENERATE, DEALER_PRODUCE, DEALER_PLATFORM
+from config import FOLDERS, MAC_TOOLS, WINDOWS_TOOLS, PROJECT_ROOT, dealer_seed, DEALER_GENERATE, DEALER_PRODUCE, DEALER_PLATFORM
 from ssh_runner import run_windows_command, mac_to_windows_path
 from operations.title import run_title
+from utils.leveling import STALE, UNLEVELED, leveled_dlr_path, leveled_pbn_path, leveled_status
 
 # ANSI color codes
 RED = '\033[91m'
@@ -87,6 +92,7 @@ def run_pbn(scenario: str, verbose: bool = True) -> bool:
     Generate PBN file from DLR file using dealer.
 
     dlr/{scenario}.dlr -> pbn/{scenario}.pbn
+    dlr-leveled/{scenario}.dlr -> pbn-leveled/{scenario}.pbn, when leveled
 
     Args:
         scenario: Scenario name (e.g., "Smolen")
@@ -102,12 +108,34 @@ def run_pbn(scenario: str, verbose: bool = True) -> bool:
         return False
 
     pbn_path = os.path.join(FOLDERS["pbn"], f"{scenario}.pbn")
+    if not _make_pbn(scenario, dlr_path, pbn_path, verbose):
+        return False
+
+    status = leveled_status(scenario)
+    if status == UNLEVELED:
+        return True
+    if status == STALE:
+        print_error(f"Error: dlr-leveled/{scenario}.dlr was made from an older "
+                    f"dlr/{scenario}.dlr; run level first")
+        return False
+
+    os.makedirs(FOLDERS["pbn_leveled"], exist_ok=True)
+    # Interleaved, so any run of boards from the top walks through the hand types
+    return _make_pbn(scenario, leveled_dlr_path(scenario), leveled_pbn_path(scenario),
+                     verbose, interleave=True)
+
+
+def _make_pbn(scenario: str, dlr_path: str, pbn_path: str, verbose: bool,
+              interleave: bool = False) -> bool:
+    """Deal dlr_path into pbn_path, then add the comments and title."""
+    dlr_rel = os.path.relpath(dlr_path, PROJECT_ROOT)
+    pbn_rel = os.path.relpath(pbn_path, PROJECT_ROOT)
 
     if DEALER_PLATFORM == "mac":
         # Step 1: Run dealer locally on Mac
         # Note: dealer3 reads input from stdin, not as a file argument
         if verbose:
-            print(f"--------- dealer (Mac): Creating pbn/{scenario}.pbn from dlr/{scenario}.dlr")
+            print(f"--------- dealer (Mac): Creating {pbn_rel} from {dlr_rel}")
 
         seed = dealer_seed(scenario)
         dealer_cmd = [
@@ -118,6 +146,8 @@ def run_pbn(scenario: str, verbose: bool = True) -> bool:
             "-f", "printpbn",
             "-v",
         ]
+        if interleave:
+            dealer_cmd.append("--interleave")
 
         if verbose:
             print(f"  [Local] {' '.join(dealer_cmd)} < {dlr_path}")
@@ -193,7 +223,9 @@ def run_pbn(scenario: str, verbose: bool = True) -> bool:
     else:
         # Step 1: Run dealer.exe on Windows via SSH
         if verbose:
-            print(f"--------- dealer.exe (Windows): Creating pbn/{scenario}.pbn from dlr/{scenario}.dlr")
+            print(f"--------- dealer.exe (Windows): Creating {pbn_rel} from {dlr_rel}")
+            if interleave:
+                print("  (dealer.exe has no --interleave; boards stay in the order dealt)")
 
         # Build Windows paths
         win_dlr = mac_to_windows_path(dlr_path)
@@ -222,7 +254,7 @@ def run_pbn(scenario: str, verbose: bool = True) -> bool:
 
     # Step 2: Run oneComment.py locally to add comments
     if verbose:
-        print(f"--------- oneComment.py: Adding comments to pbn/{scenario}.pbn")
+        print(f"--------- oneComment.py: Adding comments to {pbn_rel}")
 
     py_dir = FOLDERS["py"]
     comment_script = os.path.join(py_dir, "oneComment.py")
@@ -233,7 +265,7 @@ def run_pbn(scenario: str, verbose: bool = True) -> bool:
 
     try:
         result = subprocess.run(
-            [MAC_TOOLS["python"], comment_script, "--scenario", scenario],
+            [MAC_TOOLS["python"], comment_script, "--scenario", scenario, "--pbn", pbn_path],
             cwd=py_dir,
             capture_output=True,
             text=True,
@@ -250,13 +282,12 @@ def run_pbn(scenario: str, verbose: bool = True) -> bool:
         return False
 
     # Verify output was created
-    pbn_path = os.path.join(FOLDERS["pbn"], f"{scenario}.pbn")
     if not os.path.exists(pbn_path):
         print_error(f"Error: PBN file was not created: {pbn_path}")
         return False
 
     # Step 3: Set correct Event tags from PBS file
-    run_title(scenario, verbose)
+    run_title(scenario, verbose, pbn_path)
 
     return True
 

--- a/build-scripts-mac/operations/release.py
+++ b/build-scripts-mac/operations/release.py
@@ -6,9 +6,11 @@ The BBO extension and Bridge Classroom load dlr/<name>.dlr from main, so a push
 to main is the release (issue #321). Which buttons each channel shows is still
 set by btn/-button-layout-{release,beta}.txt; see release-layout.
 
-The .dlr is regenerated from the .btn first, so what ships always matches the
-master file. Only those two files are committed; anything else staged or
-modified in the tree is left alone.
+The .dlr is regenerated from the .btn first, and then leveled (issue #322), so
+what ships always matches the master file. Only those files are committed:
+the .btn, the .dlr, and dlr-leveled/<name>.dlr when the scenario is leveled
+(or its removal, when it no longer is). Anything else staged or modified in
+the tree is left alone.
 
 This operation is intentionally NOT included in OPERATIONS_ORDER,
 so it won't run with "*" or "op+" wildcards. It must be invoked explicitly.
@@ -22,6 +24,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from config import FOLDERS, PROJECT_ROOT
 from operations.dlr_from_btn import run_dlr
+from operations.level import run_level
+from utils.leveling import leveled_dlr_path
 
 
 def _git(*args):
@@ -49,18 +53,23 @@ def run_release(scenario: str, verbose: bool = True) -> bool:
         print(f"Error: release: on branch '{branch}'; release pushes main")
         return False
 
-    if not run_dlr(scenario, verbose):
+    if not run_dlr(scenario, verbose) or not run_level(scenario, verbose):
         return False
 
     paths = [
         os.path.relpath(os.path.join(FOLDERS["btn"], f"{scenario}.btn"), PROJECT_ROOT),
         os.path.relpath(os.path.join(FOLDERS["dlr"], f"{scenario}.dlr"), PROJECT_ROOT),
     ]
+    # The leveled copy ships with it, or its deletion does when level removed it
+    leveled = os.path.relpath(leveled_dlr_path(scenario), PROJECT_ROOT)
+    if os.path.exists(leveled_dlr_path(scenario)) or \
+            _git("ls-files", "--error-unmatch", "--", leveled).returncode == 0:
+        paths.append(leveled)
 
     original_dir = os.getcwd()
     os.chdir(PROJECT_ROOT)
     try:
-        result = _git("add", "--", *paths)
+        result = _git("add", "-A", "--", *paths)
         if result.returncode != 0:
             print(f"  Git add failed: {result.stderr.strip()}")
             return False

--- a/build-scripts-mac/operations/rotate.py
+++ b/build-scripts-mac/operations/rotate.py
@@ -10,7 +10,8 @@ import sys
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from config import FOLDERS, MAC_TOOLS
+from config import FOLDERS, MAC_TOOLS, PROJECT_ROOT
+from utils.leveling import leveled_or_original
 
 
 def run_rotate(scenario: str, verbose: bool = True) -> bool:
@@ -20,6 +21,8 @@ def run_rotate(scenario: str, verbose: bool = True) -> bool:
     pbn/{scenario}.pbn -> pbn-rotated-for-4-players/{scenario}.pbn
                        -> lin-rotated-for-4-players/{scenario}.lin
 
+    Reads pbn-leveled/{scenario}.pbn instead when the scenario is leveled.
+
     Args:
         scenario: Scenario name (e.g., "Smolen")
         verbose: Whether to print progress
@@ -27,11 +30,12 @@ def run_rotate(scenario: str, verbose: bool = True) -> bool:
     Returns:
         True if successful, False otherwise
     """
+    pbn_path = leveled_or_original(scenario, "pbn")
     if verbose:
-        print(f"--------- bridge-wrangler: Creating rotated files for {scenario}")
+        print(f"--------- bridge-wrangler: Creating rotated files for {scenario} "
+              f"from {os.path.relpath(pbn_path, PROJECT_ROOT)}")
 
     # Check that PBN file exists
-    pbn_path = os.path.join(FOLDERS["pbn"], f"{scenario}.pbn")
     if not os.path.exists(pbn_path):
         print(f"Error: rotate: PBN file not found: {pbn_path}")
         return False

--- a/build-scripts-mac/operations/title.py
+++ b/build-scripts-mac/operations/title.py
@@ -44,7 +44,7 @@ def get_title_from_pbs(scenario: str) -> str:
     return scenario
 
 
-def run_title(scenario: str, verbose: bool = True) -> bool:
+def run_title(scenario: str, verbose: bool = True, pbn_path: str = None) -> bool:
     """
     Update title metadata in the PBN file with the title from PBS.
 
@@ -57,6 +57,7 @@ def run_title(scenario: str, verbose: bool = True) -> bool:
     Args:
         scenario: Scenario name (e.g., "Smolen")
         verbose: Whether to print progress
+        pbn_path: The file to update, if not pbn/{scenario}.pbn
 
     Returns:
         True if successful, False otherwise
@@ -71,7 +72,7 @@ def run_title(scenario: str, verbose: bool = True) -> bool:
         print(f"  Title: {title}")
 
     # Update PBN file
-    pbn_path = os.path.join(FOLDERS["pbn"], f"{scenario}.pbn")
+    pbn_path = pbn_path or os.path.join(FOLDERS["pbn"], f"{scenario}.pbn")
 
     if not os.path.exists(pbn_path):
         print(f"Error: PBN file not found: {pbn_path}")

--- a/build-scripts-mac/pbs-pipeline-mac.py
+++ b/build-scripts-mac/pbs-pipeline-mac.py
@@ -36,6 +36,7 @@ def print_error(msg: str):
     print(f"{RED}{msg}{RESET}")
 
 # Import operations
+from operations.level import run_level
 from operations.pbn_from_dlr import run_pbn
 from operations.rotate import run_rotate
 from operations.bba_from_pbn import run_bba
@@ -54,6 +55,7 @@ from scenario_summary import generate_summary
 # Map operation names to functions
 OPERATIONS = {
     "dlr": run_dlr,         # Generate DLR from BTN
+    "level": run_level,     # Leveled copy of a DLR that declares hand types
     "pbn": run_pbn,
     "rotate": run_rotate,
     "bba": run_bba,
@@ -362,7 +364,10 @@ Examples:
 
 Operations (in order):
     dlr         - Generate DLR from BTN file (outputs to dlr/)
-    pbn         - Generate PBN hands from DLR using dealer
+    level       - For a DLR that declares HandType_ variables, write the leveled
+                  copy to dlr-leveled/; it wins downstream wherever it exists
+    pbn         - Generate PBN hands from DLR using dealer (and pbn-leveled/
+                  from dlr-leveled/, when the scenario is leveled)
     rotate      - Create rotated PBN/LIN files for 4-player practice
     bba         - Analyze bidding with BBA
     filter      - Filter hands by auction pattern

--- a/build-scripts-mac/scenario_summary.py
+++ b/build-scripts-mac/scenario_summary.py
@@ -27,6 +27,7 @@ OUTPUT_FILE = os.path.join(PROJECT_ROOT, "docs", "Scenario_Summary.html")
 # Columns for ET: operation names and their short display headers
 OP_COLUMNS = [
     ("dlr", "dlr"),
+    ("level", "level"),
     ("pbn", "pbn"),
     ("rotate", "rotate"),
     ("bba", "bba"),

--- a/build-scripts-mac/utils/leveling.py
+++ b/build-scripts-mac/utils/leveling.py
@@ -1,0 +1,139 @@
+"""
+Leveling (issue #322): which dealer script, and which PBN, a scenario's
+downstream stages read.
+
+A scenario levels when its script declares hand types: variables named
+HandType_* (see docs/leveling-guide.md in the dealer3 repo). The level
+operation writes its leveled copy:
+
+    dlr/<name>.dlr  --[level]-->  dlr-leveled/<name>.dlr
+
+and from then on the leveled version wins wherever it exists. pbn deals the
+leveled script into pbn-leveled/<name>.pbn and keeps pbn/<name>.pbn as the
+natural mix, which is how you see what leveling changed. rotate, bba, gib and
+package read the leveled files. They all ask leveled_or_original() rather
+than deciding for themselves.
+
+A leveled file's first line records the dlr it was made from:
+
+    # leveled-from: dlr/<name>.dlr sha256:<hex>
+
+so a stale one is caught instead of used. (dealer3 stamps no source hash of
+its own.)
+
+Stdlib only, so CI can run the check without dealer3:
+
+    python3 build-scripts-mac/utils/leveling.py --check
+"""
+import hashlib
+import os
+import re
+import sys
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from config import FOLDERS
+
+# dealer3 reads the prefix in any case: handtype_x declares the type x too
+HAND_TYPE_RE = re.compile(r"^\s*handtype_\w+\s*=", re.IGNORECASE | re.MULTILINE)
+STAMP_RE = re.compile(r"^# leveled-from: \S+ sha256:([0-9a-f]{64})\s*$")
+
+UNLEVELED = "unleveled"   # no dlr-leveled file
+CURRENT = "current"       # made from the dlr as it stands
+STALE = "stale"           # made from some other dlr, or its dlr is gone
+
+
+def dlr_path(scenario: str) -> str:
+    return os.path.join(FOLDERS["dlr"], f"{scenario}.dlr")
+
+
+def leveled_dlr_path(scenario: str) -> str:
+    return os.path.join(FOLDERS["dlr_leveled"], f"{scenario}.dlr")
+
+
+def pbn_path(scenario: str) -> str:
+    return os.path.join(FOLDERS["pbn"], f"{scenario}.pbn")
+
+
+def leveled_pbn_path(scenario: str) -> str:
+    return os.path.join(FOLDERS["pbn_leveled"], f"{scenario}.pbn")
+
+
+def declares_hand_types(dlr_file: str) -> bool:
+    """True if the script names at least one HandType_ variable."""
+    try:
+        with open(dlr_file, encoding="utf-8") as f:
+            return bool(HAND_TYPE_RE.search(f.read()))
+    except OSError:
+        return False
+
+
+def source_hash(path: str) -> str:
+    with open(path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def stamp_line(scenario: str) -> str:
+    """The first line of dlr-leveled/<name>.dlr, naming the dlr it came from."""
+    return f"# leveled-from: dlr/{scenario}.dlr sha256:{source_hash(dlr_path(scenario))}"
+
+
+def leveled_status(scenario: str) -> str:
+    """UNLEVELED, CURRENT or STALE."""
+    leveled = leveled_dlr_path(scenario)
+    if not os.path.exists(leveled):
+        return UNLEVELED
+    with open(leveled, encoding="utf-8") as f:
+        m = STAMP_RE.match(f.readline())
+    source = dlr_path(scenario)
+    if m and os.path.exists(source) and m.group(1) == source_hash(source):
+        return CURRENT
+    return STALE
+
+
+def is_leveled(scenario: str) -> bool:
+    return os.path.exists(leveled_dlr_path(scenario))
+
+
+def leveled_or_original(scenario: str, kind: str) -> str:
+    """The file a stage should read. kind is "dlr" or "pbn"."""
+    leveled = is_leveled(scenario)
+    if kind == "dlr":
+        return leveled_dlr_path(scenario) if leveled else dlr_path(scenario)
+    if kind == "pbn":
+        return leveled_pbn_path(scenario) if leveled else pbn_path(scenario)
+    raise ValueError(f"leveled_or_original: unknown kind {kind!r}")
+
+
+def check_all() -> list:
+    """Every leveled file that doesn't match its dlr, and every scenario that
+    declares hand types but has no leveled file. One line each."""
+    names = set()
+    for key in ("dlr", "dlr_leveled"):
+        if os.path.isdir(FOLDERS[key]):
+            names |= {f[:-4] for f in os.listdir(FOLDERS[key]) if f.endswith(".dlr")}
+
+    problems = []
+    for name in sorted(names):
+        status = leveled_status(name)
+        if status == STALE and not os.path.exists(dlr_path(name)):
+            problems.append(f"dlr-leveled/{name}.dlr has no dlr/{name}.dlr")
+        elif status == STALE:
+            problems.append(f"dlr-leveled/{name}.dlr was not made from the current "
+                            f"dlr/{name}.dlr; run level")
+        elif status == UNLEVELED and declares_hand_types(dlr_path(name)):
+            problems.append(f"dlr/{name}.dlr declares hand types but has no "
+                            f"dlr-leveled/{name}.dlr; run level")
+    return problems
+
+
+if __name__ == "__main__":
+    if sys.argv[1:] != ["--check"]:
+        print("Usage: python3 build-scripts-mac/utils/leveling.py --check")
+        sys.exit(2)
+    problems = check_all()
+    for problem in problems:
+        print(problem)
+    print(f"{len(problems)} problem(s)" if problems else "Leveled scripts match their sources")
+    sys.exit(1 if problems else 0)

--- a/manifest/README.md
+++ b/manifest/README.md
@@ -8,7 +8,9 @@ and refreshed on every push by
 **Why (PBS #167):** building the menu used to cost ~1 layout fetch + ~300
 per-scenario `.pbs` fetches + GitHub-API listing calls for the missing/orphan
 diagnostics — roughly **400 requests per menu build**. A consumer now fetches
-**one** manifest, and on a click fetches that scenario's `dlr/<name>.dlr`.
+**one** manifest, and on a click fetches that scenario's `dlr` path:
+`dlr-leveled/<name>.dlr` when the scenario is leveled (PBS #322), otherwise
+`dlr/<name>.dlr`.
 
 ## Files / tiers
 
@@ -36,7 +38,7 @@ Bridge-Classroom-served coaching collection (`coaching-non-rotated/`). The
   "schemaVersion": 2,
   "tier": "release",
   "generatedAtCommit": "<sha>",
-  "sources": { "layout": "btn/-button-layout-release.txt", "dlr": "dlr" },
+  "sources": { "layout": "btn/-button-layout-release.txt", "dlr": "dlr", "dlrLeveled": "dlr-leveled" },
 
   "layout": [                    // ordered menu tree — render top to bottom
     { "type": "major",     "title": "Bidding Scenarios ..." },
@@ -59,7 +61,9 @@ Bridge-Classroom-served coaching collection (`coaching-non-rotated/`). The
       "bbaWorks": true,          // from .btn  (NOT available in the menu today)
       "conventionCardNS": "21GF-GIB",
       "conventionCardEW": "21GF-GIB",
-      "missing": false           // true => referenced by layout but no .dlr exists
+      "missing": false,          // true => referenced by layout but no .dlr exists
+      "dlr": "dlr/Smolen.dlr"    // the script to load; dlr-leveled/<name>.dlr when
+                                 // the scenario is leveled (PBS #322); null if missing
     }
   },
 

--- a/py/build_manifest.py
+++ b/py/build_manifest.py
@@ -7,7 +7,9 @@ deal-source dialog used to build their scenario menu by fetching the layout
 file and then one `.pbs` file per button (~300 requests) plus GitHub-API listing
 calls for the orphan diagnostics — roughly 400 hits every time a menu was
 built. This script pre-computes a single JSON manifest per tier so a consumer
-makes ONE request instead. On a click, the consumer fetches dlr/<name>.dlr.
+makes ONE request instead. On a click, the consumer fetches the scenario's
+`dlr` path: dlr-leveled/<name>.dlr when the scenario is leveled (issue #322),
+dlr/<name>.dlr otherwise.
 
 Each manifest folds together everything the menu needs:
   * the button LAYOUT (majors, action buttons, sections, button rows with
@@ -55,6 +57,8 @@ SCHEMA_VERSION = 2
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BTN_DIR = os.path.join(ROOT, "btn")
 DLR_DIR = os.path.join(ROOT, "dlr")
+# Leveled copies (issue #322): where one exists, it is the script to load
+DLR_LEVELED_DIR = os.path.join(ROOT, "dlr-leveled")
 # Bridge-Classroom-served coaching collection: source of the v2 `lessons` roster
 # (producer contract R5). One .pbn per lesson; key = PBN basename.
 COACHING_DIR = os.path.join(ROOT, "coaching-non-rotated")
@@ -412,11 +416,18 @@ def build_tier(tier, btn_meta, lessons, dlr_index):
     missing = []
     for name in referenced:
         dlr_path = dlr_index.get(name)
-        button = parse_dlr_button(dlr_path) if dlr_path else None
         is_missing = dlr_path is None
         if is_missing:
             missing.append(name)
-        scenarios[name] = scenario_entry(name, btn_meta, button, is_missing)
+        # A leveled scenario's chat comes from its leveled copy, where dealer3
+        # has filled in the {{level-mix}} tokens
+        leveled = os.path.join(DLR_LEVELED_DIR, f"{name}.dlr")
+        if dlr_path and os.path.exists(leveled):
+            dlr_path = leveled
+        button = parse_dlr_button(dlr_path) if dlr_path else None
+        entry = scenario_entry(name, btn_meta, button, is_missing)
+        entry["dlr"] = os.path.relpath(dlr_path, ROOT) if dlr_path else None
+        scenarios[name] = entry
 
     # Orphans: a .dlr the layout doesn't reference.
     ref_set = set(referenced)
@@ -426,7 +437,7 @@ def build_tier(tier, btn_meta, lessons, dlr_index):
         "schemaVersion": SCHEMA_VERSION,
         "tier": tier,
         "generatedAtCommit": git_sha(),
-        "sources": {"layout": f"btn/{layout_name}", "dlr": "dlr"},
+        "sources": {"layout": f"btn/{layout_name}", "dlr": "dlr", "dlrLeveled": "dlr-leveled"},
         "layout": items,
         "scenarios": scenarios,
         # v2 producer-contract R5 roster (tier-independent — coaching collection).

--- a/py/gib_capture.py
+++ b/py/gib_capture.py
@@ -62,10 +62,16 @@ LOCK = os.path.join(tempfile.gettempdir(), 'pbs-gib-capture.lock')
 
 
 def resolve_dlr(arg: str) -> tuple:
-    """A scenario name or a .dlr path -> (scenario name, .dlr path)."""
+    """A scenario name or a .dlr path -> (scenario name, .dlr path).
+
+    A scenario name reads its leveled copy when it has one (issue #322).
+    """
     if arg.endswith('.dlr') or os.sep in arg:
         path = os.path.abspath(arg)
         return os.path.splitext(os.path.basename(path))[0], path
+    leveled = os.path.join(PROJECT_ROOT, 'dlr-leveled', f'{arg}.dlr')
+    if os.path.exists(leveled):
+        return arg, leveled
     return arg, os.path.join(PROJECT_ROOT, 'dlr', f'{arg}.dlr')
 
 

--- a/py/oneComment.py
+++ b/py/oneComment.py
@@ -3,6 +3,7 @@ import argparse
 
 parser = argparse.ArgumentParser(description="Extract dealer code")
 parser.add_argument("--scenario", type=str, help="Name of scenario is required")
+parser.add_argument("--pbn", type=str, help="PBN file to process (default: ../pbn/<scenario>.pbn)")
 args = parser.parse_args()
 scenario = str(args.scenario)
 
@@ -43,7 +44,7 @@ def process():
 
 # Do a single scenario
 filename = scenario + '.pbn'
-file_path = os.path.join('..', 'pbn', filename)
+file_path = args.pbn or os.path.join('..', 'pbn', filename)
 if os.path.isfile(file_path):
     process()
 else:

--- a/vs-code/package.json
+++ b/vs-code/package.json
@@ -73,6 +73,10 @@
         "title": "PBS: Run DLR"
       },
       {
+        "command": "pbs.runLevel",
+        "title": "PBS: Run Level"
+      },
+      {
         "command": "pbs.runPbn",
         "title": "PBS: Run PBN"
       },
@@ -99,6 +103,10 @@
       {
         "command": "pbs.runDlrPlus",
         "title": "PBS: Run DLR+"
+      },
+      {
+        "command": "pbs.runLevelPlus",
+        "title": "PBS: Run Level+"
       },
       {
         "command": "pbs.runPbnPlus",
@@ -148,7 +156,7 @@
       },
       {
         "command": "pbs.runRelease",
-        "title": "PBS: Publish (commit + push btn/dlr)"
+        "title": "PBS: Publish (commit + push btn/dlr/dlr-leveled)"
       },
       {
         "command": "pbs.runReleaseLayout",
@@ -184,7 +192,7 @@
       "editor/title": [
         {
           "submenu": "pbs.pipeline",
-          "when": "resourcePath =~ /\\/(btn|dlr|pbn|pbn-rotated-for-4-players|bba|bba-filtered|bba-filtered-out|bba-summary|bidding-sheets|lin|lin-rotated-for-4-players|quiz)\\/[^/]+$/ && resourceFilename != -button-layout-beta.txt",
+          "when": "resourcePath =~ /\\/(btn|dlr|dlr-leveled|pbn|pbn-leveled|pbn-rotated-for-4-players|bba|bba-filtered|bba-filtered-out|bba-summary|bidding-sheets|lin|lin-rotated-for-4-players|quiz)\\/[^/]+$/ && resourceFilename != -button-layout-beta.txt",
           "group": "navigation"
         },
         {
@@ -201,6 +209,10 @@
         {
           "command": "pbs.runDlr",
           "group": "2_individual@1"
+        },
+        {
+          "command": "pbs.runLevel",
+          "group": "2_individual@2"
         },
         {
           "command": "pbs.runPbn",
@@ -242,6 +254,10 @@
         {
           "command": "pbs.runDlrPlus",
           "group": "3_plus@1"
+        },
+        {
+          "command": "pbs.runLevelPlus",
+          "group": "3_plus@2"
         },
         {
           "command": "pbs.runPbnPlus",

--- a/vs-code/src/currentScenarioProvider.ts
+++ b/vs-code/src/currentScenarioProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { getBtnMetadata, clearMetadataCache } from './btnParser';
-import { getScenarioFromPath } from './scenarioPaths';
+import { getScenarioFromPath, isLeveled, pbnFor } from './scenarioPaths';
 
 /**
  * Find the first packaged PBN file for a scenario in the Bidding Scenarios hierarchy.
@@ -28,37 +28,60 @@ function findPackagePath(scenario: string, root: string): string {
 
 // Define all artifacts in pipeline order with their dependencies
 // requiresBba indicates artifacts that need bba-works=true to be shown
+// requiresLeveled indicates artifacts only a leveled scenario has (issue #322)
 const ARTIFACTS = [
     {
         name: 'dlr',
         shortName: 'dlr',
         requiresBba: false,
+        requiresLeveled: false,
         getPath: (s: string, r: string) => path.join(r, 'dlr', `${s}.dlr`),
         getSourcePath: (s: string, r: string) => path.join(r, 'btn', `${s}.btn`),
         command: 'pbs.runDlr'
     },
     {
+        name: 'dlr-leveled',
+        shortName: 'lvl',
+        requiresBba: false,
+        requiresLeveled: true,
+        getPath: (s: string, r: string) => path.join(r, 'dlr-leveled', `${s}.dlr`),
+        getSourcePath: (s: string, r: string) => path.join(r, 'dlr', `${s}.dlr`),
+        command: 'pbs.runLevel'
+    },
+    {
         name: 'pbn',
         shortName: 'pbn',
         requiresBba: false,
+        requiresLeveled: false,
         getPath: (s: string, r: string) => path.join(r, 'pbn', `${s}.pbn`),
         getSourcePath: (s: string, r: string) => path.join(r, 'dlr', `${s}.dlr`),
+        command: 'pbs.runPbn'
+    },
+    {
+        name: 'pbn-leveled',
+        shortName: 'pbnL',
+        requiresBba: false,
+        requiresLeveled: true,
+        getPath: (s: string, r: string) => path.join(r, 'pbn-leveled', `${s}.pbn`),
+        getSourcePath: (s: string, r: string) => path.join(r, 'dlr-leveled', `${s}.dlr`),
         command: 'pbs.runPbn'
     },
     {
         name: 'rotate',
         shortName: 'rot',
         requiresBba: false,
+        requiresLeveled: false,
         getPath: (s: string, r: string) => path.join(r, 'pbn-rotated-for-4-players', `${s}.pbn`),
-        getSourcePath: (s: string, r: string) => path.join(r, 'pbn', `${s}.pbn`),
+        getSourcePath: (s: string, r: string) => pbnFor(s, r),
         command: 'pbs.runRotate'
     },
     {
         name: 'bba',
         shortName: 'bba',
         requiresBba: true,
+        requiresLeveled: false,
         getPath: (s: string, r: string) => path.join(r, 'bba', `${s}.pbn`),
-        getSourcePath: (s: string, r: string) => path.join(r, 'pbn', `${s}.pbn`),
+        getSourcePath: (s: string, r: string) => pbnFor(s, r),
         command: 'pbs.runBba'
     },
     {
@@ -94,7 +117,7 @@ const ARTIFACTS = [
             // Package copies from bba-filtered (with pbn fallback), so compare against actual source
             const filtered = path.join(r, 'bba-filtered', `${s}.pbn`);
             if (fs.existsSync(filtered)) { return filtered; }
-            return path.join(r, 'pbn', `${s}.pbn`);
+            return pbnFor(s, r);
         },
         command: 'pbs.runPackage'
     }
@@ -335,9 +358,11 @@ export class CurrentScenarioProvider implements vscode.TreeDataProvider<Scenario
             // Get scenario metadata to filter artifacts
             const metadata = getBtnMetadata(this.currentScenario!, this.workspaceRoot!);
 
-            // Filter artifacts based on bbaWorks
+            // Filter artifacts based on bbaWorks, and on whether the scenario is leveled
+            const leveled = isLeveled(this.currentScenario!, this.workspaceRoot!);
             const visibleArtifacts = ARTIFACTS.filter(artifact =>
-                !artifact.requiresBba || metadata.bbaWorks
+                (!artifact.requiresBba || metadata.bbaWorks) &&
+                (!artifact.requiresLeveled || leveled)
             );
 
             // Build artifact children

--- a/vs-code/src/extension.ts
+++ b/vs-code/src/extension.ts
@@ -175,7 +175,7 @@ export function activate(context: vscode.ExtensionContext) {
     configWatcher.onDidChange(refreshButtonViews);
 
     // Watch artifact directories for current scenario status updates
-    const artifactWatcher = vscode.workspace.createFileSystemWatcher('**/{dlr,pbn,pbn-rotated-for-4-players,bba,bba-filtered,bidding-sheets,quiz}/*');
+    const artifactWatcher = vscode.workspace.createFileSystemWatcher('**/{dlr,dlr-leveled,pbn,pbn-leveled,pbn-rotated-for-4-players,bba,bba-filtered,bidding-sheets,quiz}/*');
     artifactWatcher.onDidChange(restoreFreshnessOnBuild);
     artifactWatcher.onDidCreate(restoreFreshnessOnBuild);
     artifactWatcher.onDidDelete(() => currentScenarioProvider.refresh());

--- a/vs-code/src/pipelineRunner.ts
+++ b/vs-code/src/pipelineRunner.ts
@@ -73,6 +73,7 @@ export function registerPipelineCommands(context: vscode.ExtensionContext): void
 
     // Individual operations
     registerCommand(context, 'pbs.runDlr', 'dlr');
+    registerCommand(context, 'pbs.runLevel', 'level');
     registerCommand(context, 'pbs.runPbn', 'pbn');
     registerCommand(context, 'pbs.runRotate', 'rotate');
     registerCommand(context, 'pbs.runBba', 'bba');
@@ -84,6 +85,7 @@ export function registerPipelineCommands(context: vscode.ExtensionContext): void
 
     // Plus operations (from X through end)
     registerCommand(context, 'pbs.runDlrPlus', 'dlr+');
+    registerCommand(context, 'pbs.runLevelPlus', 'level+');
     registerCommand(context, 'pbs.runPbnPlus', 'pbn+');
     registerCommand(context, 'pbs.runRotatePlus', 'rotate+');
     registerCommand(context, 'pbs.runBbaPlus', 'bba+');
@@ -94,7 +96,8 @@ export function registerPipelineCommands(context: vscode.ExtensionContext): void
 
     // Release operation (not included in wildcards - must be explicit).
     // Publishes the scenario: commits and pushes btn/<name>.btn + dlr/<name>.dlr
-    // to main, which is what the BBO extension loads.
+    // (and dlr-leveled/<name>.dlr when leveled) to main, which is what the BBO
+    // extension loads.
     context.subscriptions.push(
         vscode.commands.registerCommand('pbs.runRelease', async () => {
             const scenario = getCurrentScenario();
@@ -106,7 +109,7 @@ export function registerPipelineCommands(context: vscode.ExtensionContext): void
                 `Publish ${scenario}?`,
                 {
                     modal: true,
-                    detail: `Commits btn/${scenario}.btn and dlr/${scenario}.dlr and pushes them to main. BBO users get the change as soon as the push lands.`
+                    detail: `Commits btn/${scenario}.btn and dlr/${scenario}.dlr, and dlr-leveled/${scenario}.dlr if the scenario is leveled, and pushes them to main. BBO users get the change as soon as the push lands.`
                 },
                 'Publish'
             );

--- a/vs-code/src/scenarioPaths.ts
+++ b/vs-code/src/scenarioPaths.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 
 /**
@@ -8,7 +9,9 @@ import * as path from 'path';
 export const ARTIFACT_DIRS = [
     'btn',
     'dlr',
+    'dlr-leveled',
     'pbn',
+    'pbn-leveled',
     'pbn-rotated-for-4-players',
     'bba',
     'bba-filtered',
@@ -43,4 +46,32 @@ export function getScenarioFromPath(filePath: string | undefined): string | unde
     }
 
     return baseName;
+}
+
+// dealer3 reads the HandType_ prefix in any case
+const HAND_TYPE_RE = /^\s*handtype_\w+\s*=/im;
+
+/**
+ * True if the scenario is leveled (issue #322): it has a dlr-leveled/ copy, or
+ * its dlr declares hand types, so the level operation will write one.
+ */
+export function isLeveled(scenario: string, root: string): boolean {
+    if (fs.existsSync(path.join(root, 'dlr-leveled', `${scenario}.dlr`))) {
+        return true;
+    }
+    try {
+        return HAND_TYPE_RE.test(fs.readFileSync(path.join(root, 'dlr', `${scenario}.dlr`), 'utf8'));
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * The PBN that rotate and bba read, by the pipeline's rule
+ * (build-scripts-mac/utils/leveling.py): pbn-leveled/ when leveled.
+ */
+export function pbnFor(scenario: string, root: string): string {
+    return fs.existsSync(path.join(root, 'dlr-leveled', `${scenario}.dlr`))
+        ? path.join(root, 'pbn-leveled', `${scenario}.pbn`)
+        : path.join(root, 'pbn', `${scenario}.pbn`);
 }


### PR DESCRIPTION
Implements the build side of #322. The script conversions stay on #294.

## What it does

- **`level` operation**, between `dlr` and `pbn`. For a `.dlr` that declares `HandType_*` variables, it runs `dealer3 --write-leveled` into `dlr-leveled/<name>.dlr`. It skips every other scenario, and removes leftover leveled files when a scenario stops declaring hand types.
- **Leveled wins downstream**, through one resolver: `leveled_or_original()` in `build-scripts-mac/utils/leveling.py`.
  - `pbn` writes both `pbn/` (the natural mix) and `pbn-leveled/` (with `--interleave`, so the first boards cycle through the types).
  - `rotate`, `bba`, `gib` (`py/gib_capture.py`), `package` and `release` read the leveled files.
- **Staleness.** The leveled file's first line stamps the sha256 of the `.dlr` it came from; dealer3 writes no source hash of its own. `level` skips a current file, `pbn` refuses a stale one, and the new `check-leveled` workflow fails CI on a stale or missing one. The CI check compares hashes, so it needs no dealer3.
- **Reproducible.** It uses `-s 1` with no `-p`: dealer3 sizes the measurement itself, and the timeout is set well past it. A rebuild is byte-identical.
- **Self-check.** It deals 10,000 from the leveled file and fails if any hand type lands more than 2 points from the mix dealer3 reported.
- **Budget.** `# level-budget: N` in a `.btn` caps the cost.
- **Manifest.** Each scenario gets a `dlr` path, which is `dlr-leveled/...` when leveled. Its chat comes from the leveled file, so the `{{level-mix}}` shares are filled in. `release` levels the script and commits the leveled file too.
- **VS Code.** Level and Level+ commands. `lvl` and `pbnL` nodes in Current Scenario, with staleness following the same leveled-or-original rule. The new folders are added to the scenario-from-path lists and the file watcher.

## Tested

- NT_Ladder, using dealer3's `examples/NT_Ladder.stock.dlr` in place of `dlr/NT_Ladder.dlr`, run from `level` through `bba`:
  - On the 10,000-deal check, every type landed within 0.2 points of 20%.
  - The natural PBN's hand types split 296/149/32/13/10 over 500 deals; the leveled PBN splits 92/93/92/103/120.
  - The rebuild is byte-identical.
  - A stale leveled file is caught by both `pbn` and the CI check.
  - Removing the hand types deletes the leveled files.
  - The manifest entry points at the leveled file, with its chat filled in.
- Unleveled `1N`: the same deals as `main`. Only the timing line differs, and it does on `main` too.
- The extension compiles. `npm run lint` has no ESLint config; that is already true on `main`.

## Not in this PR

- The `.btn` conversions (#294).
- The BBO extension reading the manifest's new `dlr` field (#321, pbs-bbo-extension).
- The `-p 500` vs `produce` loose end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
