### PR TITLE
Build bidding sheets with --no-page-furniture

### DIFF
--- a/build-scripts-mac/operations/bidding_sheet.py
+++ b/build-scripts-mac/operations/bidding_sheet.py
@@ -138,7 +138,9 @@ def run_bidding_sheet(scenario: str, verbose: bool = True) -> bool:
         bridge_wrangler, "to-pdf",
         "-i", dest_pbn,
         "-o", pdf_path,
-        "-l", "bidding-sheets"
+        "-l", "bidding-sheets",
+        # The sheets carry their own banner; no page furniture from the PBN
+        "--no-page-furniture",
     ]
 
     try:


### PR DESCRIPTION
Part of the rollout for bridge-craftwork/pbn-to-pdf#37 (issue pbn-to-pdf#28).

pbn-to-pdf now prints the page furniture a PBN asks for, as BridgeComposer does. Bidding sheets carry their own banner, so `bidding_sheet.py` passes `--no-page-furniture` to `bridge-wrangler to-pdf`. The furniture only applies to the analysis layout today, so this changes no bidding sheet. It keeps them unchanged if that ever widens, and it's what #28 asks every publishing pipeline to do.

**Merge after** the bridge-wrangler PR that adds `--no-page-furniture` is in and a bridge-wrangler with it has been built. An older binary rejects the unknown flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)